### PR TITLE
CI: Quarkus main is now using GraalVM/Mandrel 21.3

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,9 +43,6 @@ jobs:
           - name: "Q 2.2 Mandrel 21.3 image from quay.io"
             inputs: '{"quarkus-version": "2.2", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"}'
             workflow: 'base.yml'
-          - name: "Q main Mandrel 21.2 image from quay.io"
-            inputs: '{"quarkus-version": "main", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:21.2-java11"}'
-            workflow: 'base.yml'
           - name: "Q main Mandrel 21.3 image from quay.io"
             inputs: '{"quarkus-version": "main", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"}'
             workflow: 'base.yml'


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/pull/20894