### PR TITLE
CI: 20.3 updates

### DIFF
--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -191,13 +191,7 @@ jobs:
           mkdir -p ${QUARKUS_PATH}
           tar xf quarkus.tgz -C ${QUARKUS_PATH} --strip-components=1
       - name: Reclaim disk space
-        run: |
-          # Reclaim disk space, otherwise we only have 13 GB free at the start of a job
-          docker rmi node:10 node:12 mcr.microsoft.com/azure-pipelines/node8-typescript:latest
-          # That is 18 GB
-          sudo rm -rf /usr/share/dotnet
-          # That is 1.2 GB
-          sudo rm -rf /usr/share/swift
+        run: ${QUARKUS_PATH}/.github/ci-prerequisites.sh
       - name: Build with Maven
         env:
           TEST_MODULES: ${{matrix.test-modules}}

--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Get Quarkus versions
       id: versions
       run: |
-        quarkus_latest=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
+        quarkus_latest=1.11 #$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
         echo ${quarkus_latest}
         build_json=$(jq -n --arg version ${quarkus_latest} '{"jdk": ["ga", "ea"], "quarkus-version": [$version, "main"]}' | tr -d '\n')
         echo ${build_json}

--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         repository: graalvm/mandrel-packaging.git
-        ref: master
+        ref: 20.3
         path: mandrel-packaging
     - uses: actions/cache@v1
       with:


### PR DESCRIPTION
* Backport of https://github.com/graalvm/mandrel/pull/231
* Use mandrel-packaging 20.3
* Test branch 1.11 (instead of latest release) and main