### PR TITLE
Refactor static library search paths

### DIFF
--- a/sdk/mx.sdk/mx_sdk_vm.py
+++ b/sdk/mx.sdk/mx_sdk_vm.py
@@ -701,15 +701,9 @@ grant codeBase "jrt:/com.oracle.graal.graal_enterprise" {
                 zf.writestr(name, contents)
 
         mx.logv('[Copying static libraries]')
-        lib_prefix = mx.add_lib_prefix('')
-        lib_suffix = '.lib' if mx.is_windows() else '.a'
-        lib_directory = join(jdk.home, 'lib')
-        dst_lib_directory = join(dst_jdk_dir, 'lib')
-        for f in os.listdir(lib_directory):
-            if f.startswith(lib_prefix) and f.endswith(lib_suffix):
-                lib_path = join(lib_directory, f)
-                if isfile(lib_path):
-                    shutil.copy2(lib_path, dst_lib_directory)
+        lib_directory = join(jdk.home, 'lib', 'static')
+        dst_lib_directory = join(dst_jdk_dir, 'lib', 'static')
+        mx.copytree(lib_directory, dst_lib_directory)
 
         # Build the list of modules whose classes might have annotations
         # to be processed by native-image (GR-15192).

--- a/sdk/mx.sdk/mx_sdk_vm.py
+++ b/sdk/mx.sdk/mx_sdk_vm.py
@@ -702,8 +702,20 @@ grant codeBase "jrt:/com.oracle.graal.graal_enterprise" {
 
         mx.logv('[Copying static libraries]')
         lib_directory = join(jdk.home, 'lib', 'static')
-        dst_lib_directory = join(dst_jdk_dir, 'lib', 'static')
-        mx.copytree(lib_directory, dst_lib_directory)
+        if exists(lib_directory):
+            dst_lib_directory = join(dst_jdk_dir, 'lib', 'static')
+            mx.copytree(lib_directory, dst_lib_directory)
+        # Allow older JDK versions to work
+        else:
+            lib_prefix = mx.add_lib_prefix('')
+            lib_suffix = '.lib' if mx.is_windows() else '.a'
+            lib_directory = join(jdk.home, 'lib')
+            dst_lib_directory = join(dst_jdk_dir, 'lib')
+            for f in os.listdir(lib_directory):
+                if f.startswith(lib_prefix) and f.endswith(lib_suffix):
+                    lib_path = join(lib_directory, f)
+                    if isfile(lib_path):
+                        shutil.copy2(lib_path, dst_lib_directory)
 
         # Build the list of modules whose classes might have annotations
         # to be processed by native-image (GR-15192).

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -808,6 +808,9 @@ def gen_fallbacks():
             if mx.is_linux():
                 # Assume we are running under glibc by default for now.
                 staticlib_path = staticlib_path + ['glibc']
+            # Allow older labsjdk versions to work
+            if not exists(join(mx_compiler.jdk.home, *staticlib_path)):
+                staticlib_path = ['lib']
         staticlib_wildcard = staticlib_path + [mx_subst.path_substitutions.substitute('<staticlib:*>')]
         staticlib_wildcard_path = join(mx_compiler.jdk.home, *staticlib_wildcard)
         for staticlib_path in glob(staticlib_wildcard_path):

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/GLibc.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/GLibc.java
@@ -31,8 +31,8 @@ import java.util.List;
 public class GLibc implements LibCBase {
 
     @Override
-    public String getJDKStaticLibsPath() {
-        return LibCBase.PATH_DEFAULT;
+    public String getName() {
+        return "glibc";
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/LibCBase.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/LibCBase.java
@@ -33,16 +33,18 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
 import org.graalvm.util.GuardedAnnotationAccess;
 
 public interface LibCBase {
 
-    String PATH_DEFAULT = "<default>";
-
+    @Platforms(Platform.HOSTED_ONLY.class)
     static boolean containsLibCAnnotation(AnnotatedElement element) {
         return GuardedAnnotationAccess.getAnnotation(element, Libc.class) != null;
     }
 
+    @Platforms(Platform.HOSTED_ONLY.class)
     static boolean isProvidedInCurrentLibc(AnnotatedElement element) {
         LibCBase currentLibC = ImageSingletons.lookup(LibCBase.class);
         Libc targetLibC = GuardedAnnotationAccess.getAnnotation(element, Libc.class);
@@ -61,6 +63,7 @@ public interface LibCBase {
      * @param clazz Type to check if contained in the current libc implementation.
      * @return true if contained in the current libc implementation, false otherwise.
      */
+    @Platforms(Platform.HOSTED_ONLY.class)
     static boolean isTypeProvidedInCurrentLibc(Class<?> clazz) {
         Class<?> currentClazz = clazz;
         while (currentClazz != null) {
@@ -76,6 +79,7 @@ public interface LibCBase {
         return true;
     }
 
+    @Platforms(Platform.HOSTED_ONLY.class)
     static boolean isMethodProvidedInCurrentLibc(Method method) {
         if (containsLibCAnnotation(method) && !isProvidedInCurrentLibc(method)) {
             return false;
@@ -84,12 +88,16 @@ public interface LibCBase {
         return isTypeProvidedInCurrentLibc(declaringClass);
     }
 
-    String getJDKStaticLibsPath();
+    @Platforms(Platform.HOSTED_ONLY.class)
+    String getName();
 
+    @Platforms(Platform.HOSTED_ONLY.class)
     void prepare(Path directory);
 
+    @Platforms(Platform.HOSTED_ONLY.class)
     List<String> getAdditionalQueryCodeCompilerOptions();
 
+    @Platforms(Platform.HOSTED_ONLY.class)
     List<String> getCCompilerOptions();
 
     static LibCBase singleton() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/MuslLibc.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/MuslLibc.java
@@ -50,7 +50,7 @@ public class MuslLibc implements LibCBase {
     private static final String PATH_PLACEHOLDER = "__BASE_PATH__";
 
     @Override
-    public String getJDKStaticLibsPath() {
+    public String getName() {
         return "musl";
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
@@ -282,13 +282,16 @@ public final class NativeLibraries {
     private static Path getPlatformDependentJDKStaticLibraryPath() throws IOException {
         Path baseSearchPath = Paths.get(System.getProperty("java.home")).resolve("lib").toRealPath();
         if (JavaVersionUtil.JAVA_SPEC > 8) {
-            baseSearchPath = baseSearchPath.resolve("static");
+            Path staticLibPath = baseSearchPath.resolve("static");
             SubstrateTargetDescription target = ConfigurationValues.getTarget();
-            Path platformDependentPath = baseSearchPath.resolve((OS.getCurrent().className + "-" + target.arch.getName()).toLowerCase());
+            Path platformDependentPath = staticLibPath.resolve((OS.getCurrent().className + "-" + target.arch.getName()).toLowerCase());
             if (OS.getCurrent() == OS.LINUX) {
                 platformDependentPath = platformDependentPath.resolve(LibCBase.singleton().getName());
             }
-            return platformDependentPath;
+            // Fallback for older JDK versions
+            if (Files.exists(platformDependentPath)) {
+                return platformDependentPath;
+            }
         }
         return baseSearchPath;
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
@@ -48,6 +48,7 @@ import java.util.stream.Stream;
 
 import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
 import org.graalvm.compiler.debug.DebugContext;
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.c.CContext;
@@ -68,7 +69,9 @@ import org.graalvm.word.WordBase;
 import com.oracle.graal.pointsto.infrastructure.WrappedElement;
 import com.oracle.svm.core.OS;
 import com.oracle.svm.core.SubstrateOptions;
+import com.oracle.svm.core.SubstrateTargetDescription;
 import com.oracle.svm.core.c.libc.LibCBase;
+import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.jdk.PlatformNativeLibrarySupport;
 import com.oracle.svm.core.option.OptionUtils;
 import com.oracle.svm.core.util.UserError;
@@ -276,6 +279,20 @@ public final class NativeLibraries {
     private static final String libPrefix = OS.getCurrent() == OS.WINDOWS ? "" : "lib";
     private static final String libSuffix = OS.getCurrent() == OS.WINDOWS ? ".lib" : ".a";
 
+    private static Path getPlatformDependentJDKStaticLibraryPath() throws IOException {
+        Path baseSearchPath = Paths.get(System.getProperty("java.home")).resolve("lib").toRealPath();
+        if (JavaVersionUtil.JAVA_SPEC > 8) {
+            baseSearchPath = baseSearchPath.resolve("static");
+            SubstrateTargetDescription target = ConfigurationValues.getTarget();
+            Path platformDependentPath = baseSearchPath.resolve((OS.getCurrent().className + "-" + target.arch.getName()).toLowerCase());
+            if (OS.getCurrent() == OS.LINUX) {
+                platformDependentPath = platformDependentPath.resolve(LibCBase.singleton().getName());
+            }
+            return platformDependentPath;
+        }
+        return baseSearchPath;
+    }
+
     private static LinkedHashSet<String> initCLibraryPath() {
         LinkedHashSet<String> libraryPaths = new LinkedHashSet<>();
 
@@ -284,9 +301,7 @@ public final class NativeLibraries {
 
         /* Probe for static JDK libraries in JDK lib directory */
         try {
-            Path baseSearchPath = Paths.get(System.getProperty("java.home")).resolve("lib").toRealPath();
-            String currentLibcDir = ImageSingletons.lookup(LibCBase.class).getJDKStaticLibsPath();
-            Path jdkLibDir = currentLibcDir.equals(LibCBase.PATH_DEFAULT) ? baseSearchPath : baseSearchPath.resolve(CUSTOM_LIBC_STATIC_DIST_PATH).resolve(currentLibcDir);
+            Path jdkLibDir = getPlatformDependentJDKStaticLibraryPath();
 
             List<String> defaultBuiltInLibraries = Arrays.asList(PlatformNativeLibrarySupport.defaultBuiltInLibraries);
             Predicate<String> hasStaticLibrary = s -> Files.isRegularFile(jdkLibDir.resolve(libPrefix + s + libSuffix));


### PR DESCRIPTION
20.1 backport of https://github.com/oracle/graal/commit/d7b5904db656d1313d6462a0034818dfccbbb69b

This is in preparation for #125 and corresponding fix in upstream OpenJDK packaging in https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/pull/10

We should only merge close to the OpenJDK 11.0.9 release. The main difference to https://github.com/oracle/graal/commit/d7b5904db656d1313d6462a0034818dfccbbb69b are in `substratevm/mx.substratevm/mx_substratevm.py`