### PR TITLE
CI: use script from quarkus to reclaim space

### DIFF
--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -180,13 +180,7 @@ jobs:
           mkdir -p ${QUARKUS_PATH}
           tar xf quarkus.tgz -C ${QUARKUS_PATH} --strip-components=1
       - name: Reclaim disk space
-        run: |
-          # Reclaim disk space, otherwise we only have 13 GB free at the start of a job
-          docker rmi node:10 node:12 mcr.microsoft.com/azure-pipelines/node8-typescript:latest
-          # That is 18 GB
-          sudo rm -rf /usr/share/dotnet
-          # That is 1.2 GB
-          sudo rm -rf /usr/share/swift
+        run: ${QUARKUS_PATH}/.github/ci-prerequisites.sh
       - name: Build with Maven
         env:
           TEST_MODULES: ${{matrix.test-modules}}


### PR DESCRIPTION
Fixes failures due to not fount docker image (see https://github.com/graalvm/mandrel/runs/2224868590?check_suite_focus=true#step:7:34) 