### PR TITLE
Rework passing of arguments between the driver and the native-image generator runner

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1251,7 +1251,8 @@ public class NativeImage {
     protected static String createImageBuilderArgumentFile(List<String> imageBuilderArguments) {
         try {
             Path argsFile = Files.createTempFile("native-image", "args");
-            Files.write(argsFile, imageBuilderArguments);
+            String joinedOptions = String.join("\0", imageBuilderArguments);
+            Files.write(argsFile, joinedOptions.getBytes());
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 @Override
                 public void run() {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -67,9 +67,8 @@ import java.util.function.Supplier;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.graalvm.compiler.options.OptionKey;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
@@ -89,6 +88,7 @@ import com.oracle.svm.driver.MacroOption.EnabledOption;
 import com.oracle.svm.driver.MacroOption.MacroOptionKind;
 import com.oracle.svm.driver.MacroOption.Registry;
 import com.oracle.svm.hosted.AbstractNativeImageClassLoaderSupport;
+import com.oracle.svm.hosted.NativeImageGeneratorRunner;
 import com.oracle.svm.hosted.NativeImageSystemClassLoader;
 import com.oracle.svm.util.ModuleSupport;
 
@@ -1248,6 +1248,26 @@ public class NativeImage {
         return result;
     }
 
+    protected static String createImageBuilderArgumentFile(List<String> imageBuilderArguments) {
+        try {
+            Path argsFile = Files.createTempFile("native-image", "args");
+            Files.write(argsFile, imageBuilderArguments);
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        Files.delete(argsFile);
+                    } catch (IOException e) {
+                        System.err.println("Failed to delete temporary image builder arguments file: " + argsFile.toString());
+                    }
+                }
+            });
+            return NativeImageGeneratorRunner.IMAGE_BUILDER_ARG_FILE_OPTION + argsFile.toString();
+        } catch (IOException e) {
+            throw showError(e.getMessage());
+        }
+    }
+
     protected int buildImage(List<String> javaArgs, LinkedHashSet<Path> bcp, LinkedHashSet<Path> cp, LinkedHashSet<String> imageArgs, LinkedHashSet<Path> imagecp) {
         /* Construct ProcessBuilder command from final arguments */
         List<String> command = new ArrayList<>();
@@ -1266,10 +1286,12 @@ public class NativeImage {
              */
             command.addAll(Arrays.asList(SubstrateOptions.WATCHPID_PREFIX, "" + ProcessProperties.getProcessID()));
         }
-        command.addAll(createImageBuilderArgs(imageArgs, imagecp));
+        List<String> finalImageBuilderArgs = createImageBuilderArgs(imageArgs, imagecp);
+        List<String> completeCommandList = Stream.concat(command.stream(), finalImageBuilderArgs.stream()).collect(Collectors.toList());
+        command.add(createImageBuilderArgumentFile(finalImageBuilderArgs));
 
         showVerboseMessage(isVerbose() || dryRun, "Executing [");
-        showVerboseMessage(isVerbose() || dryRun, SubstrateUtil.getShellCommandString(command, true));
+        showVerboseMessage(isVerbose() || dryRun, SubstrateUtil.getShellCommandString(completeCommandList, true));
         showVerboseMessage(isVerbose() || dryRun, "]");
 
         if (dryRun) {
@@ -1278,44 +1300,14 @@ public class NativeImage {
 
         int exitStatus = 1;
         try {
-            Path[] argsFileBox = new Path[1];
-            if (config.useJavaModules()) {
-                /* For Java > 8 we use an argument file to pass the options to the builder */
-                Path argsFile = Files.createTempFile("native-image", "args");
-                argsFileBox[0] = argsFile;
-                Runtime.getRuntime().addShutdownHook(new Thread() {
-                    @Override
-                    public void run() {
-                        if (argsFileBox[0] != null) {
-                            argsFileBox[0].toFile().delete();
-                        }
-                    }
-                });
-                Files.write(argsFile, (Iterable<String>) command.stream().skip(1).map(NativeImage::quoteFileArg)::iterator);
-                List<String> atCommand = new ArrayList<>();
-                atCommand.add(command.get(0));
-                atCommand.add("@" + argsFile);
-                command = atCommand;
-            }
             ProcessBuilder pb = new ProcessBuilder();
             pb.command(command);
             Process p = pb.inheritIO().start();
             exitStatus = p.waitFor();
-            if (exitStatus != 0 && isVerbose()) {
-                argsFileBox[0] = null;
-            }
         } catch (IOException | InterruptedException e) {
             throw showError(e.getMessage());
         }
         return exitStatus;
-    }
-
-    private static String quoteFileArg(String arg) {
-        String resultArg = arg.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("\\\\"));
-        if (resultArg.contains(" ")) {
-            resultArg = "\"" + resultArg + "\"";
-        }
-        return resultArg;
     }
 
     private static final Function<BuildConfiguration, NativeImage> defaultNativeImageProvider = config -> IS_AOT ? NativeImageServer.create(config) : new NativeImage(config);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
@@ -35,9 +35,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TimerTask;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.graalvm.collections.Pair;
 import org.graalvm.compiler.debug.DebugContext;
@@ -80,9 +82,11 @@ import jdk.vm.ci.code.Architecture;
 public class NativeImageGeneratorRunner implements ImageBuildTask {
 
     private volatile NativeImageGenerator generator;
+    public static final String IMAGE_BUILDER_ARG_FILE_OPTION = "--image-args-file=";
 
     public static void main(String[] args) {
-        ArrayList<String> arguments = new ArrayList<>(Arrays.asList(args));
+        List<String> arguments = new ArrayList<>(Arrays.asList(args));
+        arguments = extractDriverArguments(arguments);
         final String[] classPath = extractImagePathEntries(arguments, SubstrateOptions.IMAGE_CLASSPATH_PREFIX);
         int watchPID = extractWatchPID(arguments);
         TimerTask timerTask = null;
@@ -170,6 +174,21 @@ public class NativeImageGeneratorRunner implements ImageBuildTask {
         NativeImageGenerator.setSystemPropertiesForImageEarly();
 
         return new ImageClassLoader(NativeImageGenerator.defaultPlatform(nativeImageClassLoader), nativeImageClassLoaderSupport);
+    }
+
+    public static List<String> extractDriverArguments(List<String> args) {
+        ArrayList<String> result = args.stream().filter(arg -> !arg.startsWith(IMAGE_BUILDER_ARG_FILE_OPTION)).collect(Collectors.toCollection(ArrayList::new));
+        Optional<String> argsFile = args.stream().filter(arg -> arg.startsWith(IMAGE_BUILDER_ARG_FILE_OPTION)).findFirst();
+
+        if (argsFile.isPresent()) {
+            String argFilePath = argsFile.get().substring(IMAGE_BUILDER_ARG_FILE_OPTION.length());
+            try {
+                result.addAll(Files.readAllLines(Paths.get(argFilePath)));
+            } catch (IOException e) {
+                throw VMError.shouldNotReachHere("Exception occurred during image builder argument file processing.", e);
+            }
+        }
+        return result;
     }
 
     public static String[] extractImagePathEntries(List<String> arguments, String pathPrefix) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
@@ -183,7 +183,8 @@ public class NativeImageGeneratorRunner implements ImageBuildTask {
         if (argsFile.isPresent()) {
             String argFilePath = argsFile.get().substring(IMAGE_BUILDER_ARG_FILE_OPTION.length());
             try {
-                result.addAll(Files.readAllLines(Paths.get(argFilePath)));
+                String options = new String(Files.readAllBytes(Paths.get(argFilePath)));
+                result.addAll(Arrays.asList(options.split("\0")));
             } catch (IOException e) {
                 throw VMError.shouldNotReachHere("Exception occurred during image builder argument file processing.", e);
             }


### PR DESCRIPTION
Backports:
* https://github.com/oracle/graal/commit/7f4e2f1b8013e1f697352de301add9fd2f9fb175
* https://github.com/oracle/graal/commit/6afdd1bed96bae714f136e3deee0278a0d216335

Fixes `ResourcesITCase` from Quarkus `Main` test suite.

Relates to: #169 and https://github.com/quarkusio/quarkus/issues/13472 