### PR TITLE
[20.2] Remove cancel-previous-runs ro conform to new rules + backport of #140

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -28,7 +28,7 @@ env:
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test
-  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.additional-build-args=-J-ea -Dtest-postgresql -Dtest-elasticsearch -Dtest-keycloak -Dtest-amazon-services -Dtest-db2 -Dtest-mysql -Dtest-mariadb -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dtest-redis -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install"
+  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.additional-build-args=-J-ea -Dtest-postgresql -Dtest-elasticsearch -Delasticsearch.hosts='localhost:9200' -Dtest-keycloak -Dtest-amazon-services -Dtest-db2 -Dtest-mysql -Dtest-mariadb -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dtest-redis -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
   MX_GIT_CACHE: refcache
   JAVA_HOME: ${{ github.workspace }}/openjdk
   MANDREL_REPO: ${{ github.workspace }}
@@ -119,7 +119,7 @@ jobs:
       run: |
         export JAVA_HOME="${HOME}/mandrelvm"
         cd ${GITHUB_WORKSPACE}/quarkus
-        mvn -e -B --settings .github/mvn-settings.xml -DskipTests -DskipITs -Dno-format -Ddocumentation-pdf clean install
+        mvn -e -B --settings .github/mvn-settings.xml -DskipTests -DskipITs -Dno-format -DskipDocs clean install
     - name: Tar Maven Repo
       shell: bash
       run: tar -czvf maven-repo-${{ matrix.quarkus-name }}.tgz -C ~ .m2/repository
@@ -128,6 +128,9 @@ jobs:
       with:
         name: maven-repo-${{ matrix.quarkus-name }}
         path: maven-repo-${{ matrix.quarkus-name }}.tgz
+    - name: Delete Local Artifacts From Cache
+      shell: bash
+      run: rm -r ~/.m2/repository/io/quarkus
 
   native-tests:
     name: ${{matrix.quarkus-name}} - ${{matrix.category}}
@@ -187,7 +190,7 @@ jobs:
           - category: Data4
             neo4j: "true"
             redis: "true"
-            timeout: 60
+            timeout: 70
             test-modules: >
               mongodb-client
               mongodb-panache
@@ -196,7 +199,7 @@ jobs:
               hibernate-orm-rest-data-panache
           - category: Data5
             postgres: "true"
-            timeout: 55
+            timeout: 75
             test-modules: >
               jpa-postgresql
               narayana-stm
@@ -205,6 +208,7 @@ jobs:
               hibernate-reactive-postgresql
           - category: Data6
             postgres: "true"
+            elasticsearch: "true"
             timeout: 40
             test-modules: >
               elasticsearch-rest-client
@@ -256,7 +260,7 @@ jobs:
               infinispan-client
               cache
           - category: HTTP
-            timeout: 55
+            timeout: 75
             test-modules: >
               resteasy-jackson
               resteasy-mutiny
@@ -291,11 +295,16 @@ jobs:
             test-modules: >
               kubernetes-client
           - category: Misc4
-            timeout: 30
+            timeout: 95
             test-modules: >
               smallrye-graphql
               picocli-native
               gradle
+              micrometer-mp-metrics
+              micrometer-prometheus
+              smallrye-metrics
+              logging-json
+              jaxp
           - category: Spring
             timeout: 75
             test-modules: >
@@ -318,9 +327,9 @@ jobs:
       # These should be services, but services do not (yet) allow conditional execution
       - name: Postgres Service
         run: |
-              docker run --rm --publish 5432:5432 --name build-postgres \
-              -e POSTGRES_USER=$DB_USER -e POSTGRES_PASSWORD=$DB_PASSWORD -e POSTGRES_DB=$DB_NAME \
-              -d postgres:10.5
+          docker run --rm --publish 5432:5432 --name build-postgres \
+          -e POSTGRES_USER=$DB_USER -e POSTGRES_PASSWORD=$DB_PASSWORD -e POSTGRES_DB=$DB_NAME \
+          -d postgres:10.5
         if: matrix.postgres
       - name: MySQL Service
         run: |
