### PR TITLE
[20.1] Remove cancel-previous-runs to conform to new rules and skipDocs

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -123,7 +123,7 @@ jobs:
       run: |
         export JAVA_HOME="${HOME}/mandrelvm"
         cd ${GITHUB_WORKSPACE}/quarkus
-        mvn -e -B --settings .github/mvn-settings.xml -DskipTests -DskipITs -Dno-format -Ddocumentation-pdf clean install
+        mvn -e -B --settings .github/mvn-settings.xml -DskipTests -DskipITs -Dno-format -DskipDocs clean install
     - name: Tar Maven Repo
       shell: bash
       run: tar -czvf maven-repo-${{ matrix.quarkus }}-${{ matrix.jdk }}.tgz -C ~ .m2/repository

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -63,9 +63,6 @@ jobs:
         repository: graalvm/mandrel-packaging.git
         ref: master
         path: mandrel-packaging
-    - uses: n1hility/cancel-previous-runs@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/cache@v1
       with:
         path: ~/.mx


### PR DESCRIPTION
GraalVM organization no longer allows running third party actions other than those under:
```
docker/*,
graalvm/*,
oracle/*,
```
and actions created by GitHub.

Thus this PR removes the cancel-previous-runs action from our workflow and also adds skipDocs since it appears to be causing issues without testing any part of native-image.