### PR TITLE
Backport: [GR-34638] Introduce PrintAnalysisCallTreeType option

### DIFF
--- a/docs/reference-manual/native-image/Reports.md
+++ b/docs/reference-manual/native-image/Reports.md
@@ -17,8 +17,11 @@ the image heap, respectively.
 The call tree is a a breadth-first tree reduction of the call graph as seen by the points-to analysis.
 The points-to analysis eliminates calls to methods that it determines cannot be reachable at runtime, based on the analysed receiver types.
 It also completely eliminates invocations in unreachable code blocks, e.g., blocks guarded by a type check that always fails.
-The call tree report is enabled using the `-H:+PrintAnalysisCallTree` option.
-It produces a file with the structure:
+The call tree report is enabled using the `-H:+PrintAnalysisCallTree` option and can be formatted either as a `TXT` file (default) or as a set of `CSV` files using the `-H:PrintAnalysisCallTreeType=CSV` option.
+
+##### TXT Format
+
+When using the `TXT` format a file with the following structure is generated:
 
 ```
 VM Entry Points
@@ -51,6 +54,18 @@ Each `id=<method-id>` and `id-ref=<method-id>` are followed by a blank space to 
 
 Each invoke is tagged with the invocation bci: `@bci=<invoke-bci>`.
 For invokes of inline methods the `<invoke-bci>` is a list of bci values, separated with `->`, enumerating the inline locations, backwards to the original invocation location.
+
+##### CSV Format
+When using the `CSV` format a set of files containing raw data for methods and their relationships is generated.
+The aim of these files is to enable this raw data to be easily imported into graph databases.
+Graph databases can provide the following functionality:
+
+* Sophisticated graphical visualization of the call tree graph that provide a different perspective compared to text-based formats.
+* Ability to execute complex queries that can for example show a subset of the tree that causes certain code path to be included in the call tree analysis.
+  This querying functionality is crucial in making big analysis call trees manageable.
+
+The process to import the files into graph databases is specific to each database.
+Please follow the instructions provided by the graph database providers to find out how to import them.
 
 #### Image object tree
 The image object tree is an exhaustive expansion of the objects included in the native image heap.
@@ -147,20 +162,8 @@ Roots suppression/expansion:
 The reports are generated in the `reports` subdirectory, relative to the image building directory.
 When executing the `native-image` executable the image build directory defaults to the working directory and can be modified using the `-H:Path=<dir>` option.
 
-The call tree report name has the structure `call_tree_<image_name>_<date_time>.txt`.
+The call tree report name has the structure `call_tree_<image_name>_<date_time>.txt` when using the `TXT` format or, when using the `CSV` format, the call tree reports' names have the structure `call_tree_*_<image_name>_<date_time>.csv`.
+When producing `CSV` formatted call tree reports, symbolic links following the structure `call_tree_*.csv` pointing to the latest call tree CSV reports are also generated.
 The object tree report name has the structure: `object_tree_<image_name>_<date_time>.txt`.
 The image name is the name of the generated image, which can be set with the `-H:Name=<name>` option.
 The `<date_time>` is in the `yyyyMMdd_HHmmss` format.
-
-#### CSV files
-
-The reports include a number of CSV files containing raw data for methods and their relationships.
-The aim of these files is to make it enable this raw data to be easily imported into graph databases.
-Graph databases can provide the following functionality:
-
-* Sophisticated graphical visualization of the call tree graph that provide a different perspective compared to text-based formats.
-* Ability to execute complex queries that can for example show a subset of the tree that causes certain code path to be included in the call tree analysis.
-This querying functionality is crucial in making big analysis call trees manageable.
-
-The process to import the files into graph databases is specific to each database.
-Please follow the instructions provided by the graph database providers to find out how to import them.

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisReportsOptions.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisReportsOptions.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.graal.pointsto.reports;
 
+import org.graalvm.collections.EconomicMap;
+import org.graalvm.compiler.options.EnumOptionKey;
 import org.graalvm.compiler.options.Option;
 import org.graalvm.compiler.options.OptionKey;
 
@@ -37,6 +39,15 @@ public class AnalysisReportsOptions {
 
     @Option(help = "Print analysis call tree, a breadth-first tree reduction of the call graph.")//
     public static final OptionKey<Boolean> PrintAnalysisCallTree = new OptionKey<>(false);
+
+    @Option(help = "Change the output format of the analysis call tree. See: Reports.md.")//
+    public static final EnumOptionKey<CallTreeType> PrintAnalysisCallTreeType = new EnumOptionKey<CallTreeType>(CallTreeType.TXT) {
+        @Override
+        protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, CallTreeType oldValue, CallTreeType newValue) {
+            super.onValueUpdate(values, oldValue, newValue);
+            PrintAnalysisCallTree.update(values, true);
+        }
+    };
 
     @Option(help = "Print image object hierarchy.")//
     public static final OptionKey<Boolean> PrintImageObjectTree = new OptionKey<>(false);
@@ -52,4 +63,9 @@ public class AnalysisReportsOptions {
 
     @Option(help = "Suppress the expansion of specified types. See: Reports.md.")//
     public static final OptionKey<String> ImageObjectTreeSuppressTypes = new OptionKey<>("");
+
+    enum CallTreeType {
+        TXT,
+        CSV;
+    }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisReportsOptions.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisReportsOptions.java
@@ -40,7 +40,7 @@ public class AnalysisReportsOptions {
     @Option(help = "Print analysis call tree, a breadth-first tree reduction of the call graph.")//
     public static final OptionKey<Boolean> PrintAnalysisCallTree = new OptionKey<>(false);
 
-    @Option(help = "Change the output format of the analysis call tree. See: Reports.md.")//
+    @Option(help = "Change the output format of the analysis call tree, available options are TXT and CSV. See: Reports.md.")//
     public static final EnumOptionKey<CallTreeType> PrintAnalysisCallTreeType = new EnumOptionKey<CallTreeType>(CallTreeType.TXT) {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, CallTreeType oldValue, CallTreeType newValue) {

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
@@ -339,13 +339,14 @@ public final class CallTreePrinter {
             walkNodes(node, directEdges, virtualEdges, overridenByEdges, virtualNodes, nonVirtualNodes, virtualNodeId);
         }
 
-        toCsvFile("call tree for vm entry point", reportsPath, "csv_call_tree_vm", reportName, CallTreePrinter::printVMEntryPoint);
-        toCsvFile("call tree for methods", reportsPath, "csv_call_tree_methods", reportName, writer -> printMethodNodes(methodToNode.values(), writer));
-        toCsvFile("call tree for virtual methods", reportsPath, "csv_call_tree_virtual_methods", reportName, writer -> printVirtualNodes(virtualNodes, writer));
-        toCsvFile("call tree for entry points", reportsPath, "csv_call_tree_entry_points", reportName, writer -> printEntryPointIds(entryPointIds, writer));
-        toCsvFile("call tree for direct edges", reportsPath, "csv_call_tree_direct_edges", reportName, writer -> printBciEdges(directEdges, writer));
-        toCsvFile("call tree for overriden by edges", reportsPath, "csv_call_tree_override_by_edges", reportName, writer -> printNonBciEdges(overridenByEdges, writer));
-        toCsvFile("call tree for virtual edges", reportsPath, "csv_call_tree_virtual_edges", reportName, writer -> printBciEdges(virtualEdges, writer));
+        String msgPrefix = "call tree csv file for ";
+        toCsvFile(msgPrefix + "vm entry point", reportsPath, "call_tree_vm", reportName, CallTreePrinter::printVMEntryPoint);
+        toCsvFile(msgPrefix + "methods", reportsPath, "call_tree_methods", reportName, writer -> printMethodNodes(methodToNode.values(), writer));
+        toCsvFile(msgPrefix + "virtual methods", reportsPath, "call_tree_virtual_methods", reportName, writer -> printVirtualNodes(virtualNodes, writer));
+        toCsvFile(msgPrefix + "entry points", reportsPath, "call_tree_entry_points", reportName, writer -> printEntryPointIds(entryPointIds, writer));
+        toCsvFile(msgPrefix + "direct edges", reportsPath, "call_tree_direct_edges", reportName, writer -> printBciEdges(directEdges, writer));
+        toCsvFile(msgPrefix + "overriden by edges", reportsPath, "call_tree_override_by_edges", reportName, writer -> printNonBciEdges(overridenByEdges, writer));
+        toCsvFile(msgPrefix + "virtual edges", reportsPath, "call_tree_virtual_edges", reportName, writer -> printBciEdges(virtualEdges, writer));
     }
 
     private static void toCsvFile(String description, String reportsPath, String prefix, String reportName, Consumer<PrintWriter> reporter) {


### PR DESCRIPTION
Backports: https://github.com/oracle/graal/pull/3861

This option enables users to choose the structure of the call tree
report. Currently supported formats are txt and csv.

The use of this flag implicitly enables PrintAnalysisCallTree option.

Closes: https://github.com/graalvm/mandrel/issues/294