### PR TITLE
CI: Change quarkus.version for Quarkus 2.2

### DIFF
--- a/.github/update_quarkus_version.sh
+++ b/.github/update_quarkus_version.sh
@@ -1,0 +1,1 @@
+find -type f \( -name "*.xml" -o -name "*.properties" -o -name "*.java" \) -exec sed -i "s/999-SNAPSHOT/$1/g" {} +

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -152,6 +152,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        fetch-depth: 1
+        path: workflow-mandrel
+    - uses: actions/checkout@v2
+      with:
         repository: quarkusio/quarkus
         fetch-depth: 1
         ref: ${{ matrix.quarkus-version }}
@@ -161,6 +165,15 @@ jobs:
         path: ~/.m2/repository
         key: base-windows-${{ matrix.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: base-windows-${{ matrix.quarkus-version }}-maven-
+    - name: Change quarkus.version for Quarkus 2.2 to make mandrel-integration-test not apply quarkus_main.patch
+      # See https://github.com/Karm/mandrel-integration-tests/pull/64
+      shell: bash
+      run: |
+        if [ "${{ matrix.quarkus-version }}" == "2.2" ]
+        then
+          cd quarkus
+          bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ matrix.quarkus-version }}
+        fi
     - name: Build quarkus
       run: |
         curl -L https://api.adoptium.net/v3/binary/latest/11/${{ matrix.jdk }}/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
@@ -194,6 +207,10 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.get-quarkus-versions.outputs.tests-matrix) }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: workflow-mandrel
       - name: Download Maven Repo
         if: startsWith(matrix.os-name, 'windows')
         uses: actions/download-artifact@v1
@@ -233,6 +250,16 @@ jobs:
         shell: bash
         run: |
           cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+      - name: Change quarkus.version for Quarkus 2.2 to make mandrel-integration-test not apply quarkus_main.patch
+        if: startsWith(matrix.os-name, 'windows')
+        # See https://github.com/Karm/mandrel-integration-tests/pull/64
+        shell: bash
+        run: |
+          if [ "${{ matrix.quarkus-version }}" == "2.2" ]
+          then
+            cd quarkus
+            bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ matrix.quarkus-version }}
+          fi
       - name: Build with Maven
         if: startsWith(matrix.os-name, 'windows')
         env:
@@ -324,7 +351,8 @@ jobs:
             exit 1
           }
           $QUARKUS_VERSION="${{ matrix.quarkus-version }}"
-          if (! ($QUARKUS_VERSION -match "^.*\.(Final|CR|Alpha|Beta)[0-9]?$")) {
+          # Don't use SNAPSHOT version for 2.2 and release tags
+          if (! ($QUARKUS_VERSION -match "^(2\.2|.*\.(Final|CR|Alpha|Beta)[0-9]?)$")) {
             $QUARKUS_VERSION="999-SNAPSHOT"
           }
           Write-Host "$QUARKUS_VERSION"

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -294,6 +294,7 @@ jobs:
   mandrel-integration-tests:
     name: Q Mandrel IT - ${{ matrix.quarkus-version}}-${{ matrix.jdk }}
     needs:
+      - build-mandrel
       - build-quarkus
       - get-quarkus-versions
     runs-on: windows-latest

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -140,6 +140,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        fetch-depth: 1
+        path: workflow-mandrel
+    - uses: actions/checkout@v2
+      with:
         repository: quarkusio/quarkus
         fetch-depth: 1
         ref: ${{ matrix.quarkus-version }}
@@ -159,6 +163,14 @@ jobs:
         mkdir -p ${JAVA_HOME}
         tar xzf jdk-${{ matrix.jdk }}.tgz -C ${JAVA_HOME} --strip-components=1
         ${JAVA_HOME}/bin/java -version
+    - name: Change quarkus.version for Quarkus 2.2 to make mandrel-integration-test not apply quarkus_main.patch
+      # See https://github.com/Karm/mandrel-integration-tests/pull/64
+      run: |
+        if [ "${{ matrix.quarkus-version }}" == "2.2" ]
+        then
+          cd quarkus
+          bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ matrix.quarkus-version }}
+        fi
     - name: Build quarkus
       run: |
         cd ${QUARKUS_PATH}
@@ -188,6 +200,10 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.get-quarkus-versions.outputs.tests-matrix) }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: workflow-mandrel
       - name: Download Maven Repo
         if: "!startsWith(matrix.os-name, 'windows')"
         uses: actions/download-artifact@v1
@@ -226,6 +242,15 @@ jobs:
         shell: bash
         run: |
           cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+      - name: Change quarkus.version for Quarkus 2.2 to make mandrel-integration-test not apply quarkus_main.patch
+        if: "!startsWith(matrix.os-name, 'windows')"
+        # See https://github.com/Karm/mandrel-integration-tests/pull/64
+        run: |
+          if [ "${{ matrix.quarkus-version }}" == "2.2" ]
+          then
+            cd quarkus
+            bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ matrix.quarkus-version }}
+          fi
       - name: Build with Maven
         if: "!startsWith(matrix.os-name, 'windows')"
         env:
@@ -296,7 +321,8 @@ jobs:
           export GRAALVM_HOME="${JAVA_HOME}"
           export PATH="${GRAALVM_HOME}/bin:$PATH"
           export QUARKUS_VERSION=${{ matrix.quarkus-version }}
-          if ! $(expr match "$QUARKUS_VERSION" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
+          # Don't use SNAPSHOT version for 2.2 and release tags
+          if ! $(expr match "$QUARKUS_VERSION" "^\(2\.2\|.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?\)$" > /dev/null)
           then
             export QUARKUS_VERSION="999-SNAPSHOT"
           fi

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -276,6 +276,7 @@ jobs:
   mandrel-integration-tests:
     name: Q Mandrel IT - ${{ matrix.quarkus-version}}-${{ matrix.jdk }}
     needs:
+      - build-mandrel
       - build-quarkus
       - get-quarkus-versions
     runs-on: ubuntu-latest


### PR DESCRIPTION
Makes mandrel-integration-test not apply quarkus_main.patch which
breaks the tests on 2.2.
See https://github.com/Karm/mandrel-integration-tests/pull/64