### PR TITLE
CI: Treat quarkus-version as a fixed string

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -245,7 +245,7 @@ jobs:
         then
           export QUARKUS_VERSION=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
         else
-          export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ github.event.inputs.quarkus-repo }} | grep ${{ github.event.inputs.quarkus-version }} | cut -f 1)
+          export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ github.event.inputs.quarkus-repo }} | grep -F ${{ github.event.inputs.quarkus-version }} | cut -f 1)
         fi
         if [ "$QUARKUS_VERSION" == "" ]
         then

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -206,7 +206,7 @@ jobs:
         then
           export QUARKUS_VERSION=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
         else
-          export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ github.event.inputs.quarkus-repo }} | grep ${{ github.event.inputs.quarkus-version }} | cut -f 1)
+          export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ github.event.inputs.quarkus-repo }} | grep -F ${{ github.event.inputs.quarkus-version }} | cut -f 1)
         fi
         if [ "$QUARKUS_VERSION" == "" ]
         then


### PR DESCRIPTION
When grepping the results of ls-remote to get the commit hash
corresponding to the given tag/branch we need to treat quarkus-version
as a fixed string to avoid treating dots as "any char"