### PR TITLE
CI: Disable nightly pipeline on PRs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,9 +4,6 @@ on:
   push:
     paths:
       - '.github/workflows/nightly.yml'
-  pull_request:
-    paths:
-      - '.github/workflows/nightly.yml'
   schedule:
   - cron: '0 2 * * *'
 


### PR DESCRIPTION
nighlty requires an AUTH token to trigger the builds and users openning
PRs normally don't have that token set up, resulting in the pipeline
failing.