### PR TITLE
Account for JDK-8236867: Enhance Graal interface handling

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -65,8 +65,8 @@ jobs:
           ${{ runner.os }}-mx-
     - name: Get openJDK11 with static libs
       run: |
-        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B7/OpenJDK11U-jdk_x64_linux_11.0.8_7_ea.tar.gz -o jdk.tar.gz
-        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B7/OpenJDK11U-static-libs_x64_linux_11.0.8_7_ea.tar.gz -o jdk-static-libs.tar.gz
+        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B10/OpenJDK11U-jdk_x64_linux_11.0.8_10.tar.gz -o jdk.tar.gz
+        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B10/OpenJDK11U-static-libs_x64_linux_11.0.8_10.tar.gz -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1

--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/SingleImplementorInterfaceTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/SingleImplementorInterfaceTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.test;
+
+import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.compiler.nodes.CallTargetNode;
+import org.graalvm.compiler.nodes.InvokeNode;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.java.InstanceOfNode;
+import org.graalvm.compiler.phases.OptimisticOptimizations;
+import org.graalvm.compiler.phases.common.CanonicalizerPhase;
+import org.graalvm.compiler.phases.common.inlining.InliningPhase;
+import org.graalvm.compiler.phases.tiers.HighTierContext;
+import org.graalvm.compiler.phases.tiers.PhaseContext;
+import org.graalvm.compiler.serviceprovider.GraalServices;
+import org.junit.Test;
+
+public class SingleImplementorInterfaceTest extends GraalCompilerTest {
+
+    public interface Interface0 {
+        void interfaceMethod();
+    }
+
+    public interface Interface1 extends Interface0 {
+
+    }
+
+    public interface Interface2 extends Interface1 {
+    }
+
+    @SuppressWarnings("all")
+    public static class SingleImplementor1 implements Interface1 {
+        public void interfaceMethod() {
+        }
+    }
+
+    // Requires that the CHA analysis starts from the referenced type. Since {@code
+    // SingleImplementor1}
+    // is not a single implementor of {@code Interface2} devirtualization shouldn't happen.
+    @SuppressWarnings("all")
+    private static void singleImplementorInterfaceSnippet1(Interface2 i) {
+        i.interfaceMethod();
+    }
+
+    // Devirtualization should happen in this case.
+    @SuppressWarnings("all")
+    private static void singleImplementorInterfaceSnippet2(Interface1 i) {
+        i.interfaceMethod();
+    }
+
+    @Test
+    public void testSingleImplementorInterfaceDevirtualization1() {
+        ResolvedJavaType singleImplementorType = getMetaAccess().lookupJavaType(SingleImplementor1.class);
+        ResolvedJavaType expectedReferencedType = getMetaAccess().lookupJavaType(Interface2.class);
+        singleImplementorType.initialize();
+        StructuredGraph graph = parseEager("singleImplementorInterfaceSnippet1", StructuredGraph.AllowAssumptions.YES);
+        createCanonicalizerPhase().apply(graph, getDefaultHighTierContext());
+        // Devirtualization shouldn't work in this case. The invoke should remain intact.
+        InvokeNode invoke = graph.getNodes().filter(InvokeNode.class).first();
+        assertTrue(invoke != null, "Should have an invoke");
+        assertTrue(invoke.callTarget().invokeKind() == CallTargetNode.InvokeKind.Interface, "Should still be an interface call");
+        if (GraalServices.hasLookupReferencedType()) {
+            assertTrue(invoke.callTarget().referencedType() != null, "Invoke should have a reference class set");
+            assertTrue(invoke.callTarget().referencedType().equals(expectedReferencedType));
+        }
+    }
+
+    @Test
+    public void testSingleImplementorInterfaceDevirtualization2() {
+        ResolvedJavaType singleImplementorType = getMetaAccess().lookupJavaType(SingleImplementor1.class);
+        singleImplementorType.initialize();
+        StructuredGraph graph = parseEager("singleImplementorInterfaceSnippet2", StructuredGraph.AllowAssumptions.YES);
+        createCanonicalizerPhase().apply(graph, getDefaultHighTierContext());
+        InvokeNode invoke = graph.getNodes().filter(InvokeNode.class).first();
+        assertTrue(invoke != null, "Should have an invoke");
+        if (GraalServices.hasLookupReferencedType()) {
+            assertTrue(invoke.callTarget().invokeKind() == CallTargetNode.InvokeKind.Special, "Should be devirtualized");
+            InstanceOfNode instanceOfNode = graph.getNodes().filter(InstanceOfNode.class).first();
+            assertTrue(instanceOfNode != null, "Missing the subtype check");
+            assertTrue(instanceOfNode.getCheckedStamp().type().equals(singleImplementorType), "Checking against a wrong type");
+        } else {
+            assertTrue(invoke.callTarget().invokeKind() == CallTargetNode.InvokeKind.Interface, "Should not be devirtualized");
+        }
+    }
+
+    @Test
+    public void testSingleImplementorInterfaceInlining1() {
+        ResolvedJavaType singleImplementorType = getMetaAccess().lookupJavaType(SingleImplementor1.class);
+        ResolvedJavaType expectedReferencedType = getMetaAccess().lookupJavaType(Interface2.class);
+        singleImplementorType.initialize();
+        StructuredGraph graph = parseEager("singleImplementorInterfaceSnippet1", StructuredGraph.AllowAssumptions.YES);
+        HighTierContext context = new HighTierContext(getProviders(), getDefaultGraphBuilderSuite(), OptimisticOptimizations.ALL);
+        createInliningPhase(createCanonicalizerPhase()).apply(graph, context);
+        // Inlining shouldn't do anything
+        InvokeNode invoke = graph.getNodes().filter(InvokeNode.class).first();
+        assertTrue(invoke != null, "Should have an invoke");
+        if (GraalServices.hasLookupReferencedType()) {
+            assertTrue(invoke.callTarget().referencedType() != null, "Invoke should have a reference class set");
+            assertTrue(invoke.callTarget().invokeKind() == CallTargetNode.InvokeKind.Interface, "Should still be an interface call");
+            assertTrue(invoke.callTarget().referencedType().equals(expectedReferencedType));
+        } else {
+            assertTrue(invoke.callTarget().invokeKind() == CallTargetNode.InvokeKind.Interface, "Should not be devirtualized");
+        }
+    }
+
+    @Test
+    public void testSingleImplementorInterfaceInlining2() {
+        ResolvedJavaType singleImplementorType = getMetaAccess().lookupJavaType(SingleImplementor1.class);
+        ResolvedJavaType expectedReferencedType = getMetaAccess().lookupJavaType(Interface1.class);
+        singleImplementorType.initialize();
+        StructuredGraph graph = parseEager("singleImplementorInterfaceSnippet2", StructuredGraph.AllowAssumptions.YES);
+        HighTierContext context = new HighTierContext(getProviders(), getDefaultGraphBuilderSuite(), OptimisticOptimizations.ALL);
+        createInliningPhase(createCanonicalizerPhase()).apply(graph, context);
+
+        // Right now inlining will not do anything, but if it starts doing devirtualization of
+        // interface calls
+        // in the future there should be a subtype check.
+        InvokeNode invoke = graph.getNodes().filter(InvokeNode.class).first();
+        if (invoke != null) {
+            assertTrue(invoke.callTarget().invokeKind() == CallTargetNode.InvokeKind.Interface, "Should still be an interface call");
+            if (GraalServices.hasLookupReferencedType()) {
+                assertTrue(invoke.callTarget().referencedType() != null, "Invoke should have a reference class set");
+                assertTrue(invoke.callTarget().referencedType().equals(expectedReferencedType));
+            }
+        } else {
+            InstanceOfNode instanceOfNode = graph.getNodes().filter(InstanceOfNode.class).first();
+            assertTrue(instanceOfNode != null, "Missing the subtype check");
+            assertTrue(instanceOfNode.getCheckedStamp().type().equals(singleImplementorType), "Checking against a wrong type");
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/inlining/InliningTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/inlining/InliningTest.java
@@ -43,6 +43,7 @@ import org.graalvm.compiler.phases.OptimisticOptimizations;
 import org.graalvm.compiler.phases.PhaseSuite;
 import org.graalvm.compiler.phases.common.DeadCodeEliminationPhase;
 import org.graalvm.compiler.phases.tiers.HighTierContext;
+import org.graalvm.compiler.serviceprovider.GraalServices;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -182,7 +183,9 @@ public class InliningTest extends GraalCompilerTest {
     public void testClassHierarchyAnalysis() {
         assertInlined(getGraph("invokeLeafClassMethodSnippet", false));
         assertInlined(getGraph("invokeConcreteMethodSnippet", false));
-        assertInlined(getGraph("invokeSingleImplementorInterfaceSnippet", false));
+        if (GraalServices.hasLookupReferencedType()) {
+            assertInlined(getGraph("invokeSingleImplementorInterfaceSnippet", false));
+        }
         // assertInlined(getGraph("invokeConcreteInterfaceMethodSnippet", false));
 
         assertNotInlined(getGraph("invokeOverriddenPublicMethodSnippet", false));
@@ -194,7 +197,9 @@ public class InliningTest extends GraalCompilerTest {
     public void testClassHierarchyAnalysisIP() {
         assertManyMethodInfopoints(assertInlined(getGraph("invokeLeafClassMethodSnippet", true)));
         assertManyMethodInfopoints(assertInlined(getGraph("invokeConcreteMethodSnippet", true)));
-        assertManyMethodInfopoints(assertInlined(getGraph("invokeSingleImplementorInterfaceSnippet", true)));
+        if (GraalServices.hasLookupReferencedType()) {
+            assertManyMethodInfopoints(assertInlined(getGraph("invokeSingleImplementorInterfaceSnippet", true)));
+        }
         //@formatter:off
         // assertInlineInfopoints(assertInlined(getGraph("invokeConcreteInterfaceMethodSnippet", true)));
         //@formatter:on

--- a/compiler/src/org.graalvm.compiler.java/src/org/graalvm/compiler/java/BytecodeParser.java
+++ b/compiler/src/org.graalvm.compiler.java/src/org/graalvm/compiler/java/BytecodeParser.java
@@ -432,6 +432,7 @@ import org.graalvm.compiler.nodes.util.GraphUtil;
 import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.phases.OptimisticOptimizations;
 import org.graalvm.compiler.phases.util.ValueMergeUtil;
+import org.graalvm.compiler.serviceprovider.GraalServices;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.word.LocationIdentity;
 
@@ -1697,13 +1698,17 @@ public class BytecodeParser implements GraphBuilderContext {
 
     protected void genInvokeInterface(int cpi, int opcode) {
         JavaMethod target = lookupMethod(cpi, opcode);
-        genInvokeInterface(target);
+        JavaType referencedType = lookupReferencedTypeInPool(cpi, opcode);
+        genInvokeInterface(referencedType, target);
     }
 
-    protected void genInvokeInterface(JavaMethod target) {
-        if (callTargetIsResolved(target)) {
+    protected void genInvokeInterface(JavaType referencedType, JavaMethod target) {
+        if (callTargetIsResolved(target) && (referencedType == null || referencedType instanceof ResolvedJavaType)) {
             ValueNode[] args = frameState.popArguments(target.getSignature().getParameterCount(true));
-            appendInvoke(InvokeKind.Interface, (ResolvedJavaMethod) target, args);
+            Invoke invoke = appendInvoke(InvokeKind.Interface, (ResolvedJavaMethod) target, args);
+            if (invoke != null) {
+                invoke.callTarget().setReferencedType((ResolvedJavaType) referencedType);
+            }
         } else {
             handleUnresolvedInvoke(target, InvokeKind.Interface);
         }
@@ -4317,6 +4322,16 @@ public class BytecodeParser implements GraphBuilderContext {
         JavaMethod result = lookupMethodInPool(cpi, opcode);
         assert !graphBuilderConfig.unresolvedIsError() || result instanceof ResolvedJavaMethod : unresolvedMethodAssertionMessage(result);
         return result;
+    }
+
+    protected JavaType lookupReferencedTypeInPool(int cpi, int opcode) {
+        if (GraalServices.hasLookupReferencedType()) {
+            return GraalServices.lookupReferencedType(constantPool, cpi, opcode);
+        }
+        // Returning null means that we should not attempt using CHA to devirtualize or inline
+        // interface calls. This is a normal behavior if the JVMCI doesn't support
+        // {@code ConstantPool.lookupReferencedType()}.
+        return null;
     }
 
     protected JavaMethod lookupMethodInPool(int cpi, int opcode) {

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/CallTargetNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/CallTargetNode.java
@@ -79,6 +79,46 @@ public abstract class CallTargetNode extends ValueNode implements LIRLowerable {
 
     @Input protected NodeInputList<ValueNode> arguments;
     protected ResolvedJavaMethod targetMethod;
+
+    /**
+     * Receiver type referenced at the interface call site.
+     *
+     * We need to distinguish the declaring type from the type referenced at the call site. We must
+     * use the referenced type as lower type bound when doing CHA since interface calls must throw
+     * exception if the receiver type is not a subtype of the reference type.
+     *
+     * Example:
+     *
+     * <pre>
+     * interface I1 {
+     *     void foo();
+     * }
+     *
+     * interface I2 extends I1 {
+     * }
+     *
+     * void bar(I2 o) {
+     *     o.foo();
+     * }
+     * </pre>
+     *
+     * Here at the call site the declaring type for {@code foo()} is {@code I1}, while the
+     * referenced type is {@code I2}. Only receivers of type {@code T} that is {@code T <: I2}
+     * should be allowed at the call site. If they are not - an exception should be thrown.
+     *
+     * Since the interface types are not verified, another way to think about this call site is to
+     * rewrite it as follows:
+     *
+     * <pre>
+     * void bar(Object o) {
+     *     ((I2) o).foo();
+     * }
+     * </pre>
+     *
+     * So, in case the receiver is not a subtype of {@code I2} an exception is thrown.
+     */
+    protected ResolvedJavaType referencedType;
+
     protected InvokeKind invokeKind;
     protected final StampPair returnStamp;
 
@@ -128,6 +168,14 @@ public abstract class CallTargetNode extends ValueNode implements LIRLowerable {
      */
     public ResolvedJavaMethod targetMethod() {
         return targetMethod;
+    }
+
+    public void setReferencedType(ResolvedJavaType referencedType) {
+        this.referencedType = referencedType;
+    }
+
+    public ResolvedJavaType referencedType() {
+        return referencedType;
     }
 
     public InvokeKind invokeKind() {

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/MethodCallTargetNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/MethodCallTargetNode.java
@@ -180,9 +180,10 @@ public class MethodCallTargetNode extends CallTargetNode implements IterableNode
         Assumptions assumptions = graph().getAssumptions();
         /*
          * Even though we are not registering an assumption (see comment below), the optimization is
-         * only valid when speculative optimizations are enabled.
+         * only valid when speculative optimizations are enabled. We need to check the invoke kind
+         * to avoid recursive simplification for virtual interface methods calls.
          */
-        if (invokeKind().isIndirect() && invokeKind().isInterface() && assumptions != null) {
+        if (invokeKind().isIndirect() && assumptions != null) {
 
             // check if the type of the receiver can narrow the result
             ValueNode receiver = receiver();
@@ -190,27 +191,28 @@ public class MethodCallTargetNode extends CallTargetNode implements IterableNode
             // try to turn a interface call into a virtual call
             ResolvedJavaType declaredReceiverType = targetMethod().getDeclaringClass();
 
-            /*
-             * We need to check the invoke kind to avoid recursive simplification for virtual
-             * interface methods calls.
-             */
-            if (declaredReceiverType.isInterface()) {
-                ResolvedJavaType singleImplementor = declaredReceiverType.getSingleImplementor();
-                if (singleImplementor != null && !singleImplementor.equals(declaredReceiverType)) {
-                    TypeReference speculatedType = TypeReference.createTrusted(assumptions, singleImplementor);
-                    if (tryCheckCastSingleImplementor(receiver, speculatedType)) {
-                        return;
+            ResolvedJavaType referencedReceiverType = referencedType();
+            if (referencedReceiverType != null) {
+                if (declaredReceiverType.isInterface()) {
+                    ResolvedJavaType singleImplementor = referencedReceiverType.getSingleImplementor();
+                    // If singleImplementor is equal to declaredReceiverType it means that there are
+                    // multiple implementors.
+                    if (singleImplementor != null && !singleImplementor.equals(declaredReceiverType)) {
+                        TypeReference speculatedType = TypeReference.createTrusted(assumptions, singleImplementor);
+                        if (tryCheckCastSingleImplementor(receiver, speculatedType)) {
+                            return;
+                        }
                     }
                 }
-            }
-
-            if (receiver instanceof UncheckedInterfaceProvider) {
-                UncheckedInterfaceProvider uncheckedInterfaceProvider = (UncheckedInterfaceProvider) receiver;
-                Stamp uncheckedStamp = uncheckedInterfaceProvider.uncheckedStamp();
-                if (uncheckedStamp != null) {
-                    TypeReference speculatedType = StampTool.typeReferenceOrNull(uncheckedStamp);
-                    if (speculatedType != null) {
-                        tryCheckCastSingleImplementor(receiver, speculatedType);
+                if (receiver instanceof UncheckedInterfaceProvider) {
+                    UncheckedInterfaceProvider uncheckedInterfaceProvider = (UncheckedInterfaceProvider) receiver;
+                    Stamp uncheckedStamp = uncheckedInterfaceProvider.uncheckedStamp();
+                    if (uncheckedStamp != null) {
+                        TypeReference speculatedType = StampTool.typeReferenceOrNull(uncheckedStamp);
+                        // speculatedType must be related to the referencedReceiverType.
+                        if (speculatedType != null && referencedReceiverType.isAssignableFrom(speculatedType.getType())) {
+                            tryCheckCastSingleImplementor(receiver, speculatedType);
+                        }
                     }
                 }
             }
@@ -227,7 +229,7 @@ public class MethodCallTargetNode extends CallTargetNode implements IterableNode
                  * with an invoke virtual.
                  *
                  * To do so we need to ensure two properties: 1) the receiver must implement the
-                 * interface (declaredReceiverType). The verifier does not prove this so we need a
+                 * interface (referencedReceiverType). The verifier does not prove this so we need a
                  * dynamic check. 2) we need to ensure that there is still only one implementor of
                  * this interface, i.e. that we are calling the right method. We could do this with
                  * an assumption but as we need an instanceof check anyway we can verify both

--- a/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/inlining/walker/InliningData.java
+++ b/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/inlining/walker/InliningData.java
@@ -235,17 +235,18 @@ public class InliningData {
             }
         }
 
-        AssumptionResult<ResolvedJavaType> leafConcreteSubtype = holder.findLeafConcreteSubtype();
-        if (leafConcreteSubtype != null) {
-            ResolvedJavaMethod resolvedMethod = leafConcreteSubtype.getResult().resolveConcreteMethod(targetMethod, contextType);
-            if (resolvedMethod != null && leafConcreteSubtype.canRecordTo(callTarget.graph().getAssumptions())) {
-                return getAssumptionInlineInfo(invoke, resolvedMethod, leafConcreteSubtype);
+        if (invokeKind != InvokeKind.Interface) {
+            AssumptionResult<ResolvedJavaType> leafConcreteSubtype = holder.findLeafConcreteSubtype();
+            if (leafConcreteSubtype != null) {
+                ResolvedJavaMethod resolvedMethod = leafConcreteSubtype.getResult().resolveConcreteMethod(targetMethod, contextType);
+                if (resolvedMethod != null && leafConcreteSubtype.canRecordTo(callTarget.graph().getAssumptions())) {
+                    return getAssumptionInlineInfo(invoke, resolvedMethod, leafConcreteSubtype);
+                }
             }
-        }
-
-        AssumptionResult<ResolvedJavaMethod> concrete = holder.findUniqueConcreteMethod(targetMethod);
-        if (concrete != null && concrete.canRecordTo(callTarget.graph().getAssumptions())) {
-            return getAssumptionInlineInfo(invoke, concrete.getResult(), concrete);
+            AssumptionResult<ResolvedJavaMethod> concrete = holder.findUniqueConcreteMethod(targetMethod);
+            if (concrete != null && concrete.canRecordTo(callTarget.graph().getAssumptions())) {
+                return getAssumptionInlineInfo(invoke, concrete.getResult(), concrete);
+            }
         }
 
         // type check based inlining

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/classfile/ConstantPoolPatch.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/classfile/ConstantPoolPatch.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.replacements.classfile;
+
+import jdk.vm.ci.meta.JavaType;
+
+public interface ConstantPoolPatch {
+    JavaType lookupReferencedType(int index, int opcode);
+}

--- a/compiler/src/org.graalvm.compiler.serviceprovider.jdk8/src/org/graalvm/compiler/serviceprovider/GraalServices.java
+++ b/compiler/src/org.graalvm.compiler.serviceprovider.jdk8/src/org/graalvm/compiler/serviceprovider/GraalServices.java
@@ -40,6 +40,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import jdk.vm.ci.code.VirtualObject;
+import jdk.vm.ci.meta.ConstantPool;
+import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.ResolvedJavaField;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
@@ -448,5 +450,14 @@ public final class GraalServices {
             throw new InternalError("Unexpected java.vm.version value: " + vmVersion);
         }
         return Integer.parseInt(matcher.group(1));
+    }
+
+    @SuppressWarnings("unused")
+    public static JavaType lookupReferencedType(ConstantPool constantPool, int cpi, int opcode) {
+        throw new InternalError("This JVMCI version doesn't support ConstantPool.lookupReferencedType()");
+    }
+
+    public static boolean hasLookupReferencedType() {
+        return false;
     }
 }

--- a/compiler/src/org.graalvm.compiler.serviceprovider/src/org/graalvm/compiler/serviceprovider/GraalServices.java
+++ b/compiler/src/org.graalvm.compiler.serviceprovider/src/org/graalvm/compiler/serviceprovider/GraalServices.java
@@ -29,6 +29,8 @@ import java.io.InputStream;
 import java.util.List;
 
 import jdk.vm.ci.code.VirtualObject;
+import jdk.vm.ci.meta.ConstantPool;
+import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.meta.SpeculationLog.SpeculationReason;
 import jdk.vm.ci.services.JVMCIPermission;
@@ -253,4 +255,14 @@ public final class GraalServices {
     public static int getJavaUpdateVersion() {
         throw shouldNotReachHere();
     }
+
+    @SuppressWarnings("unused")
+    public static JavaType lookupReferencedType(ConstantPool constantPool, int cpi, int opcode) {
+        throw shouldNotReachHere();
+    }
+
+    public static boolean hasLookupReferencedType() {
+        throw shouldNotReachHere();
+    }
+
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/infrastructure/WrappedConstantPool.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/infrastructure/WrappedConstantPool.java
@@ -160,6 +160,15 @@ public class WrappedConstantPool implements ConstantPool {
     }
 
     @Override
+    public JavaType lookupReferencedType(int cpi, int opcode) {
+        if (wrapped instanceof WrappedConstantPool) {
+            return ((WrappedConstantPool) wrapped).lookupReferencedType(cpi, opcode);
+        } else {
+            return wrapped.lookupReferencedType(cpi, opcode);
+        }
+    }
+
+    @Override
     public WrappedSignature lookupSignature(int cpi) {
         return universe.lookup(wrapped.lookupSignature(cpi), defaultAccessingClass);
     }


### PR DESCRIPTION
This fixes the build with latest OpenJDK 11.0.8-ga. See this change which makes it necessary to account for it in Graal VM land:
http://hg.openjdk.java.net/jdk-updates/jdk11u/rev/76890092b5ca

I'm going to try to get this into upstream Graal VM as well.