### PR TITLE
[backport] correct computation of prologue size

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -320,7 +320,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
         /*
          * 4 ubyte prologue length includes rest of header and dir + file table section.
          */
-        int prologueSize = classEntry.getLinePrologueSize() - 6;
+        int prologueSize = classEntry.getLinePrologueSize() - (4 + 2 + 4);
         pos = putInt(prologueSize, buffer, pos);
         /*
          * 1 ubyte min instruction length is always 1.


### PR DESCRIPTION
Backport to 20.1 branch fix for https://github.com/oracle/graal/issues/2431.