### PR TITLE
CI: Add windows and linux workflows for 21.3 branch

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -1,0 +1,344 @@
+name: Windows Mandrel-Quarkus tests
+
+on:
+  push:
+    paths-ignore:
+      - '.github/workflows/main.yml'
+      - '.github/workflows/quarkus.yml'
+      - '.github/workflows/base-windows.yml'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/main.yml'
+      - '.github/workflows/quarkus.yml'
+      - '.github/workflows/base-windows.yml'
+      - '**.md'
+
+# The following aims to reduce CI CPU cycles by:
+# 1. Cancelling any previous builds of this PR when pushing new changes to it
+# 2. Cancelling any previous builds of a branch when pushing new changes to it in a fork
+# 3. Cancelling any pending builds, but not active ones, when pushing to a branch in the main
+#    repository. This prevents us from constantly cancelling CI runs, while being able to skip
+#    intermediate builds. E.g., if we perform two pushes the first one will start a CI job and
+#    the second one will add another one to the queue; if we perform a third push while the
+#    first CI job is still running the previously queued CI job (for the second push) will be
+#    cancelled and a new CI job will be queued for the latest (third) push.
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'graalvm/mandrel' }}
+
+env:
+  # Workaround testsuite locale issue
+  LANG: en_US.UTF-8
+  DB_USER: hibernate_orm_test
+  DB_PASSWORD: hibernate_orm_test
+  DB_NAME: hibernate_orm_test
+  COMMON_MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
+  NATIVE_TEST_MAVEN_OPTS: "-Dtest-containers -Dstart-containers -DfailIfNoTests=false -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests -DskipDocs"
+  MX_GIT_CACHE: refcache
+  JAVA_HOME: ${{ github.workspace }}\openjdk
+  MANDREL_REPO: ${{ github.workspace }}\mandrel
+  MANDREL_HOME: ${{ github.workspace }}\..\mandrelvm
+  MX_PATH: ${{ github.workspace }}\mx
+  MX_PYTHON_VERSION: 3
+  QUARKUS_PATH: ${{ github.workspace }}\quarkus
+  MANDREL_PACKAGING_REPO: ${{ github.workspace }}\mandrel-packaging
+  MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
+
+jobs:
+  build-mandrel:
+    name: Mandrel 21.3 build - OpenJDK11-${{ matrix.jdk }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [ 'ea', 'ga' ]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        path: ${{ env.MANDREL_REPO }}
+    - name: Checkout MX
+      run: |
+        VERSION=$(find ${MANDREL_REPO} -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
+        git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
+        ./mx/mx --version
+      shell: bash
+    - uses: actions/checkout@v2
+      with:
+        repository: graalvm/mandrel-packaging
+        ref: 21.3
+        path: ${{ env.MANDREL_PACKAGING_REPO }}
+    - uses: actions/cache@v2.1.5
+      with:
+        path: ~/.mx
+        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+        restore-keys: ${{ runner.os }}-mx-
+    - name: Get OpenJDK 11 with static libs
+      run: |
+        $files = @{
+            "https://api.adoptopenjdk.net/v3/binary/latest/11/${{ matrix.jdk }}/windows/x64/jdk/hotspot/normal/openjdk" = "jdk.zip"
+            "https://api.adoptopenjdk.net/v3/binary/latest/11/${{ matrix.jdk }}/windows/x64/staticlibs/hotspot/normal/openjdk" = "jdk-static-libs.zip"
+        }
+        $wc = New-Object System.Net.WebClient
+        foreach ($h in $files.GetEnumerator()) {
+            Write-Host "Processing $($h.Name) -> $($h.Value)"
+            $wc.DownloadFile($($h.Name), "$Env:temp\$($h.Value)")
+            Expand-Archive "$Env:temp\$($h.Value)" -DestinationPath "$Env:temp"
+        }
+        Move-Item -Path "$Env:temp\openjdk*" -Destination $Env:JAVA_HOME
+        & $Env:JAVA_HOME\bin\java -version
+    - name: Build Mandrel
+      run: |
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+        Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
+          if ($_ -match "^(.*?)=(.*)$") {
+            Set-Content "Env:\$($matches[1])" $matches[2]
+          }
+        }
+        & $Env:JAVA_HOME\bin\java -ea $Env:MANDREL_PACKAGING_REPO\build.java `
+          --mx-home $Env:MX_PATH `
+          --mandrel-repo $Env:MANDREL_REPO `
+          --mandrel-home $Env:MANDREL_HOME
+        & $Env:MANDREL_HOME\bin\native-image --version
+        Remove-Item -Recurse $Env:JAVA_HOME
+        Move-Item -Path $Env:MANDREL_HOME -Destination $Env:JAVA_HOME
+    - name: Archive JDK
+      shell: bash
+      run: tar czvf jdk-${{ matrix.jdk }}.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
+    - name: Persist Mandrel build
+      uses: actions/upload-artifact@v2
+      with:
+        name: jdk-${{ matrix.jdk }}
+        path: jdk-${{ matrix.jdk }}.tgz
+
+  get-quarkus-versions:
+    name: Get Quarkus versions
+    runs-on: ubuntu-latest
+    outputs:
+      build-matrix: ${{ steps.versions.outputs.build-matrix }}
+      tests-matrix: ${{ steps.versions.outputs.tests-matrix }}
+    steps:
+    - name: Get Quarkus versions
+      id: versions
+      run: |
+        quarkus_latest=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
+        echo ${quarkus_latest}
+        quarkus_main=$(git ls-remote ${GITHUB_SERVER_URL}/quarkusio/quarkus | grep "refs/heads/main$" | cut -f 1)
+        echo ${quarkus_main}
+        build_json=$(jq -n --arg latest ${quarkus_latest} --arg main ${quarkus_main} '{"jdk": ["ga", "ea"], "quarkus-version": ["2.2", $latest, $main]}' | tr -d '\n')
+        echo ${build_json} | jq .
+        echo "::set-output name=build-matrix::${build_json}"
+        for version in $quarkus_latest $quarkus_main 2.2
+        do
+          curl --output native-tests.json https://raw.githubusercontent.com/quarkusio/quarkus/${version}/.github/native-tests.json
+          jq --arg version ${version} '.include[] += {"quarkus-version": $version}' native-tests.json > tests-$version.json
+        done
+        # Merge matrices getting the intersection of their categories to
+        # avoid issues with the GH actions (it a category is only
+        # available on one version it will fail on others).
+        #
+        # WARNING that means that categories not present in all versions
+        # will not be tested...
+        tests_json=$(jq -s --arg latest ${quarkus_latest} --arg main ${quarkus_main} '.[0].include = [.[0].include[] .category as $a | .[1].include[] .category as $b | .[2].include[] .category as $c | .[].include[] | select( .category == $a and .category == $b and .category == $c)] | {"jdk": ["ga", "ea"], "quarkus-version": ["2.2", $latest, $main], "category": [.[0].include[] .category] | unique } + .[0]' tests-$quarkus_latest.json tests-$quarkus_main.json tests-2.2.json | tr -d '\n')
+        echo ${tests_json} | jq .
+        echo "::set-output name=tests-matrix::${tests_json}"
+
+  build-quarkus:
+    name: Quarkus ${{ matrix.quarkus-version }} - OpenJDK11-${{ matrix.jdk }}
+    runs-on: ubuntu-latest
+    needs:
+      - get-quarkus-versions
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-quarkus-versions.outputs.build-matrix) }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: quarkusio/quarkus
+        fetch-depth: 1
+        ref: ${{ matrix.quarkus-version }}
+        path: quarkus
+    - uses: actions/cache@v2.1.5
+      with:
+        path: ~/.m2/repository
+        key: base-windows-${{ matrix.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: base-windows-${{ matrix.quarkus-version }}-maven-
+    - name: Build quarkus
+      run: |
+        curl -L https://api.adoptopenjdk.net/v3/binary/latest/11/${{ matrix.jdk }}/linux/x64/jdk/hotspot/normal/openjdk -o jdk.tar.gz
+        export JAVA_HOME=$(pwd)/openjdk
+        echo ${JAVA_HOME}
+        mkdir -p ${JAVA_HOME}
+        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
+        ${JAVA_HOME}/bin/java -version
+        cd quarkus
+        ./mvnw ${COMMON_MAVEN_ARGS} -Dquickly
+    - name: Tar Maven Repo
+      run: tar -I 'pigz -9' -cf maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}.tgz -C ~ .m2/repository
+    - name: Persist Maven Repo
+      uses: actions/upload-artifact@v2
+      with:
+        name: maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}
+        path: maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}.tgz
+    - name: Delete Local Artifacts From Cache
+      run: rm -r ~/.m2/repository/io/quarkus
+
+  native-tests:
+    name: Q ${{ matrix.quarkus-version }} - ${{ matrix.category }} - OpenJDK11-${{ matrix.jdk }}
+    needs:
+      - build-quarkus
+      - build-mandrel
+      - get-quarkus-versions
+    runs-on: windows-latest
+    # Ignore the following YAML Schema error
+    timeout-minutes: ${{matrix.timeout}}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-quarkus-versions.outputs.tests-matrix) }}
+    steps:
+      - name: Download Maven Repo
+        if: startsWith(matrix.os-name, 'windows')
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}
+          path: .
+      - name: Extract Maven Repo
+        if: startsWith(matrix.os-name, 'windows')
+        shell: bash
+        run: tar -xzf maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}.tgz -C ~
+      - name: Download Mandrel
+        if: startsWith(matrix.os-name, 'windows')
+        uses: actions/download-artifact@v1
+        with:
+          name: jdk-${{ matrix.jdk }}
+          path: .
+      - name: Extract Mandrel
+        if: startsWith(matrix.os-name, 'windows')
+        shell: bash
+        run: |
+          mkdir -p openjdk
+          tar -xzf jdk-${{ matrix.jdk }}.tgz -C openjdk --strip-components=1
+          openjdk/bin/java --version
+      - uses: actions/checkout@v2
+        if: startsWith(matrix.os-name, 'windows')
+        with:
+          repository: quarkusio/quarkus
+          fetch-depth: 1
+          ref: ${{ matrix.quarkus-version }}
+          path: ${{ env.QUARKUS_PATH }}
+      # - name: Reclaim disk space
+      #   shell: bash
+      #   run: ${QUARKUS_PATH}/.github/ci-prerequisites.sh
+      # We do this so we can get better analytics for the downloaded version of the build images
+      - name: Update Docker Client User Agent
+        if: startsWith(matrix.os-name, 'windows')
+        shell: bash
+        run: |
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+      - name: Build with Maven
+        if: startsWith(matrix.os-name, 'windows')
+        env:
+          TEST_MODULES: ${{matrix.test-modules}}
+          CATEGORY: ${{matrix.category}}
+        run: |
+          cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+          Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
+            if ($_ -match "^(.*?)=(.*)$") {
+              Set-Content "Env:\$($matches[1])" $matches[2]
+            }
+          }
+          cd $Env:QUARKUS_PATH
+          Set-Content "Env:GRAALVM_HOME" "$Env:JAVA_HOME"
+          if (Test-Path "$Env:GRAALVM_HOME/bin/native-image" -PathType leaf) {
+            & "$Env:GRAALVM_HOME/bin/native-image" --version
+          }
+          $opts=@()
+          -split $Env:NATIVE_TEST_MAVEN_OPTS | foreach { $opts += "`"$_`"" }
+          mvn -f integration-tests -pl "$Env:TEST_MODULES" $opts install
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar czvf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-reports-native-${{matrix.quarkus-version}}-${{matrix.jdk}}-${{matrix.category}}
+          path: 'test-reports.tgz'
+
+  mandrel-integration-tests:
+    name: Q Mandrel IT - ${{ matrix.quarkus-version}}-${{ matrix.jdk }}
+    needs:
+      - build-quarkus
+      - get-quarkus-versions
+    runs-on: windows-latest
+    env:
+      # leave more space for the actual native compilation and execution
+      MAVEN_OPTS: -Xmx1g
+      # Don't perform performance checks since GH runners are not that stable
+      FAIL_ON_PERF_REGRESSION: false
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-quarkus-versions.outputs.build-matrix) }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: Karm/mandrel-integration-tests
+          fetch-depth: 1
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzvf maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}.tgz -C ~
+      - name: Download Mandrel or OpenJDK11
+        uses: actions/download-artifact@v1
+        with:
+          name: jdk-${{ matrix.jdk }}
+          path: .
+      - name: Extract Mandrel
+        shell: bash
+        run: |
+          mkdir -p openjdk
+          tar -xzf jdk-${{ matrix.jdk }}.tgz -C openjdk --strip-components=1
+          openjdk/bin/java --version
+      - name: Update Docker Client User Agent
+        shell: bash
+        run: |
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+      - name: Build with Maven
+        run: |
+          cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+          Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
+            if ($_ -match "^(.*?)=(.*)$") {
+              Set-Content "Env:\$($matches[1])" $matches[2]
+            }
+          }
+          $Env:GRAALVM_HOME="$Env:JAVA_HOME"
+          $Env:PATH="$Env:JAVA_HOME\bin;$Env:PATH"
+          if (Test-Path "$Env:GRAALVM_HOME\bin\native-image.cmd" -PathType leaf) {
+            & "$Env:GRAALVM_HOME\bin\native-image" --version
+          } else {
+            Write-Host "Cannot find native-image tool. Quitting..."
+            exit 1
+          }
+          $QUARKUS_VERSION="${{ matrix.quarkus-version }}"
+          if (! ($QUARKUS_VERSION -match "^.*\.(Final|CR|Alpha|Beta)[0-9]?$")) {
+            $QUARKUS_VERSION="999-SNAPSHOT"
+          }
+          Write-Host "$QUARKUS_VERSION"
+          mvn clean verify "-Dquarkus.native.native-image-xmx=5g" "-Dquarkus.version=$QUARKUS_VERSION" -Ptestsuite
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: tar czvf test-reports-mandrel-it.tgz ./testsuite/target/archived-logs/
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-reports-mandrel-it-Q${{ matrix.quarkus-version }}-${{ matrix.category }}
+          path: 'test-reports-mandrel-it.tgz'

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,0 +1,316 @@
+name: Mandrel-Quarkus tests
+
+on:
+  push:
+    paths-ignore:
+      - '.github/workflows/main.yml'
+      - '.github/workflows/quarkus.yml'
+      - '.github/workflows/base-windows.yml'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/main.yml'
+      - '.github/workflows/quarkus.yml'
+      - '.github/workflows/base-windows.yml'
+      - '**.md'
+
+# The following aims to reduce CI CPU cycles by:
+# 1. Cancelling any previous builds of this PR when pushing new changes to it
+# 2. Cancelling any previous builds of a branch when pushing new changes to it in a fork
+# 3. Cancelling any pending builds, but not active ones, when pushing to a branch in the main
+#    repository. This prevents us from constantly cancelling CI runs, while being able to skip
+#    intermediate builds. E.g., if we perform two pushes the first one will start a CI job and
+#    the second one will add another one to the queue; if we perform a third push while the
+#    first CI job is still running the previously queued CI job (for the second push) will be
+#    cancelled and a new CI job will be queued for the latest (third) push.
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'graalvm/mandrel' }}
+
+env:
+  # Workaround testsuite locale issue
+  LANG: en_US.UTF-8
+  DB_USER: hibernate_orm_test
+  DB_PASSWORD: hibernate_orm_test
+  DB_NAME: hibernate_orm_test
+  NATIVE_TEST_MAVEN_OPTS: "--fail-at-end -Dtest-containers -Dstart-containers -DfailIfNoTests=false -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
+  MX_GIT_CACHE: refcache
+  JAVA_HOME: ${{ github.workspace }}/openjdk
+  MANDREL_REPO: ${{ github.workspace }}/mandrel
+  MANDREL_HOME: ${{ github.workspace }}/../mandrelvm
+  MX_PATH: ${{ github.workspace }}/mx
+  MX_PYTHON_VERSION: 3
+  QUARKUS_PATH: ${{ github.workspace }}/quarkus
+  MANDREL_PACKAGING_REPO: ${{ github.workspace }}/mandrel-packaging
+  MANDREL_IT_PATH: ${{ github.workspace }}/mandrel-integration-tests
+
+jobs:
+  build-mandrel:
+    name: Mandrel 21.3 build - OpenJDK11-${{ matrix.jdk }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [ 'ea', 'ga' ]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        path: ${{ env.MANDREL_REPO }}
+    - name: Checkout MX
+      run: |
+        VERSION=$(find ${MANDREL_REPO} -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
+        git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_PATH}
+        ./mx/mx --version
+    - uses: actions/checkout@v2
+      with:
+        repository: graalvm/mandrel-packaging
+        ref: 21.3
+        path: ${{ env.MANDREL_PACKAGING_REPO }}
+    - uses: actions/cache@v2.1.5
+      with:
+        path: ~/.mx
+        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+        restore-keys: ${{ runner.os }}-mx-
+    - name: Get OpenJDK 11 with static libs
+      run: |
+        curl -sL https://api.adoptopenjdk.net/v3/binary/latest/11/${{ matrix.jdk }}/linux/x64/jdk/hotspot/normal/openjdk -o jdk.tar.gz
+        curl -sL https://api.adoptopenjdk.net/v3/binary/latest/11/${{ matrix.jdk }}/linux/x64/staticlibs/hotspot/normal/openjdk -o jdk-static-libs.tar.gz
+        mkdir -p ${JAVA_HOME}
+        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
+        tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
+        echo ${JAVA_HOME}
+        ${JAVA_HOME}/bin/java --version
+    - name: Build Mandrel
+      run: |
+        ${JAVA_HOME}/bin/java -ea ${MANDREL_PACKAGING_REPO}/build.java \
+          --mx-home ${MX_PATH} \
+          --mandrel-repo ${MANDREL_REPO} \
+          --mandrel-home ${MANDREL_HOME} \
+          --archive-suffix tar.gz
+        ${MANDREL_HOME}/bin/native-image --version
+        mv mandrel-java11-linux-amd64-*.tar.gz ${{ github.workspace }}/jdk-${{ matrix.jdk }}.tgz
+    - name: Persist Mandrel build
+      uses: actions/upload-artifact@v2
+      with:
+        name: jdk-${{ matrix.jdk }}
+        path: jdk-${{ matrix.jdk }}.tgz
+
+  get-quarkus-versions:
+    name: Get Quarkus versions
+    runs-on: ubuntu-latest
+    outputs:
+      build-matrix: ${{ steps.versions.outputs.build-matrix }}
+      tests-matrix: ${{ steps.versions.outputs.tests-matrix }}
+    steps:
+    - name: Get Quarkus versions
+      id: versions
+      run: |
+        quarkus_latest=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
+        echo ${quarkus_latest}
+        quarkus_main=$(git ls-remote ${GITHUB_SERVER_URL}/quarkusio/quarkus | grep "refs/heads/main$" | cut -f 1)
+        echo ${quarkus_main}
+        build_json=$(jq -n --arg latest ${quarkus_latest} --arg main ${quarkus_main} '{"jdk": ["ga", "ea"], "quarkus-version": ["2.2", $latest, $main]}' | tr -d '\n')
+        echo ${build_json} | jq .
+        echo "::set-output name=build-matrix::${build_json}"
+        for version in $quarkus_latest $quarkus_main 2.2
+        do
+          curl --output native-tests.json https://raw.githubusercontent.com/quarkusio/quarkus/${version}/.github/native-tests.json
+          jq --arg version ${version} '.include[] += {"quarkus-version": $version}' native-tests.json > tests-$version.json
+        done
+        # Merge matrices getting the intersection of their categories to
+        # avoid issues with the GH actions (it a category is only
+        # available on one version it will fail on others).
+        #
+        # WARNING that means that categories not present in all versions
+        # will not be tested...
+        tests_json=$(jq -s --arg latest ${quarkus_latest} --arg main ${quarkus_main} '.[0].include = [.[0].include[] .category as $a | .[1].include[] .category as $b | .[2].include[] .category as $c | .[].include[] | select( .category == $a and .category == $b and .category == $c)] | {"jdk": ["ga", "ea"], "quarkus-version": ["2.2", $latest, $main], "category": [.[0].include[] .category] | unique } + .[0]' tests-$quarkus_latest.json tests-$quarkus_main.json tests-2.2.json | tr -d '\n')
+        echo ${tests_json} | jq .
+        echo "::set-output name=tests-matrix::${tests_json}"
+
+  build-quarkus:
+    name: Quarkus ${{ matrix.quarkus-version }} - OpenJDK11-${{ matrix.jdk }}
+    runs-on: ubuntu-latest
+    needs:
+      - get-quarkus-versions
+      - build-mandrel
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-quarkus-versions.outputs.build-matrix) }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: quarkusio/quarkus
+        fetch-depth: 1
+        ref: ${{ matrix.quarkus-version }}
+        path: ${{ env.QUARKUS_PATH }}
+    - uses: actions/cache@v2.1.5
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-${{ matrix.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.quarkus-version }}-maven-
+    - name: Download Mandrel build
+      uses: actions/download-artifact@v1
+      with:
+        name: jdk-${{ matrix.jdk }}
+        path: .
+    - name: Extract Mandrel build
+      run: |
+        mkdir -p ${JAVA_HOME}
+        tar xzf jdk-${{ matrix.jdk }}.tgz -C ${JAVA_HOME} --strip-components=1
+        ${JAVA_HOME}/bin/java -version
+    - name: Build quarkus
+      run: |
+        cd ${QUARKUS_PATH}
+        mvn -e -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml  -Dquickly
+    - name: Tar Maven Repo
+      run: tar -czf maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}.tgz -C ~ .m2/repository
+    - name: Persist Maven Repo
+      uses: actions/upload-artifact@v2
+      with:
+        name: maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}
+        path: maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}.tgz
+    - name: Delete Local Artifacts From Cache
+      run: rm -r ~/.m2/repository/io/quarkus
+
+  native-tests:
+    name: Q ${{ matrix.quarkus-version }} - ${{ matrix.category }} - OpenJDK11-${{ matrix.jdk }}
+    needs:
+      - build-quarkus
+      - get-quarkus-versions
+    runs-on: ubuntu-latest
+    env:
+      # leave more space for the actual native compilation and execution
+      MAVEN_OPTS: -Xmx1g
+    # Ignore the following YAML Schema error
+    timeout-minutes: ${{matrix.timeout}}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-quarkus-versions.outputs.tests-matrix) }}
+    steps:
+      - name: Download Maven Repo
+        if: "!startsWith(matrix.os-name, 'windows')"
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}
+          path: .
+      - name: Extract Maven Repo
+        if: "!startsWith(matrix.os-name, 'windows')"
+        shell: bash
+        run: tar -xzf maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}.tgz -C ~
+      - name: Download Mandrel
+        if: "!startsWith(matrix.os-name, 'windows')"
+        uses: actions/download-artifact@v1
+        with:
+          name: jdk-${{ matrix.jdk }}
+          path: .
+      - name: Extract Mandrel or OpenJDK11
+        if: "!startsWith(matrix.os-name, 'windows')"
+        shell: bash
+        run: |
+          mkdir -p ${JAVA_HOME}
+          tar -xzf jdk-${{ matrix.jdk }}.tgz -C ${JAVA_HOME} --strip-components=1
+          ${JAVA_HOME}/bin/native-image --version
+      - uses: actions/checkout@v2
+        if: "!startsWith(matrix.os-name, 'windows')"
+        with:
+          repository: quarkusio/quarkus
+          fetch-depth: 1
+          ref: ${{ matrix.quarkus-version }}
+          path: ${{ env.QUARKUS_PATH }}
+      - name: Reclaim disk space
+        if: "!startsWith(matrix.os-name, 'windows')"
+        run: ${QUARKUS_PATH}/.github/ci-prerequisites.sh
+      - name: Update Docker Client User Agent
+        if: "!startsWith(matrix.os-name, 'windows')"
+        shell: bash
+        run: |
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+      - name: Build with Maven
+        if: "!startsWith(matrix.os-name, 'windows')"
+        env:
+          TEST_MODULES: ${{matrix.test-modules}}
+          CATEGORY: ${{matrix.category}}
+        shell: bash
+        run: |
+          cd ${QUARKUS_PATH}
+          export GRAALVM_HOME="${JAVA_HOME}"
+          ${GRAALVM_HOME}/bin/native-image --version
+          ./mvnw -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml -f integration-tests -pl "$TEST_MODULES" $NATIVE_TEST_MAVEN_OPTS
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar czvf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-reports-native-${{matrix.quarkus-version}}-${{matrix.jdk}}-${{matrix.category}}
+          path: 'test-reports.tgz'
+
+  mandrel-integration-tests:
+    name: Q Mandrel IT - ${{ matrix.quarkus-version}}-${{ matrix.jdk }}
+    needs:
+      - build-quarkus
+      - get-quarkus-versions
+    runs-on: ubuntu-latest
+    env:
+      # leave more space for the actual native compilation and execution
+      MAVEN_OPTS: -Xmx1g
+      # Don't perform performance checks since GH runners are not that stable
+      FAIL_ON_PERF_REGRESSION: false
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-quarkus-versions.outputs.build-matrix) }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: Karm/mandrel-integration-tests
+          fetch-depth: 1
+          path: ${{ env.MANDREL_IT_PATH }}
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}
+          path: .
+      - name: Extract Maven Repo
+        run: tar -xzvf maven-repo-${{ matrix.quarkus-version }}-${{ matrix.jdk }}.tgz -C ~
+      - name: Download Mandrel or OpenJDK11
+        uses: actions/download-artifact@v1
+        with:
+          name: jdk-${{ matrix.jdk }}
+          path: .
+      - name: Extract Mandrel or OpenJDK11
+        run: |
+          mkdir -p ${JAVA_HOME}
+          tar -xzvf jdk-${{ matrix.jdk }}.tgz -C ${JAVA_HOME} --strip-components=1
+      - name: Update Docker Client User Agent
+        run: |
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+      - name: Install gdb
+        run: sudo apt install gdb
+      - name: Build with Maven
+        run: |
+          cd ${MANDREL_IT_PATH}
+          export GRAALVM_HOME="${JAVA_HOME}"
+          export PATH="${GRAALVM_HOME}/bin:$PATH"
+          export QUARKUS_VERSION=${{ matrix.quarkus-version }}
+          if ! $(expr match "$QUARKUS_VERSION" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
+          then
+            export QUARKUS_VERSION="999-SNAPSHOT"
+          fi
+          echo $QUARKUS_VERSION
+          ${GRAALVM_HOME}/bin/native-image --version
+          mvn clean verify -Dquarkus.native.native-image-xmx=5g \
+              -Dquarkus.version=$QUARKUS_VERSION \
+              -Ptestsuite
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        run: tar czvf test-reports-mandrel-it.tgz ${MANDREL_IT_PATH}/testsuite/target/archived-logs/
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-reports-mandrel-it-Q${{ matrix.quarkus-version }}-${{ matrix.category }}
+          path: 'test-reports-mandrel-it.tgz'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
       env: ${{ matrix.env }}
       run: |
         mkdir jdk-dl
-        ${MX_PATH}/mx fetch-jdk --jdk-id ${JDK} --to jdk-dl --alias ${JAVA_HOME}
+        ${MX_PATH}/mx --java-home= fetch-jdk --jdk-id ${JDK} --to jdk-dl --alias ${JAVA_HOME}
     - name: Update dependency cache
       if: ${{ contains(matrix.env.GATE, 'debug') || contains(matrix.env.GATE, 'style') }}
       run: sudo apt update
@@ -132,7 +132,7 @@ jobs:
     - name: Style dependencies
       if: ${{ contains(matrix.env.GATE, 'style') }}
       run: |
-        sudo apt install python-pip python-setuptools 
+        sudo apt install python-pip python-setuptools
         cat common.json |
           jq -r '.deps.common.packages | to_entries[] | select(.key | startswith("pip:")) | (.key | split(":")[1]) + .value' |
           xargs sudo pip install


### PR DESCRIPTION
Our current setup requires manually triggering CI for testing pull requests and that doesn't always work well.

This PR enables the following matrix for 21.3:

JDKs: latest ea and latest ga OpenJDK 11
Quarkus: 2.2 branch, latest release (currently 2.4.1.Final), and main branch

The reasons I chose these parameters are the following:
* GA builds should be tested for all patches before a patch release
* EA builds help us avoid introducing regressions for the next CPU release
* Q 2.2 is expected to move to 21.3 at some point
* 21.3 is currently the default for Quarkus main so we want to make sure it works fine with it
* 21.3 will become the default in the next Quarkus release (2.5?) so we want to make sure it works fine with it (currently the latest Quarkus release is 2.4.1.Final which still uses `-H:+ParseOnce`, but that should only affect `integration-tests/main`


WARNING: Due to an issue with github matrices that requires me to define the categories of the native tests to run, I am only getting and running the intersection of categories. That means that categories not present in all versions will not be tested... (currently that would be the AWT tests), which is a bummer, but I didn't find a solution to it.

PS: Once we settle on this I will prepare a similar PR for `mandrel/21.2`