### PR TITLE
Dynamically choose class delimiter for debug entries

### DIFF
--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -42,6 +42,7 @@
 
 import re
 import sys
+import platform
 
 # A helper class which checks that a sequence of lines of output
 # from a gdb command matches a sequence of per-line regular
@@ -121,6 +122,8 @@ execute("set listsize 1")
 
 def test():
 
+    class_delimiter = "." if (platform.system() == "Windows") else "::"
+
     # define some useful patterns
     address_pattern = '0x[0-9a-f]+'
     spaces_pattern = '[ \t]+'
@@ -132,9 +135,9 @@ def test():
     wildcard_pattern = '.*'
     # disable prompting to continue output
     execute("set pagination off")
-    # set a break point at hello.Hello.main
+    # set a break point at hello.Hello::main
     # expect "Breakpoint 1 at 0x[0-9a-f]+: file hello.Hello.java, line 67."
-    exec_string = execute("break hello.Hello.main")
+    exec_string = execute("break hello.Hello%smain"%class_delimiter)
     rexp = r"Breakpoint 1 at %s: file hello/Hello\.java, line 67\."%address_pattern
     checker = Checker('break main', rexp)
     checker.check(exec_string)
@@ -149,36 +152,36 @@ def test():
     checker.check(exec_string, skip_fails=False)
 
     # run a backtrace
-    # expect "#0  hello.Hello.main(java.lang.String[]).* at hello.Hello.java:67"
-    # expect "#1  0x[0-9a-f]+ in com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper.java:[0-9]+"
+    # expect "#0  hello.Hello::main(java.lang.String[]).* at hello.Hello.java:67"
+    # expect "#1  0x[0-9a-f]+ in com.oracle.svm.core.code.IsolateEnterStub::JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper.java:[0-9]+"
     exec_string = execute("backtrace")
-    checker = Checker("backtrace hello.Hello.main",
-                      [r"#0%shello\.Hello\.main\(java\.lang\.String\[\]\)%s at hello/Hello\.java:67"%(spaces_pattern, wildcard_pattern),
-                       r"#1%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub\.JavaMainWrapper_run_%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern)
-                       ])
+    checker = Checker("backtrace hello.Hello%smain"%class_delimiter,
+                      [r"#0%shello\.Hello%smain\(java\.lang\.String\[\]\)%s at hello/Hello\.java:67"%(spaces_pattern, class_delimiter, wildcard_pattern),
+                       r"#1%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub%sJavaMainWrapper_run_%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, class_delimiter, wildcard_pattern, package_pattern)
+                      ])
     checker.check(exec_string, skip_fails=False)
 
-    # look up PrintStream.println methods
-    # expect "All functions matching regular expression "java.io.PrintStream.println":"
+    # look up PrintStream::println methods
+    # expect "All functions matching regular expression "java.io.PrintStream::println":"
     # expect ""
     # expect "File java.base/java/io/PrintStream.java:"
-    # expect "      void java.io.PrintStream.println(java.lang.Object)(void);"
-    # expect "      void java.io.PrintStream.println(java.lang.String)(void);"
-    exec_string = execute("info func java.io.PrintStream.println")
-    #    checker = Checker("info func java.io.PrintStream.println",
-    #                      ["All functions matching regular expression \"java\\.io\\.PrintStream\.println\":",
-    #                       "",
-    #                       "File .*java/io/PrintStream.java:",
-    #                       "[ \t]*void java.io.PrintStream\.println\\(java\\.lang\\.Object\\)\\(void\\);",
-    #                       "[ \t]*void java.io.PrintStream\.println\\(java\\.lang\\.String\\)\\(void\\);",
-    #                      ])
-    checker = Checker("info func java.io.PrintStream.println",
-                      r"%svoid java.io.PrintStream\.println\(java\.lang\.String\)"%maybe_spaces_pattern)
+    # expect "      void java.io.PrintStream::println(java.lang.Object)(void);"
+    # expect "      void java.io.PrintStream::println(java.lang.String)(void);"
+    exec_string = execute("info func java.io.PrintStream%sprintln"%class_delimiter)
+#    checker = Checker("info func java.io.PrintStream::println",
+#                      ["All functions matching regular expression \"java\\.io\\.PrintStream::println\":",
+#                       "",
+#                       "File .*java/io/PrintStream.java:",
+#                       "[ \t]*void java.io.PrintStream::println\\(java\\.lang\\.Object\\)\\(void\\);",
+#                       "[ \t]*void java.io.PrintStream::println\\(java\\.lang\\.String\\)\\(void\\);",
+#                      ])
+    checker = Checker("info func java.io.PrintStream%sprintln"%class_delimiter,
+                      r"%svoid java.io.PrintStream%sprintln\(java\.lang\.String\)"%(maybe_spaces_pattern, class_delimiter))
     checker.check(exec_string)
 
-    # set a break point at PrintStream.println(String)
+    # set a break point at PrintStream::println(String)
     # expect "Breakpoint 2 at 0x[0-9a-f]+: java.base/java/io/PrintStream.java, line [0-9]+."
-    exec_string = execute("break java.io.PrintStream.println(java.lang.String)")
+    exec_string = execute("break java.io.PrintStream%sprintln(java.lang.String)"%class_delimiter)
     rexp = r"Breakpoint 2 at %s: file .*java/io/PrintStream\.java, line %s\."%(address_pattern, digits_pattern)
     checker = Checker('break println', rexp)
     checker.check(exec_string, skip_fails=False)
@@ -190,28 +193,28 @@ def test():
     # expect "34	            if (args.length == 0) {"
     exec_string = execute("list")
     rexp = r"34%sif \(args\.length == 0\) {"%spaces_pattern
