### PR TITLE
CI: Force the use of python3

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -49,6 +49,7 @@ env:
   MANDREL_REPO: ${{ github.workspace }}\mandrel
   MANDREL_HOME: ${{ github.workspace }}\..\mandrelvm
   MX_PATH: ${{ github.workspace }}\mx
+  MX_PYTHON_VERSION: 3
   QUARKUS_PATH: ${{ github.workspace }}\quarkus
   MANDREL_PACKAGING_REPO: ${{ github.workspace }}\mandrel-packaging
   MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -47,6 +47,7 @@ env:
   MANDREL_REPO: ${{ github.workspace }}/mandrel
   MANDREL_HOME: ${{ github.workspace }}/../mandrelvm
   MX_PATH: ${{ github.workspace }}/mx
+  MX_PYTHON_VERSION: 3
   QUARKUS_PATH: ${{ github.workspace }}/quarkus
   MANDREL_PACKAGING_REPO: ${{ github.workspace }}/mandrel-packaging
 


### PR DESCRIPTION
mx is close to removing python2 support and the CI is currently failing
due to https://github.com/graalvm/mx/issues/238