### PR TITLE
Sync and test graal/master instead of master

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -21,6 +21,8 @@ on:
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
       - '.travis.yml'
+  schedule:
+  - cron: '0 5 * * *'
 
 env:
   # Workaround testsuite locale issue
@@ -43,6 +45,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
+        ref: graal/master
         path: mandrel
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -68,8 +68,8 @@ jobs:
           ${{ runner.os }}-mx-
     - name: Get openJDK11 with static libs
       run: |
-        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B7/OpenJDK11U-jdk_x64_linux_11.0.8_7_ea.tar.gz -o jdk.tar.gz
-        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.8%2B7/OpenJDK11U-static-libs_x64_linux_11.0.8_7_ea.tar.gz -o jdk-static-libs.tar.gz
+        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.9%2B1/OpenJDK11U-jdk_x64_linux_11.0.9_1_ea.tar.gz -o jdk.tar.gz
+        curl -sL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.9%2B1/OpenJDK11U-static-libs_x64_linux_11.0.9_1_ea.tar.gz -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -13,16 +13,16 @@ jobs:
   mandrel-master:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Master branch
+    - name: Checkout graal/master branch
       uses: actions/checkout@v2
       with:
-        ref: master
+        ref: graal/master
         fetch-depth: 0
-    - name: Sync Master branch
+    - name: Sync branch
       run: |
         git config --local user.email "fzakkak@redhat.com"
         git config --local user.name "Foivos Zakkak through GH action"
         git remote add upstream https://github.com/oracle/graal
         git fetch upstream master
         git merge upstream/master
-        git push --quiet origin master
+        git push --quiet origin graal/master


### PR DESCRIPTION
First step towards Proposal 1 of https://oss.oracle.com/pipermail/graalvm-dev/2020-July/000071.html:

> Make the default branch contain only a README file explaining what Mandrel is, how it relates to Graal, and how to get your hands on it. This branch will also contain any workflows related to housekeeping, syncing branches, nightly testing, etc.
> This branch will not contain any code. So after `git clone https://github.com/graalvm/mandrel` and reading the README users will be asked to checkout another branch if they want to access the source code.