### PR TITLE
CI: Drop 20.3 and 21.3-dev nightly tests, add 21.2 and 21.3 image tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,23 +31,20 @@ jobs:
           - name: "Q main Mandrel build of latest graal on windows"
             inputs: '{"quarkus-version": "main", "version": "graal/master", "jdk": "ea"}'
             workflow: 'base-windows.yml'
-          - name: "Q main Mandrel build of 21.3-dev"
-            inputs: '{"quarkus-version": "main", "version": "mandrel/21.3", "mandrel-packaging-version": "21.3", "jdk": "ea"}'
-            workflow: 'base.yml'
-          - name: "Q main Mandrel build of 21.3-dev on windows"
-            inputs: '{"quarkus-version": "main", "version": "mandrel/21.3", "mandrel-packaging-version": "21.3", "jdk": "ea"}'
-            workflow: 'base-windows.yml'
           - name: "Q main GraalVM CE build of latest graal"
             inputs: '{"quarkus-version": "main", "version": "graal/master", "distribution": "graalvm"}'
             workflow: 'base.yml'
           ####
           # Test Quarkus main with supported Mandrel versions using the Quay.io images
           ####
-          - name: "Q 2.2 Mandrel 20.3 image from quay.io"
-            inputs: '{"quarkus-version": "2.2", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11"}'
+          - name: "Q 2.2 Mandrel 21.2 image from quay.io"
+            inputs: '{"quarkus-version": "2.2", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:21.2-java11"}'
             workflow: 'base.yml'
           - name: "Q main Mandrel 21.2 image from quay.io"
             inputs: '{"quarkus-version": "main", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:21.2-java11"}'
+            workflow: 'base.yml'
+          - name: "Q main Mandrel 21.3 image from quay.io"
+            inputs: '{"quarkus-version": "main", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"}'
             workflow: 'base.yml'
           ####
           # Test Quarkus main with supported Mandrel versions using the release archives


### PR DESCRIPTION
* Mandrel 20.3 has reached EOL.
* 21.3 is now released so instead of building from source we should use the released image for our nightly Quarkus tests 
* Keep testing Quarkus 2.2 with 21.2 till it's confirmed it can move to 21.3