### PR TITLE
Fix failures due to missing JDK

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -157,6 +157,8 @@ jobs:
         restore-keys: ${{ runner.os }}-mx-
     - name: Build graalvm native-image
       if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' #&& github.event.inputs.builder-image == 'null'
+      env:
+        MX_OUTPUT_ROOT_INCLUDES_CONFIG: false
       run: |
         cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
         Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -138,6 +138,8 @@ jobs:
         restore-keys: ${{ runner.os }}-mx-
     - name: Get labs OpenJDK 11
       if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
+      env:
+        MX_OUTPUT_ROOT_INCLUDES_CONFIG: false
       run: |
         mkdir jdk-dl
         ${MX_PATH}/mx fetch-jdk --java-distribution labsjdk-ce-11 --to jdk-dl --alias ${JAVA_HOME}


### PR DESCRIPTION
https://github.com/graalvm/mx/commit/de1eba18b1f289ae6545976a88fe9c1ca92ca8f2
changed the default value of MX_OUTPUT_ROOT_INCLUDES_CONFIG to false to
prevent errors like:
```
Path in JAVA_HOME is not pointing to a JDK (Java launcher does not exist: /opt/jvms/openjdk-11.0.10_9/bin/java): /opt/jvms/openjdk-11.0.10_9/
Error while creating project com.oracle.jvmtiasmagent
```
when running mx fetch-jdk
See https://github.com/graalvm/mandrel/runs/3893569688?check_suite_focus=true#step:5:20