### PR TITLE
Removes infinispan-embedded quarkus integration test

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -248,7 +248,6 @@ jobs:
             test-modules: >
               infinispan-cache-jpa
               infinispan-client
-              infinispan-embedded
               cache
           - category: HTTP
             timeout: 55


### PR DESCRIPTION
The test is no longer available on quarkus master