@@ -368,8 +377,14 @@ jobs:
               -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M \
               -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true \
               -Dkeycloak.profile.feature.upload_scripts=enabled" \
-            -d quay.io/keycloak/keycloak:11.0.0
+            -d quay.io/keycloak/keycloak:11.0.1
         if: matrix.keycloak
+      - name: Elasticsearch Service
+        run: |
+          docker run --rm --publish 9200:9200 --name build-elasticsearch \
+          -e discovery.type=single-node \
+          -d docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.0
+        if: matrix.elasticsearch
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -82,31 +82,29 @@ jobs:
         path: mandreljdk.tgz
 
   build-quarkus:
-    name: ${{ matrix.category }} build
+    name: ${{ matrix.quarkus-name }} build
     runs-on: ubuntu-18.04
     needs: build-mandrel
     strategy:
       matrix:
-        category: [quarkus-release, quarkus-master]
+        quarkus-name: [release, master]
         include:
-          - category: quarkus-release
-            quarkus-url: $(curl -sL https://api.github.com/repos/quarkusio/quarkus/releases/latest | jq -r .tarball_url)
-            quarkus-name: release
-          - category: quarkus-master
-            quarkus-url: https://api.github.com/repos/quarkusio/quarkus/tarball/master
-            quarkus-name: master
+          - quarkus-name: release
+            quarkus-version: $(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
+          - quarkus-name: master
+            quarkus-version: master
     steps:
     - name: Get quarkus
       run: |
-        curl --output quarkus.tgz -sL ${{ matrix.quarkus-url }}
+        curl --output quarkus.tgz -sL https://api.github.com/repos/quarkusio/quarkus/tarball/${{ matrix.quarkus-version }}
         mkdir ${GITHUB_WORKSPACE}/quarkus
         tar xf quarkus.tgz -C ${GITHUB_WORKSPACE}/quarkus --strip-components=1
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-${{ matrix.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.quarkus-name }}-maven-
+          ${{ runner.s }}-${{ matrix.quarkus-version }}-maven-
     - name: Download Mandrel build
       uses: actions/download-artifact@v1
       with:
@@ -147,9 +145,9 @@ jobs:
         category: [Main, Data1, Data2, Data3, Data4, Data5, Data6, Security1, Security2, Security3, Amazon, Messaging, Cache, HTTP, Misc1, Misc2, Misc3, Misc4, Spring, gRPC]
         include:
           - quarkus-name: release
-            quarkus-url: $(curl -sL https://api.github.com/repos/quarkusio/quarkus/releases/latest | jq -r .tarball_url)
+            quarkus-version: $(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
           - quarkus-name: master
-            quarkus-url: https://api.github.com/repos/quarkusio/quarkus/tarball/master
+            quarkus-version: master
           - category: Main
             postgres: "true"
             timeout: 40
@@ -403,7 +401,7 @@ jobs:
         run: tar -xzvf mandreljdk.tgz -C ~
       - name: Get quarkus
         run: |
-          curl --output quarkus.tgz -sL ${{ matrix.quarkus-url }}
+          curl --output quarkus.tgz -sL https://api.github.com/repos/quarkusio/quarkus/tarball/${{ matrix.quarkus-version }}
           mkdir ${GITHUB_WORKSPACE}/quarkus
           tar xf quarkus.tgz -C ${GITHUB_WORKSPACE}/quarkus --strip-components=1
       - name: Reclaim disk space

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -54,9 +54,6 @@ jobs:
         repository: graalvm/mandrel-packaging.git
         ref: master
         path: mandrel-packaging
-    - uses: n1hility/cancel-previous-runs@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/cache@v1
       with:
         path: ~/.mx


### PR DESCRIPTION
GraalVM organization no longer allows running third party actions other than those under:
```
docker/*,
graalvm/*,
oracle/*,
```
and actions created by GitHub.

Thus this PR removes cancel-previous-runs action from the workflow.

It also backports #140 on 20.2