### PR TITLE
Clear lower half of two-slot value when upper half is not live

### DIFF
--- a/compiler/src/org.graalvm.compiler.java/src/org/graalvm/compiler/java/FrameStateBuilder.java
+++ b/compiler/src/org.graalvm.compiler.java/src/org/graalvm/compiler/java/FrameStateBuilder.java
@@ -659,14 +659,25 @@ public final class FrameStateBuilder implements SideEffectsState {
         if (liveIn) {
             for (int i = 0; i < locals.length; i++) {
                 if (!liveness.localIsLiveIn(block, i)) {
-                    assert locals[i] != TWO_SLOT_MARKER || locals[i - 1] == null : "Clearing of second slot must have cleared the first slot too";
+                    if (locals[i] == TWO_SLOT_MARKER) {
+                        /*
+                         * Clearing a slot is equivalent to a storeLocal() of that slot: if the old
+                         * value is the upper half of a two-slot value, both slots need to be
+                         * cleared. The liveness analysis cannot detect these cases and also mark
+                         * the previous slot as non-live because at the beginning / end of the block
+                         * the slot at index i - 1 can be occupied by a live single-slot value.
+                         */
+                        locals[i - 1] = null;
+                    }
                     locals[i] = null;
                 }
             }
         } else {
             for (int i = 0; i < locals.length; i++) {
                 if (!liveness.localIsLiveOut(block, i)) {
-                    assert locals[i] != TWO_SLOT_MARKER || locals[i - 1] == null : "Clearing of second slot must have cleared the first slot too";
+                    if (locals[i] == TWO_SLOT_MARKER) {
+                        locals[i - 1] = null;
+                    }
                     locals[i] = null;
                 }
             }


### PR DESCRIPTION
Backport of: https://github.com/oracle/graal/commit/929dde28d8ba99b3d044be2b6fb86ce1625a2286
Fixes: #111 