-    checker = Checker('list hello.Hello.Greeter.greeter', rexp)
+    checker = Checker("list hello.Hello.Greeter%sgreeter"%class_delimiter, rexp)
     checker.check(exec_string, skip_fails=False)
 
     # run a backtrace
-    # expect "#0  hello.Hello.greeter.greeter(java.lang.String[]).* at hello.Hello.java:34"
-    # expect "#1  0x[0-9a-f]+ in hello.Hello.main(java.lang.String[]).* at hello.Hello.java:67"
-    # expect "#2  0x[0-9a-f]+ in com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper.java:[0-9]+"
+    # expect "#0  hello.Hello.greeter::greeter(java.lang.String[]).* at hello.Hello.java:34"
+    # expect "#1  0x[0-9a-f]+ in hello.Hello::main(java.lang.String[]).* at hello.Hello.java:67"
+    # expect "#2  0x[0-9a-f]+ in com.oracle.svm.core.code.IsolateEnterStub::JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper.java:[0-9]+"
     exec_string = execute("backtrace")
-    checker = Checker("backtrace hello.Hello.Greeter.greeter",
-                      [r"#0%shello\.Hello\.Greeter\.greeter\(java\.lang\.String\[\]\)%s at hello/Hello\.java:34"%(spaces_pattern, wildcard_pattern),
-                       r"#1%s%s in hello\.Hello\.main\(java\.lang\.String\[\]\)%s at hello/Hello\.java:67"%(spaces_pattern, address_pattern, wildcard_pattern),
-                       r"#2%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub\.JavaMainWrapper_run_%s at [a-z/]+/JavaMainWrapper\.java:%s"%(spaces_pattern, address_pattern, wildcard_pattern, digits_pattern)
-                       ])
+    checker = Checker("backtrace hello.Hello.Greeter%sgreeter"%class_delimiter,
+                      [r"#0%shello\.Hello\.Greeter%sgreeter\(java\.lang\.String\[\]\)%s at hello/Hello\.java:34"%(spaces_pattern, class_delimiter, wildcard_pattern),
+                       r"#1%s%s in hello\.Hello%smain\(java\.lang\.String\[\]\)%s at hello/Hello\.java:67"%(spaces_pattern, address_pattern, class_delimiter, wildcard_pattern),
+                       r"#2%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub%sJavaMainWrapper_run_%s at [a-z/]+/JavaMainWrapper\.java:%s"%(spaces_pattern, address_pattern, class_delimiter, wildcard_pattern, digits_pattern)
+                      ])
     checker.check(exec_string, skip_fails=False)
 
     # now step into inlined code
     execute("next")
 
-    # check we are still in hello.Hello.Greeter.greeter but no longer in hello.Hello.java
+    # check we are still in hello.Hello.Greeter::greeter but no longer in hello.Hello.java
     exec_string = execute("backtrace 1")
     checker = Checker("backtrace inline",
-                      [r"#0%shello\.Hello\.Greeter\.greeter\(java\.lang\.String\[\]\)%s at (%s):%s"%(spaces_pattern, wildcard_pattern, package_file_pattern, digits_pattern)])
+                      [r"#0%shello\.Hello\.Greeter%sgreeter\(java\.lang\.String\[\]\)%s at (%s):%s"%(spaces_pattern, class_delimiter, wildcard_pattern, package_file_pattern, digits_pattern)])
     matches = checker.check(exec_string, skip_fails=False)
     # n.b. can only get back here with one match
     match = matches[0]
@@ -224,11 +227,11 @@ def test():
     # continue to next breakpoint
     execute("continue")
 
-    # run backtrace to check we are in java.io.PrintStream.println(java.lang.String)
-    # expect "#0  java.io.PrintStream.println(java.lang.String).* at java.base/java/io/PrintStream.java:[0-9]+"
+    # run backtrace to check we are in java.io.PrintStream::println(java.lang.String)
+    # expect "#0  java.io.PrintStream::println(java.lang.String).* at java.base/java/io/PrintStream.java:[0-9]+"
     exec_string = execute("backtrace 1")
-    checker = Checker("backtrace 1 PrintStream.println",
-                      [r"#0%sjava\.io\.PrintStream\.println\(java\.lang\.String\)%s at %sjava/io/PrintStream.java:%s"%(spaces_pattern, wildcard_pattern, wildcard_pattern, digits_pattern)])
+    checker = Checker("backtrace 1 PrintStream%sprintln"%class_delimiter,
+                      [r"#0%sjava\.io\.PrintStream%sprintln\(java\.lang\.String\)%s at %sjava/io/PrintStream.java:%s"%(spaces_pattern, class_delimiter, wildcard_pattern, wildcard_pattern, digits_pattern)])
     checker.check(exec_string, skip_fails=False)
 
     # list current line

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -37,7 +37,7 @@ import java.nio.file.Paths;
 
 public class Range {
 
-    private static final String CLASS_DELIMITER = ".";
+    private static final String CLASS_DELIMITER = System.getProperty("os.name").contains("Windows") ? "." : "::";
 
     private final String cachePath;
     private String fileName;


### PR DESCRIPTION
Cherry pick of https://github.com/graalvm/mandrel/pull/178

Fixes failure of debugSymbolsSmokeGDB (see https://ci.modcluster.io/view/Mandrel/job/mandrel-linux-integration-tests/35/LABEL=el8,MANDREL_VERSION=21.0/console)

This is not needed in Mandrel >21.0 due to https://github.com/oracle/graal/pull/3046
(It might be worth pushing upstream for inclusion in GraalVM CE 20.3.x though)