### PR TITLE
Do not raise an error if incomplete classpath is allowed #2556

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
@@ -394,7 +394,7 @@ public class ClassInitializationFeature implements Feature {
             }
             return false;
         } catch (NoClassDefFoundError e) {
-            if (!NativeImageOptions.AllowIncompleteClasspath.getValue()) {
+            if (NativeImageOptions.AllowIncompleteClasspath.getValue()) {
                 return false;
             }
 


### PR DESCRIPTION
Original fix brings in more than what's needed for 20.1 branch, so fixing if condition check individually.