### PR TITLE
CI: Add job to run mandrel-integration-tests

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -170,8 +170,8 @@ jobs:
         mkdir -p "$Env:temp\jdk-dl"
         & $Env:MX_PATH\mx.cmd --java-home= fetch-jdk --java-distribution labsjdk-ce-11 --to "$Env:temp\jdk-dl" --alias $Env:JAVA_HOME
         & $Env:JAVA_HOME\bin\java --version
-        & $Env:MX_PATH\mx.cmd --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" build
-        ${graalvm-home} = @(& $Env:MX_PATH\mx.cmd --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" graalvm-home)
+        & $Env:MX_PATH\mx.cmd --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" build
+        ${graalvm-home} = @(& $Env:MX_PATH\mx.cmd --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" graalvm-home)
         rm -Recurse -Force $Env:JAVA_HOME
         mv ${graalvm-home} $Env:JAVA_HOME
         & $Env:JAVA_HOME\bin\native-image --version
@@ -291,12 +291,12 @@ jobs:
         ./mvnw ${COMMON_MAVEN_ARGS} -Dquickly
     - name: Tar Maven Repo
       shell: bash
-      run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
+      run: tar -I 'pigz -9' -cf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~ .m2/repository
     - name: Persist Maven Repo
       uses: actions/upload-artifact@v2
       with:
-        name: maven-repo
-        path: maven-repo.tgz
+        name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
+        path: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz
     - name: Delete Local Artifacts From Cache
       shell: bash
       run: rm -r ~/.m2/repository/io/quarkus
@@ -320,12 +320,12 @@ jobs:
         if: startsWith(matrix.os-name, 'windows')
         uses: actions/download-artifact@v1
         with:
-          name: maven-repo
+          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
           path: .
       - name: Extract Maven Repo
         if: startsWith(matrix.os-name, 'windows')
         shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
+        run: tar -xzf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~
       - uses: actions/checkout@v2
         if: startsWith(matrix.os-name, 'windows')
         with:
@@ -374,7 +374,8 @@ jobs:
             }
           }
           cd $Env:QUARKUS_PATH
-          Set-Content "Env:GRAALVM_HOME" "$Env:JAVA_HOME"
+          $Env:GRAALVM_HOME="$Env:JAVA_HOME"
+          Write-Host "$Env:GRAALVM_HOME"
           if (Test-Path "$Env:GRAALVM_HOME/bin/native-image" -PathType leaf) {
             & "$Env:GRAALVM_HOME/bin/native-image" --version
           }
@@ -395,3 +396,78 @@ jobs:
         with:
           name: test-reports-native-${{matrix.category}}
           path: 'test-reports.tgz'
+
+  mandrel-integration-tests:
+    name: Q Mandrel IT
+    needs:
+      - build-quarkus
+      - get-test-matrix
+    runs-on: windows-latest
+    env:
+      # leave more space for the actual native compilation and execution
+      MAVEN_OPTS: -Xmx1g
+      # Don't perform performance checks since GH runners are not that stable
+      FAIL_ON_PERF_REGRESSION: false
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: Karm/mandrel-integration-tests
+          fetch-depth: 1
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~
+      - name: Download Mandrel or OpenJDK11
+        uses: actions/download-artifact@v1
+        with:
+          name: jdk
+          path: .
+      - name: Extract JDK
+        shell: bash
+        run: |
+          mkdir -p "${JAVA_HOME}"
+          tar -xzvf jdk.tgz -C openjdk --strip-components=1
+          ${JAVA_HOME}/bin/java -version
+      - name: Update Docker Client User Agent
+        shell: bash
+        run: |
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+      - name: Build with Maven
+        run: |
+          cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+          Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
+            if ($_ -match "^(.*?)=(.*)$") {
+              Set-Content "Env:\$($matches[1])" $matches[2]
+            }
+          }
+          $Env:GRAALVM_HOME="$Env:JAVA_HOME"
+          $Env:PATH="$Env:JAVA_HOME\bin;$Env:PATH"
+          if (Test-Path "$Env:GRAALVM_HOME\bin\native-image.cmd" -PathType leaf) {
+            & "$Env:GRAALVM_HOME\bin\native-image" --version
+          } else {
+            Write-Host "Cannot find native-image tool. Quitting..."
+            exit 1
+          }
+          $QUARKUS_VERSION=${{ github.event.inputs.quarkus-version }}
+          if (! ($QUARKUS_VERSION -match "^.*\.(Final|CR|Alpha|Beta)[0-9]?$")) {
+            $QUARKUS_VERSION="999-SNAPSHOT"
+          }
+          Write-Host "$QUARKUS_VERSION"
+          mvn clean verify "-Dquarkus.native.native-image-xmx=5g" "-Dquarkus.version=$QUARKUS_VERSION" -Ptestsuite
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: tar czvf test-reports-mandrel-it.tgz ./testsuite/target/archived-logs/
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-reports-mandrel-it-${{ github.event.inputs.distribution }}-${{ github.event.inputs.version }}-Q${{ needs.get-test-matrix.outputs.quarkus-version }}-${{matrix.category}}
+          path: 'test-reports-mandrel-it.tgz'

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -49,6 +49,7 @@ env:
   MX_PATH: ${{ github.workspace }}/mx
   MX_PYTHON_VERSION: 3
   QUARKUS_PATH: ${{ github.workspace }}/quarkus
