### PR TITLE
CI: Use simple name for test reports artifact on failure

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -469,5 +469,5 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: test-reports-mandrel-it-${{ github.event.inputs.distribution }}-${{ github.event.inputs.version }}-Q${{ needs.get-test-matrix.outputs.quarkus-version }}-${{matrix.category}}
+          name: test-reports-mandrel-it
           path: 'test-reports-mandrel-it.tgz'

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -435,5 +435,5 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: test-reports-mandrel-it-${{ github.event.inputs.distribution }}-${{ github.event.inputs.version }}-Q${{ needs.get-test-matrix.outputs.quarkus-version }}-${{matrix.category}}
+          name: test-reports-mandrel-it
           path: 'test-reports-mandrel-it.tgz'


### PR DESCRIPTION
Avoid issues like:

```
Artifact name is not valid: test-reports-mandrel-it-mandrel-graal/master-Qf4ecfa97b775e497e225191141dd2ff758ea72ab-. Contains character: "/". Invalid artifact name characters include: ",:,<,>,|,*,?,\,/.
```