### PR TITLE
fix native-image on openjdk11.0.8

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -34,8 +34,8 @@ jobs:
           ${{ runner.os }}-mx-
     - name: Get openJDK11 with static libs
       run: |
-        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B4/OpenJDK11U-jdk_x64_linux_11.0.8_4_ea.tar.gz -o jdk.tar.gz
-        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B4/OpenJDK11U-static-libs_x64_linux_11.0.8_4_ea.tar.gz -o jdk-static-libs.tar.gz
+        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B7/OpenJDK11U-jdk_x64_linux_11.0.8_7_ea.tar.gz -o jdk.tar.gz
+        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B7/OpenJDK11U-static-libs_x64_linux_11.0.8_7_ea.tar.gz -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -790,10 +790,10 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
     public final long dynamicNewInstanceAddress = getAddress("JVMCIRuntime::dynamic_new_instance");
 
     // Allocation stubs that return null when allocation fails
-    public final long newInstanceOrNullAddress = getAddress("JVMCIRuntime::new_instance_or_null", 0L, JVMCI || JDK >= 12);
-    public final long newArrayOrNullAddress = getAddress("JVMCIRuntime::new_array_or_null", 0L, JVMCI || JDK >= 12);
-    public final long newMultiArrayOrNullAddress = getAddress("JVMCIRuntime::new_multi_array_or_null", 0L, JVMCI || JDK >= 12);
-    public final long dynamicNewInstanceOrNullAddress = getAddress("JVMCIRuntime::dynamic_new_instance_or_null", 0L, JVMCI || JDK >= 12);
+    public final long newInstanceOrNullAddress = getAddress("JVMCIRuntime::new_instance_or_null", 0L, JVMCI || JDK >= 12 || (!IS_OPENJDK && JDK == 11 && JDK_UPDATE >= 7));
+    public final long newArrayOrNullAddress = getAddress("JVMCIRuntime::new_array_or_null", 0L, JVMCI || JDK >= 12 || (!IS_OPENJDK && JDK == 11 && JDK_UPDATE >= 7));
+    public final long newMultiArrayOrNullAddress = getAddress("JVMCIRuntime::new_multi_array_or_null", 0L, JVMCI || JDK >= 12 || (!IS_OPENJDK && JDK == 11 && JDK_UPDATE >= 7));
+    public final long dynamicNewInstanceOrNullAddress = getAddress("JVMCIRuntime::dynamic_new_instance_or_null", 0L, JVMCI || JDK >= 12 || (!IS_OPENJDK && JDK == 11 && JDK_UPDATE >= 7));
 
     public boolean areNullAllocationStubsAvailable() {
         return newInstanceOrNullAddress != 0L;
@@ -877,13 +877,15 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
     // JDK-8231756, GR-16685
     public final boolean deoptimizationSupportLargeAccessByteArrayVirtualization = getConstant("Deoptimization::_support_large_access_byte_array_virtualization", Boolean.class, false, JVMCI);
 
+    private static final boolean JDK_8245443 = ((JDK == 11 && JDK_UPDATE >= 8) || JDK >= 15);
+
     // Checkstyle: stop
     public final int MARKID_VERIFIED_ENTRY = getConstant("CodeInstaller::VERIFIED_ENTRY", Integer.class);
     public final int MARKID_UNVERIFIED_ENTRY = getConstant("CodeInstaller::UNVERIFIED_ENTRY", Integer.class);
     public final int MARKID_OSR_ENTRY = getConstant("CodeInstaller::OSR_ENTRY", Integer.class);
     public final int MARKID_EXCEPTION_HANDLER_ENTRY = getConstant("CodeInstaller::EXCEPTION_HANDLER_ENTRY", Integer.class);
     public final int MARKID_DEOPT_HANDLER_ENTRY = getConstant("CodeInstaller::DEOPT_HANDLER_ENTRY", Integer.class);
-    public final int MARKID_FRAME_COMPLETE = getConstant("CodeInstaller::FRAME_COMPLETE", Integer.class, -1, (JVMCI ? jvmciGE(JVMCI_20_1_b01) : JDK >= 15));
+    public final int MARKID_FRAME_COMPLETE = getConstant("CodeInstaller::FRAME_COMPLETE", Integer.class, -1, (JVMCI ? jvmciGE(JVMCI_20_1_b01) : JDK_8245443));
     public final int MARKID_INVOKEINTERFACE = getConstant("CodeInstaller::INVOKEINTERFACE", Integer.class);
     public final int MARKID_INVOKEVIRTUAL = getConstant("CodeInstaller::INVOKEVIRTUAL", Integer.class);
     public final int MARKID_INVOKESTATIC = getConstant("CodeInstaller::INVOKESTATIC", Integer.class);


### PR DESCRIPTION
This is a backport of this fix in master:
https://github.com/graalvm/mandrel/commit/9514d29997d78d3585d9ed5c47196607ac1d1d93

It didn't apply cleanly due to context differences. I've applied the changes manually. Without this fix we are seeing assertions like this when running native-image on a HelloWorld:

```
Exception in thread "main" jdk.vm.ci.common.JVMCIError: VM config values not expected to be present in JDK 11 linux-amd64 (java.home=/disk/graal/upstream-sources/graal/sdk/mxbuild/linux-amd64/GRAALVM_E6EC3842EE_JAVA11/graalvm-e6ec3842ee-java11-20.1.0, java.vm.name=OpenJDK 64-Bit Server VM, java.vm.version=11.0.8-ea+7):
    CodeInstaller::FRAME_COMPLETE at jdk.internal.vm.compiler/org.graalvm.compiler.hotspot.GraalHotSpotVMConfig.<init>(GraalHotSpotVMConfig.java:886) [value: 6]
	at jdk.internal.vm.compiler/org.graalvm.compiler.hotspot.GraalHotSpotVMConfigAccess.reportErrors(GraalHotSpotVMConfigAccess.java:226)
	at jdk.internal.vm.compiler/org.graalvm.compiler.hotspot.GraalHotSpotVMConfig.<init>(GraalHotSpotVMConfig.java:67)
	at jdk.internal.vm.compiler/org.graalvm.compiler.hotspot.HotSpotGraalRuntime.<init>(HotSpotGraalRuntime.java:161)
	at jdk.internal.vm.compiler/org.graalvm.compiler.hotspot.HotSpotGraalCompilerFactory.createCompiler(HotSpotGraalCompilerFactory.java:156)
	at jdk.internal.vm.compiler/org.graalvm.compiler.hotspot.HotSpotGraalCompilerFactory.createCompiler(HotSpotGraalCompilerFactory.java:134)
	at jdk.internal.vm.compiler/org.graalvm.compiler.hotspot.HotSpotGraalCompilerFactory.createCompiler(HotSpotGraalCompilerFactory.java:52)
	at jdk.internal.vm.ci/jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.getCompiler(HotSpotJVMCIRuntime.java:425)
	at com.oracle.svm.hosted.c.GraalAccess.getGraalCapability(GraalAccess.java:50)
	at com.oracle.svm.hosted.c.GraalAccess.getOriginalTarget(GraalAccess.java:38)
	at com.oracle.svm.hosted.NativeImageGeneratorRunner.isValidArchitecture(NativeImageGeneratorRunner.java:221)
	at com.oracle.svm.hosted.NativeImageGeneratorRunner.verifyValidJavaVersionAndPlatform(NativeImageGeneratorRunner.java:426)
	at com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:232)
	at com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:518)
	at com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:117)
	at com.oracle.svm.hosted.NativeImageGeneratorRunner$JDK9Plus.main(NativeImageGeneratorRunner.java:546)
```

See also:
https://bugs.openjdk.java.net/browse/JDK-8241458

which got backported to 11.0.8+5