### PR TITLE
Implement unsafe access for static fields.

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
@@ -97,6 +97,8 @@ public abstract class BigBang {
     private final HostedProviders providers;
     private final Replacements replacements;
 
+    private final HeapScanningPolicy heapScanningPolicy;
+
     /** The type of {@link java.lang.Object}. */
     private final AnalysisType objectType;
     private TypeFlow<?> allSynchronizedTypeFlow;
@@ -163,6 +165,14 @@ public abstract class BigBang {
         executor = new CompletionExecutor(this, executorService, heartbeatCallback);
         executor.init(timing);
         this.heartbeatCallback = heartbeatCallback;
+
+        heapScanningPolicy = PointstoOptions.ExhaustiveHeapScan.getValue(options)
+                        ? HeapScanningPolicy.scanAll()
+                        : HeapScanningPolicy.skipTypes(skippedHeapTypes());
+    }
+
+    public AnalysisType[] skippedHeapTypes() {
+        return new AnalysisType[]{metaAccess.lookupJavaType(String.class)};
     }
 
     public Runnable getHeartbeatCallback() {
@@ -617,6 +627,10 @@ public abstract class BigBang {
             objectScanner.scanBootImageHeapRoots(null);
         }
         AnalysisType.updateAssignableTypes(this);
+    }
+
+    public HeapScanningPolicy scanningPolicy() {
+        return heapScanningPolicy;
     }
 
     /**

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
@@ -238,18 +238,28 @@ public abstract class BigBang {
 
         // force update of the unsafe loads
         for (AbstractUnsafeLoadTypeFlow unsafeLoad : unsafeLoads.keySet()) {
-            TypeFlow<?> receiverFlow = unsafeLoad.receiver();
-            // post the receiver object flow for update; an update of the receiver object
-            // flow will trigger an updated of the observers, i.e., of the unsafe load
-            this.postFlow(receiverFlow);
+            /* Force update for unsafe accessed static fields. */
+            unsafeLoad.initClone(this);
+
+            /*
+             * Force update for unsafe accessed instance fields: post the receiver object flow for
+             * update; an update of the receiver object flow will trigger an updated of the
+             * observers, i.e., of the unsafe load.
+             */
+            this.postFlow(unsafeLoad.receiver());
         }
 
         // force update of the unsafe stores
         for (AbstractUnsafeStoreTypeFlow unsafeStore : unsafeStores.keySet()) {
-            TypeFlow<?> receiverFlow = unsafeStore.receiver();
-            // post the receiver object flow for update; an update of the receiver object
-            // flow will trigger an updated of the observers, i.e., of the unsafe store
-            this.postFlow(receiverFlow);
+            /* Force update for unsafe accessed static fields. */
+            unsafeStore.initClone(this);
+
+            /*
+             * Force update for unsafe accessed instance fields: post the receiver object flow for
+             * update; an update of the receiver object flow will trigger an updated of the
+             * observers, i.e., of the unsafe store.
+             */
+            this.postFlow(unsafeStore.receiver());
         }
     }
 

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/HeapScanningPolicy.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/HeapScanningPolicy.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.pointsto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.oracle.graal.pointsto.meta.AnalysisType;
+
+import jdk.vm.ci.meta.JavaConstant;
+
+/**
+ * Policy to decide what constants to scan.
+ * 
+ * This policy is used to control which instances are really scanned. For example the analysis
+ * object scanner doensn't need to scan all String instances, but it must scan at least one, if
+ * present. Scanning all String instances would not add additonal information to the analysis state.
+ * 
+ * This policy is also used to control the collection of embedded roots. Similarly, not all Strings
+ * need to be collected.
+ * 
+ * A side effect of skipping scanning some objects is that the object replacers will not see all
+ * those objects.
+ */
+public abstract class HeapScanningPolicy {
+
+    /** Decide if the constant will be stored in the global constant registry. */
+    public abstract boolean trackConstant(BigBang bb, JavaConstant constant);
+
+    /** Decide if the constant will be processed by the object scanner. */
+    public abstract boolean scanConstant(BigBang bb, JavaConstant constant);
+
+    public static HeapScanningPolicy scanAll() {
+        return new ScanAllPolicy();
+    }
+
+    public static HeapScanningPolicy skipTypes(AnalysisType... skipTypes) {
+        return new SkipTypesPolicy(skipTypes);
+    }
+
+    /** Scan all constants. */
+    static class ScanAllPolicy extends HeapScanningPolicy {
+        @Override
+        public boolean trackConstant(BigBang bb, JavaConstant constant) {
+            return true;
+        }
+
+        @Override
+        public boolean scanConstant(BigBang bb, JavaConstant constant) {
+            return true;
+        }
+    }
+
+    /** Skip all but one instace of the specified types. */
+    static class SkipTypesPolicy extends HeapScanningPolicy {
+
+        /** Per type skip info. */
+        static class SkipData {
+            /** Mark types already seen during tracking. */
+            volatile boolean seenForTracking;
+            /** Mark types already seen during scanning. */
+            volatile boolean seenForScanning;
+        }
+
+        /**
+         * Store the state of types to skip. Although this map is used in a concurrent context (both
+         * types tracking and scanning are parallelized) the map itself never gets modified after
+         * being created and populated. The flags marking types as tracked/scanned will eventually
+         * be set to true, but not necessarily as soon as the first constant of that type is
+         * processed. An implementation providing a stronger guarantee that exactly one constant of
+         * each type is processed is possible, but this implementation is preferred for performance
+         * reasons since constant scanning is hot code.
+         */
+        final Map<AnalysisType, SkipData> skipTypes;
+
+        SkipTypesPolicy(AnalysisType... types) {
+            skipTypes = new HashMap<>();
+            for (AnalysisType type : types) {
+                skipTypes.put(type, new SkipData());
+            }
+        }
+
+        @Override
+        public boolean trackConstant(BigBang bb, JavaConstant constant) {
+            AnalysisType type = bb.getMetaAccess().lookupJavaType(constant.getClass());
+            SkipData data = skipTypes.get(type);
+            if (data != null) {
+                if (data.seenForTracking) {
+                    return false;
+                }
+                data.seenForTracking = true;
+                return true;
+            }
+            return true;
+        }
+
+        @Override
+        public boolean scanConstant(BigBang bb, JavaConstant constant) {
+            AnalysisType type = ObjectScanner.constantType(bb, constant);
+            SkipData data = skipTypes.get(type);
+            if (data != null) {
+                if (data.seenForScanning) {
+                    return false;
+                }
+                data.seenForScanning = true;
+                return true;
+            }
+            return true;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/api/PointstoOptions.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/api/PointstoOptions.java
@@ -131,6 +131,9 @@ public class PointstoOptions {
     @Option(help = "Object scanning in parallel")//
     public static final OptionKey<Boolean> ScanObjectsParallel = new OptionKey<>(true);
 
+    @Option(help = "Scan all objects reachable from roots for analysis. By default false.")//
+    public static final OptionKey<Boolean> ExhaustiveHeapScan = new OptionKey<>(false);
+
     /**
      * Controls the static analysis context sensitivity. Available values:
      * <p/>

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/MethodTypeFlow.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/MethodTypeFlow.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.graalvm.collections.EconomicMap;
 import org.graalvm.compiler.core.common.type.ObjectStamp;
 import org.graalvm.compiler.graph.iterators.NodeIterable;
 import org.graalvm.compiler.java.BytecodeParser.BytecodeParserError;
@@ -54,9 +53,6 @@ import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.graal.pointsto.typestate.TypeState;
 import com.oracle.graal.pointsto.util.AnalysisError;
 
-import jdk.vm.ci.code.BytecodePosition;
-import jdk.vm.ci.meta.JavaConstant;
-
 public class MethodTypeFlow extends TypeFlow<AnalysisMethod> {
 
     protected MethodFlowsGraph originalMethodFlows;
@@ -64,7 +60,6 @@ public class MethodTypeFlow extends TypeFlow<AnalysisMethod> {
     private int localCallingContextDepth;
 
     private final AnalysisMethod method;
-    protected EconomicMap<JavaConstant, BytecodePosition> objectConstants;
 
     private volatile boolean methodParsed;
     private InvokeTypeFlow parsingReason;
@@ -81,10 +76,6 @@ public class MethodTypeFlow extends TypeFlow<AnalysisMethod> {
 
     public AnalysisMethod getMethod() {
         return method;
-    }
-
-    public EconomicMap<JavaConstant, BytecodePosition> getObjectConstants() {
-        return objectConstants;
     }
 
     public InvokeTypeFlow getParsingReason() {

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/OffsetLoadTypeFlow.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/OffsetLoadTypeFlow.java
@@ -180,6 +180,18 @@ public abstract class OffsetLoadTypeFlow extends TypeFlow<BytecodePosition> {
         protected abstract AbstractUnsafeLoadTypeFlow makeCopy(BigBang bb, MethodFlowsGraph methodFlows);
 
         @Override
+        public void initClone(BigBang bb) {
+            /*
+             * Unsafe load type flow models unsafe reads from both instance and static fields. From
+             * an analysis stand point for static fields the base doesn't matter. An unsafe load can
+             * read from any of the static fields marked for unsafe access.
+             */
+            for (AnalysisField field : bb.getUniverse().getUnsafeAccessedStaticFields()) {
+                field.getStaticFieldFlow().addUse(bb, this);
+            }
+        }
+
+        @Override
         public void onObservedUpdate(BigBang bb) {
             /* Only a clone should be updated */
             assert this.isClone();

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/OffsetStoreTypeFlow.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/OffsetStoreTypeFlow.java
@@ -198,6 +198,18 @@ public abstract class OffsetStoreTypeFlow extends TypeFlow<BytecodePosition> {
         protected abstract AbstractUnsafeStoreTypeFlow makeCopy(BigBang bb, MethodFlowsGraph methodFlows);
 
         @Override
+        public void initClone(BigBang bb) {
+            /*
+             * Unsafe store type flow models unsafe writes to both instance and static fields. From
+             * an analysis stand point for static fields the base doesn't matter. An unsafe store
+             * can write to any of the static fields marked for unsafe access.
+             */
+            for (AnalysisField field : bb.getUniverse().getUnsafeAccessedStaticFields()) {
+                this.addUse(bb, field.getStaticFieldFlow());
+            }
+        }
+
+        @Override
         public boolean addState(BigBang bb, TypeState add) {
             /* Only a clone should be updated */
             assert this.isClone();

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
@@ -59,6 +59,7 @@ import com.oracle.graal.pointsto.infrastructure.WrappedJavaType;
 import com.oracle.graal.pointsto.infrastructure.WrappedSignature;
 import com.oracle.graal.pointsto.util.AnalysisError;
 
+import jdk.vm.ci.code.BytecodePosition;
 import jdk.vm.ci.common.JVMCIError;
 import jdk.vm.ci.meta.ConstantPool;
 import jdk.vm.ci.meta.JavaConstant;
@@ -79,12 +80,14 @@ public class AnalysisUniverse implements Universe {
     private static final int ESTIMATED_FIELDS_PER_TYPE = 3;
     public static final int ESTIMATED_NUMBER_OF_TYPES = 2000;
     static final int ESTIMATED_METHODS_PER_TYPE = 15;
+    static final int ESTIMATED_EMBEDDED_ROOTS = 500;
 
     private final ConcurrentMap<ResolvedJavaType, Object> types = new ConcurrentHashMap<>(ESTIMATED_NUMBER_OF_TYPES);
     private final ConcurrentMap<ResolvedJavaField, AnalysisField> fields = new ConcurrentHashMap<>(ESTIMATED_FIELDS_PER_TYPE * ESTIMATED_NUMBER_OF_TYPES);
     private final ConcurrentMap<ResolvedJavaMethod, AnalysisMethod> methods = new ConcurrentHashMap<>(ESTIMATED_METHODS_PER_TYPE * ESTIMATED_NUMBER_OF_TYPES);
     private final ConcurrentMap<Signature, WrappedSignature> signatures = new ConcurrentHashMap<>(ESTIMATED_METHODS_PER_TYPE * ESTIMATED_NUMBER_OF_TYPES);
     private final ConcurrentMap<ConstantPool, WrappedConstantPool> constantPools = new ConcurrentHashMap<>(ESTIMATED_NUMBER_OF_TYPES);
+    private final ConcurrentHashMap<JavaConstant, BytecodePosition> embeddedRoots = new ConcurrentHashMap<>(ESTIMATED_EMBEDDED_ROOTS);
 
     private boolean sealed;
 
@@ -488,6 +491,17 @@ public class AnalysisUniverse implements Universe {
 
     public Collection<AnalysisMethod> getMethods() {
         return methods.values();
+    }
+
+    public Map<JavaConstant, BytecodePosition> getEmbeddedRoots() {
+        return embeddedRoots;
+    }
+
+    /**
+     * Register an embedded root, i.e., a JavaConstant embedded in a Graal graph via a ConstantNode.
+     */
+    public void registerEmbeddedRoot(JavaConstant root, BytecodePosition position) {
+        this.embeddedRoots.put(root, position);
     }
 
     public void registerObjectReplacer(Function<Object, Object> replacer) {

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
@@ -88,6 +88,7 @@ public class AnalysisUniverse implements Universe {
     private final ConcurrentMap<Signature, WrappedSignature> signatures = new ConcurrentHashMap<>(ESTIMATED_METHODS_PER_TYPE * ESTIMATED_NUMBER_OF_TYPES);
     private final ConcurrentMap<ConstantPool, WrappedConstantPool> constantPools = new ConcurrentHashMap<>(ESTIMATED_NUMBER_OF_TYPES);
     private final ConcurrentHashMap<JavaConstant, BytecodePosition> embeddedRoots = new ConcurrentHashMap<>(ESTIMATED_EMBEDDED_ROOTS);
+    private final ConcurrentMap<AnalysisField, Boolean> unsafeAccessedStaticFields = new ConcurrentHashMap<>();
 
     private boolean sealed;
 
@@ -502,6 +503,14 @@ public class AnalysisUniverse implements Universe {
      */
     public void registerEmbeddedRoot(JavaConstant root, BytecodePosition position) {
         this.embeddedRoots.put(root, position);
+    }
+
+    public void registerUnsafeAccessedStaticField(AnalysisField field) {
+        unsafeAccessedStaticFields.put(field, true);
+    }
+
+    public Set<AnalysisField> getUnsafeAccessedStaticFields() {
+        return unsafeAccessedStaticFields.keySet();
     }
 
     public void registerObjectReplacer(Function<Object, Object> replacer) {

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisHeapHistogramPrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisHeapHistogramPrinter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.pointsto.reports;
+
+import static com.oracle.graal.pointsto.reports.ReportUtils.fieldComparator;
+import static com.oracle.graal.pointsto.reports.ReportUtils.positionComparator;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.oracle.graal.pointsto.BigBang;
+import com.oracle.graal.pointsto.ObjectScanner;
+import com.oracle.graal.pointsto.api.PointstoOptions;
+import com.oracle.graal.pointsto.meta.AnalysisField;
+import com.oracle.graal.pointsto.meta.AnalysisType;
+
+import jdk.vm.ci.meta.JavaConstant;
+
+public final class AnalysisHeapHistogramPrinter extends ObjectScanner {
+
+    public static void print(BigBang bigbang, String path, String reportName) {
+        ReportUtils.report("analysis heap histogram", path + File.separatorChar + "reports", "analysis_heap_histogram_" + reportName, "txt",
+                        writer -> AnalysisHeapHistogramPrinter.doPrint(writer, bigbang));
+    }
+
+    private static void doPrint(PrintWriter out, BigBang bigbang) {
+        if (!PointstoOptions.ExhaustiveHeapScan.getValue(bigbang.getOptions())) {
+            String types = Arrays.stream(bigbang.skippedHeapTypes()).map(t -> t.toJavaName()).collect(Collectors.joining(", "));
+            System.out.println("Exhaustive heap scanning is disabled. The analysis heap histogram will not contain all instances of types: " + types);
+            System.out.println("Exhaustive heap scanning can be turned on using -H:+ExhaustiveHeapScan.");
+        }
+        AnalysisHeapHistogramPrinter printer = new AnalysisHeapHistogramPrinter(bigbang);
+        printer.scanBootImageHeapRoots(fieldComparator, positionComparator);
+        printer.printHistogram(out);
+    }
+
+    private void printHistogram(PrintWriter out) {
+        out.println("Heap histogram");
+        out.format("%8s %s %n", "Count", "Class");
+
+        histogram.entrySet().stream().sorted(Map.Entry.<AnalysisType, Integer> comparingByValue().reversed())
+                        .forEach(entry -> out.format("%8d %8s %n", entry.getValue(), entry.getKey().toJavaName()));
+    }
+
+    private final Map<AnalysisType, Integer> histogram = new HashMap<>();
+
+    private AnalysisHeapHistogramPrinter(BigBang bigbang) {
+        super(bigbang, new ReusableSet());
+    }
+
+    @Override
+    protected void forScannedConstant(JavaConstant scannedValue, ScanReason reason) {
+        AnalysisType type = constantType(bb, scannedValue);
+        int count = histogram.getOrDefault(type, 0);
+        histogram.put(type, count + 1);
+    }
+
+    @Override
+    public void forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue) {
+    }
+
+    @Override
+    public void forNullFieldValue(JavaConstant receiver, AnalysisField field) {
+    }
+
+    @Override
+    public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue) {
+    }
+
+    @Override
+    public void forNullArrayElement(JavaConstant array, AnalysisType arrayType, int index) {
+    }
+
+    @Override
+    public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int index) {
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ReportUtils.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ReportUtils.java
@@ -38,9 +38,10 @@ import java.util.function.Consumer;
 
 import com.oracle.graal.pointsto.flow.InvokeTypeFlow;
 import com.oracle.graal.pointsto.meta.AnalysisField;
-import com.oracle.graal.pointsto.meta.AnalysisMethod;
 
+import jdk.vm.ci.code.BytecodePosition;
 import jdk.vm.ci.common.JVMCIError;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 
 public class ReportUtils {
     static final String CONNECTING_INDENT = "\u2502   "; // "| "
@@ -48,9 +49,11 @@ public class ReportUtils {
     static final String CHILD = "\u251c\u2500\u2500 "; // "|-- "
     static final String LAST_CHILD = "\u2514\u2500\u2500 "; // "`-- "
 
-    static final Comparator<AnalysisMethod> methodComparator = Comparator.comparing(m -> m.format("%H.%n(%p)"));
-    static final Comparator<AnalysisField> fieldComparator = (f1, f2) -> f1.format("%H.%n").compareTo(f2.format("%H.%n"));
+    public static final Comparator<ResolvedJavaMethod> methodComparator = Comparator.comparing(m -> m.format("%H.%n(%p)"));
+    static final Comparator<AnalysisField> fieldComparator = Comparator.comparing(f -> f.format("%H.%n"));
     static final Comparator<InvokeTypeFlow> invokeComparator = Comparator.comparing(i -> i.getTargetMethod().format("%H.%n(%p)"));
+    static final Comparator<BytecodePosition> positionMethodComparator = Comparator.comparing(pos -> pos.getMethod().format("%H.%n(%p)"));
+    static final Comparator<BytecodePosition> positionComparator = positionMethodComparator.thenComparing(pos -> pos.getBCI());
 
     /**
      * Print a report in the format: path/name_timeStamp.extension. The path is relative to the

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/VarHandleFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/VarHandleFeature.java
@@ -202,17 +202,7 @@ public class VarHandleFeature implements Feature {
             VMError.guarantee(markAsUnsafeAccessed != null, "New VarHandle found after static analysis");
 
             Field field = findVarHandleField(obj);
-            if (info.isStatic) {
-                /*
-                 * GR-10238 implements Unsafe access for static fields, then this branch can be
-                 * removed and static fields can be properly marked for Unsafe access too.
-                 */
-                // Checkstyle: stop
-                System.out.println("WARNING GR-10238: VarHandle for static field is currently not fully supported. Static field " + field + " is not properly marked for Unsafe access!");
-                // Checkstyle: resume
-            } else {
-                markAsUnsafeAccessed.accept(field);
-            }
+            markAsUnsafeAccessed.accept(field);
         }
         return obj;
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -140,6 +140,7 @@ import com.oracle.graal.pointsto.meta.AnalysisMethod;
 import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.graal.pointsto.meta.HostedProviders;
+import com.oracle.graal.pointsto.reports.AnalysisHeapHistogramPrinter;
 import com.oracle.graal.pointsto.reports.AnalysisReportsOptions;
 import com.oracle.graal.pointsto.reports.CallTreePrinter;
 import com.oracle.graal.pointsto.reports.ObjectTreePrinter;
@@ -773,6 +774,7 @@ public class NativeImageGenerator {
 
                 if (AnalysisReportsOptions.PrintImageObjectTree.getValue(options)) {
                     ObjectTreePrinter.print(bigbang, SubstrateOptions.Path.getValue(), ReportUtils.extractImageName(imageName));
+                    AnalysisHeapHistogramPrinter.print(bigbang, SubstrateOptions.Path.getValue(), ReportUtils.extractImageName(imageName));
                 }
 
                 if (PointstoOptions.PrintPointsToStatistics.getValue(options)) {
@@ -988,7 +990,7 @@ public class NativeImageGenerator {
             }
 
             for (StructuredGraph graph : aReplacements.getSnippetGraphs(GraalOptions.TrackNodeSourcePosition.getValue(options), options)) {
-                new SVMMethodTypeFlowBuilder(bigbang, graph).registerUsedElements(null);
+                new SVMMethodTypeFlowBuilder(bigbang, graph).registerUsedElements(false);
             }
         }
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/flow/SVMMethodTypeFlowBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/flow/SVMMethodTypeFlowBuilder.java
@@ -25,7 +25,6 @@
 
 package com.oracle.svm.hosted.analysis.flow;
 
-import org.graalvm.collections.EconomicMap;
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.graph.NodeSourcePosition;
@@ -44,8 +43,6 @@ import com.oracle.svm.hosted.NativeImageOptions;
 import com.oracle.svm.hosted.SVMHost;
 import com.oracle.svm.hosted.substitute.ComputedValueField;
 
-import jdk.vm.ci.code.BytecodePosition;
-import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 
 public class SVMMethodTypeFlowBuilder extends MethodTypeFlowBuilder {
@@ -63,8 +60,8 @@ public class SVMMethodTypeFlowBuilder extends MethodTypeFlowBuilder {
     }
 
     @Override
-    public void registerUsedElements(EconomicMap<JavaConstant, BytecodePosition> objectConstants) {
-        super.registerUsedElements(objectConstants);
+    public void registerUsedElements(boolean registerEmbeddedRoots) {
+        super.registerUsedElements(registerEmbeddedRoots);
 
         for (Node n : graph.getNodes()) {
             if (n instanceof ConstantNode) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageHeap.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageHeap.java
@@ -191,7 +191,6 @@ public final class NativeImageHeap implements ImageHeap {
         addObjectsPhase.allow();
         internStringsPhase.allow();
 
-        addObject(StaticFieldsSupport.getStaticPrimitiveFields(), false, "primitive static fields");
         addStaticFields();
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/IntrinsifyMethodHandlesInvocationPlugin.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/IntrinsifyMethodHandlesInvocationPlugin.java
@@ -123,7 +123,7 @@ import jdk.vm.ci.meta.ResolvedJavaType;
  * not possible in the Substrate VM, for the same reasons that we cannot support arbitrary
  * reflection.
  * <p>
- * Design decisions for this phase: So support static analysis, the method handle invocation needs
+ * Design decisions for this phase: To support static analysis, the method handle invocation needs
  * to be replaced with a regular invocation before static analysis runs. This requires inlining of
  * all method that are involved in the method handle dispatch. We introduce the restriction that one
  * method handle invocation can be reduced by exactly one regular invocation, so that we can inherit
@@ -261,7 +261,7 @@ public class IntrinsifyMethodHandlesInvocationPlugin implements NodePlugin {
          * handling anyway.
          */
         if (method.getDeclaringClass().toJavaName(true).equals("java.lang.invoke.VarHandleGuards")) {
-            if (args.length < 1 || !args[0].isJavaConstant() || !varHandleType.isAssignableFrom(universeProviders.getMetaAccess().lookupJavaType(args[0].asJavaConstant()))) {
+            if (args.length < 1 || !args[0].isJavaConstant() || !isVarHandle(args[0])) {
                 throw new UnsupportedFeatureException("VarHandle object must be a compile time constant");
             }
 
@@ -283,6 +283,10 @@ public class IntrinsifyMethodHandlesInvocationPlugin implements NodePlugin {
         } else {
             return false;
         }
+    }
+
+    private boolean isVarHandle(ValueNode arg) {
+        return varHandleType.isAssignableFrom(universeProviders.getMetaAccess().lookupJavaType(arg.asJavaConstant()));
     }
 
     class MethodHandlesParameterPlugin implements ParameterPlugin {


### PR DESCRIPTION
Makes:

```
WARNING GR-10238: VarHandle for static field is currently not fully supported. Static field private static volatile java.lang.System$Logger jdk.internal.event.EventHelper.securityLogger is not properly marked for Unsafe access!
```
go away!