### PR TITLE
Work around the absence of SpeculationReasonEncoding in OpenJDK11

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -686,7 +686,7 @@ suite = {
             ],
         },
 
-        "com.oracle.svm.graal.test.jdk11": {
+        "com.oracle.svm.graal.test": {
             "subDir": "src",
             "sourceDirs": ["src"],
             "dependencies": [
@@ -702,7 +702,7 @@ suite = {
             "annotationProcessors": [
                 "compiler:GRAAL_PROCESSOR",
             ],
-            "javaCompliance": "11+",
+            "javaCompliance": "8+",
             "spotbugs": "false",
             "testProject": True,
         },
@@ -1192,7 +1192,7 @@ suite = {
             "com.oracle.svm.test",
             "com.oracle.svm.test.jdk11",
             "com.oracle.svm.configure.test",
-            "com.oracle.svm.graal.test.jdk11",
+            "com.oracle.svm.graal.test",
           ],
           "distDependencies": [
             "mx:JUNIT_TOOL",

--- a/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingNativeTest.java
+++ b/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingNativeTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.graalvm.compiler.serviceprovider.GraalServices;
 import org.graalvm.compiler.serviceprovider.UnencodedSpeculationReason;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,6 +49,10 @@ public class IsolatedSpeculationLogEncodingNativeTest {
         Constructor<?> encodedSpeculationReasonConstructor = encodedSpeculationReasonClass.getDeclaredConstructor(Integer.TYPE, String.class, Object[].class);
         SpeculationLog.SpeculationReason encodedReason = (SpeculationLog.SpeculationReason) encodedSpeculationReasonConstructor.newInstance(groupId, "testGroup", context);
 
+        final Method createSpeculationReason = GraalServices.class.getDeclaredMethod("createSpeculationReason", Integer.TYPE, String.class, Object[].class);
+        createSpeculationReason.setAccessible(true);
+        SpeculationLog.SpeculationReason encodedReason2 = (SpeculationLog.SpeculationReason) createSpeculationReason.invoke(null, groupId, "testGroup", context);
+
         Constructor<?> unencodedSpeculationReasonConstructor = UnencodedSpeculationReason.class.getDeclaredConstructor(Integer.TYPE, String.class, Object[].class);
         unencodedSpeculationReasonConstructor.setAccessible(true);
         SpeculationLog.SpeculationReason unencodedReason = (SpeculationLog.SpeculationReason) unencodedSpeculationReasonConstructor.newInstance(groupId, "testGroup", context);
@@ -56,7 +61,9 @@ public class IsolatedSpeculationLogEncodingNativeTest {
         encodeAsByteArray.setAccessible(true);
 
         byte[] encodedResult = (byte[]) encodeAsByteArray.invoke(null, encodedReason);
+        byte[] encodedResult2 = (byte[]) encodeAsByteArray.invoke(null, encodedReason2);
         byte[] unencodedResult = (byte[]) encodeAsByteArray.invoke(null, unencodedReason);
+        Assert.assertArrayEquals(encodedResult, encodedResult2);
         Assert.assertArrayEquals(encodedResult, unencodedResult);
     }
 }

--- a/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingNativeTest.java
+++ b/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingNativeTest.java
@@ -25,6 +25,8 @@
  */
 package com.oracle.svm.graal.test;
 
+// Checkstyle: allow reflection
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -45,7 +47,10 @@ public class IsolatedSpeculationLogEncodingNativeTest {
         final int groupId = 1234;
         final Object[] context = {'a', null, "Hello World!", Byte.MAX_VALUE, Short.MAX_VALUE, Long.MAX_VALUE, Integer.MAX_VALUE, Double.MAX_VALUE, Float.MAX_VALUE};
 
+        // Checkstyle: stop
         final Class<?> encodedSpeculationReasonClass = Class.forName("jdk.vm.ci.meta.EncodedSpeculationReason");
+        // Checkstyle: resume
+
         Constructor<?> encodedSpeculationReasonConstructor = encodedSpeculationReasonClass.getDeclaredConstructor(Integer.TYPE, String.class, Object[].class);
         SpeculationLog.SpeculationReason encodedReason = (SpeculationLog.SpeculationReason) encodedSpeculationReasonConstructor.newInstance(groupId, "testGroup", context);
 

--- a/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingNativeTest.java
+++ b/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingNativeTest.java
@@ -23,7 +23,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.graal.test.jdk11;
+package com.oracle.svm.graal.test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;

--- a/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingTest.java
+++ b/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingTest.java
@@ -25,6 +25,8 @@
  */
 package com.oracle.svm.graal.test;
 
+// Checkstyle: allow reflection
+
 import com.oracle.svm.graal.isolated.IsolatedSpeculationLog;
 import org.junit.Test;
 import org.junit.Assert;
@@ -49,8 +51,10 @@ public class IsolatedSpeculationLogEncodingTest {
         Class<?> sreClass = null;
         Class<?> isolatedSreClass = null;
         try {
+            // Checkstyle: stop
             sreClass = Class.forName(SRE_CLASS_NAME);
             isolatedSreClass = Class.forName(ISOLATED_SRE_CLASS_NAME);
+            // Checkstyle: resume
         } catch (ClassNotFoundException e) {
             Assert.fail("failed to get classes");
         }
@@ -75,7 +79,9 @@ public class IsolatedSpeculationLogEncodingTest {
     public void testEncodeAsByteArray() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ClassNotFoundException, InstantiationException {
         final int groupId = 1234;
         final Object[] context = {'a', null, "Hello World!", Byte.MAX_VALUE, Short.MAX_VALUE, Long.MAX_VALUE, Integer.MAX_VALUE, Double.MAX_VALUE, Float.MAX_VALUE};
+        // Checkstyle: stop
         final Class<?> encodedSpeculationReasonClass = Class.forName("jdk.vm.ci.meta.EncodedSpeculationReason");
+        // Checkstyle: resume
         Constructor<?> encodedSpeculationReasonConstructor = encodedSpeculationReasonClass.getDeclaredConstructor(Integer.TYPE, String.class, Object[].class);
         SpeculationLog.SpeculationReason reason = (SpeculationLog.SpeculationReason) encodedSpeculationReasonConstructor.newInstance(groupId, "testGroup", context);
 

--- a/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingTest.java
+++ b/substratevm/src/com.oracle.svm.graal.test/src/com/oracle/svm/graal/test/IsolatedSpeculationLogEncodingTest.java
@@ -23,7 +23,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.graal.test.jdk11;
+package com.oracle.svm.graal.test;
 
 import com.oracle.svm.graal.isolated.IsolatedSpeculationLog;
 import org.junit.Test;


### PR DESCRIPTION
Backports https://github.com/oracle/graal/pull/2945:
* https://github.com/oracle/graal/commit/50f65e5e24ca923a340ea6cc04e24a92046abbe6
* https://github.com/oracle/graal/commit/0ed0307b1129dac119f1b60c89260ceff90bd065
* https://github.com/oracle/graal/commit/64fc207db5f5a41f147f16e0c09496981a175a3e

(Replaces https://github.com/graalvm/mandrel/pull/167)