### PR TITLE
Documentation: Ubuntu-like system dependencies

### DIFF
--- a/README-Mandrel.md
+++ b/README-Mandrel.md
@@ -43,6 +43,11 @@ On Fedora/CentOS/RHEL they can be installed with:
 dnf install glibc-devel zlib-devel gcc libffi-devel
 ```
 
+On Ubuntu-like systems with:
+```bash
+apt install gcc zlib1g-dev libffi-dev
+```
+
 ### Building Mandrel From Source
 
 For building Mandrel from source please see [mandrel-packaging](https://github.com/graalvm/mandrel-packaging)


### PR DESCRIPTION
Tested on a fresh vanilla installation of Ubuntu 18.04 Desktop with:

```bash
wget https://github.com/graalvm/mandrel/releases/download/mandrel-20.1.0.0.Alpha1/mandrel-java11-linux-amd64-20.1.0.0.Alpha1.tar.gz
tar -xf mandrel-java11-linux-amd64-20.1.0.0.Alpha1.tar.gz
export JAVA_HOME="$( pwd )/mandrelJDK"
export GRAALVM_HOME="${JAVA_HOME}"
export PATH="${JAVA_HOME}/bin:${PATH}"
curl -O -J  https://code.quarkus.io/api/download
unzip code-with-quarkus.zip
cd code-with-quarkus/
./mvnw package -Pnative
./target/code-with-quarkus-1.0.0-SNAPSHOT-runner
```

[Quarkus guide](https://quarkus.io/guides/building-native-image#prerequisites) talks about apt too, so I would like to add this to the Mandrel doc as well.