+  MANDREL_IT_PATH: ${{ github.workspace }}/mandrel-integration-tests
   MANDREL_PACKAGING_REPO: ${{ github.workspace }}/mandrel-packaging
 
 jobs:
@@ -145,8 +146,8 @@ jobs:
       if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
       run: |
         cd graal/substratevm
-        ${MX_PATH}/mx --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" build
-        mv $(${MX_PATH}/mx --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" graalvm-home) ${MANDREL_HOME}
+        ${MX_PATH}/mx --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" build
+        mv $(${MX_PATH}/mx --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" graalvm-home) ${MANDREL_HOME}
         ${MANDREL_HOME}/bin/native-image --version
     - name: Tar GraalVM
       if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
@@ -269,7 +270,7 @@ jobs:
       run: rm -r ~/.m2/repository/io/quarkus
 
   native-tests:
-    name: Q ${{ github.event.inputs.quarkus-version }} - ${{ matrix.category }} - OpenJDK11-${{ github.event.inputs.jdk }}
+    name: Q IT ${{ matrix.category }}
     needs:
       - build-quarkus
       - get-test-matrix
@@ -362,3 +363,77 @@ jobs:
         with:
           name: test-reports-native-${{matrix.category}}
           path: 'test-reports.tgz'
+
+  mandrel-integration-tests:
+    name: Q Mandrel IT
+    needs:
+      - build-quarkus
+      - get-test-matrix
+    runs-on: ubuntu-latest
+    env:
+      # leave more space for the actual native compilation and execution
+      MAVEN_OPTS: -Xmx1g
+      # Don't perform performance checks since GH runners are not that stable
+      FAIL_ON_PERF_REGRESSION: false
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: Karm/mandrel-integration-tests
+          fetch-depth: 1
+          path: ${{ env.MANDREL_IT_PATH }}
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
+          path: .
+      - name: Extract Maven Repo
+        run: tar -xzvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~
+      - name: Download Mandrel or OpenJDK11
+        uses: actions/download-artifact@v1
+        with:
+          name: jdk
+          path: .
+      - name: Extract Mandrel or OpenJDK11
+        run: |
+          mkdir -p ${JAVA_HOME}
+          tar -xzvf jdk.tgz -C ${JAVA_HOME} --strip-components=1
+      - name: Update Docker Client User Agent
+        run: |
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+      - name: Install gdb
+        run: sudo apt install gdb
+      - name: Build with Maven
+        run: |
+          cd ${MANDREL_IT_PATH}
+          export GRAALVM_HOME="${JAVA_HOME}"
+          export PATH="${GRAALVM_HOME}/bin:$PATH"
+          export QUARKUS_VERSION=${{ github.event.inputs.quarkus-version }}
+          if ! $(expr match "$QUARKUS_VERSION" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
+          then
+            export QUARKUS_VERSION="999-SNAPSHOT"
+          fi
+          echo $QUARKUS_VERSION
+          if [[ ${{ github.event.inputs.builder-image }} == "null" ]]
+          then
+            ${GRAALVM_HOME}/bin/native-image --version
+            mvn clean verify -Dquarkus.native.native-image-xmx=5g \
+              -Dquarkus.version=$QUARKUS_VERSION \
+              -Ptestsuite
+          else
+            mvn clean verify -Dquarkus.native.native-image-xmx=5g \
+              -Dquarkus.version=$QUARKUS_VERSION \
+              -Dquarkus.native.builder-image=${{ github.event.inputs.builder-image }} \
+              -Ptestsuite-builder-image
+          fi
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        run: tar czvf test-reports-mandrel-it.tgz ${MANDREL_IT_PATH}/testsuite/target/archived-logs/
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-reports-mandrel-it-${{ github.event.inputs.distribution }}-${{ github.event.inputs.version }}-Q${{ needs.get-test-matrix.outputs.quarkus-version }}-${{matrix.category}}
+          path: 'test-reports-mandrel-it.tgz'


### PR DESCRIPTION
Adds mandrel-integration-tests to the CI matrix.

@Karm please advise which tests we should enable. The current configuration takes 7 minutes for the hosted version, and 4 minutes for the builder-image so there is room to add more tests (ideally I would like all of them to run).