### PR TITLE
CI: Stop testing Quarkus master with 20.1

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: ['OpenJDK11-latest-GA', 'OpenJDK11-latest-EA']
-        quarkus: [master, 1.7]
+        quarkus: [1.7]
     steps:
     - name: Get quarkus
       run: |
@@ -148,7 +148,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: ['OpenJDK11-latest-GA', 'OpenJDK11-latest-EA']
-        quarkus: [master, 1.7]
+        quarkus: [1.7]
         category: [Main, Data1, Data2, Data3, Data4, Data5, Data6, Security1, Security2, Security3, Amazon, Messaging, Cache, HTTP, Misc1, Misc2, Misc3, Misc4, Spring, gRPC]
         include:
           - category: Main


### PR DESCRIPTION
20.1 is supposed to support Quarkus 1.7.x, for later releases 20.2
should be used (https://github.com/quarkusio/quarkus/blob/f585d9d8c00f235059942aa9f81b7ccea06297af/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java#L131)