### PR TITLE
Reusable workflows

### DIFF
--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -1,0 +1,69 @@
+# Enable base.yml to be executed as a dispatch workflow with:
+#
+# gh workflow run base-windows-wrapper.yml \
+#  -f quarkus-repo=gsmet/quarkus -f quarkus-version=2.2.4-backports-1 \
+#  -f builder-image="quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"
+name: Mandrel-Quarkus windows tests wrapper
+
+on:
+  workflow_dispatch:
+    inputs:
+      quarkus-version:
+        type: string
+        description: 'Quarkus version to test (branch, tag, commit, or "latest")'
+        # "latest" is replaced by the latest release available in maven
+        default: "main"
+      quarkus-repo:
+        type: string
+        description: 'The Quarkus repository to be used'
+        default: 'quarkusio/quarkus'
+      repo:
+        type: string
+        description: 'The Mandrel/Graal repository to be used'
+        default: 'graalvm/mandrel'
+      version:
+        type: string
+        description: 'Mandrel version to test (branch, tag, or commit)'
+        default: "graal/master"
+      mandrel-packaging-version:
+        type: string
+        description: 'Mandrel packaging version to test (branch, tag, or commit)'
+        default: "master"
+      mandrel-packaging-repo:
+        type: string
+        description: 'Mandrel packaging repository to be used'
+        default: "graalvm/mandrel-packaging"
+      distribution:
+        type: string
+        description: 'Distribution to build, mandrel or graalvm'
+        default: "mandrel"
+      build-from-source:
+        type: boolean
+        description: 'Build Mandrel from source instead of grabing a release'
+        default: true
+      jdk:
+        type: choice
+        description: 'OpenJDK 11 to use, ga or ea (only needed when building from source)'
+        default: "ga"
+        options:
+          - "ga"
+          - "ea"
+      builder-image:
+        type: string
+        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
+        default: "null"
+
+jobs:
+  delegate:
+    uses: zakkak/mandrel/.github/workflows/base-windows.yml@reusable-workflows
+    with:
+      quarkus-version: ${{ github.event.inputs.quarkus-version }}
+      quarkus-repo: ${{ github.event.inputs.quarkus-repo }}
+      repo: ${{ github.event.inputs.repo }}
+      version: ${{ github.event.inputs.version }}
+      mandrel-packaging-version: ${{ github.event.inputs.mandrel-packaging-version }}
+      mandrel-packaging-repo: ${{ github.event.inputs.mandrel-packaging-repo }}
+      distribution: ${{ github.event.inputs.distribution }}
+      build-from-source: ${{ github.event.inputs.build-from-source }}
+      jdk: ${{ github.event.inputs.jdk }}
+      builder-image: ${{ github.event.inputs.builder-image }}

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -1,41 +1,45 @@
 name: Windows Mandrel-Quarkus tests
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      name:
-        description: 'The human-friendly name of this workflow'
-        default: "Windows Mandrel-Quarkus tests"
       quarkus-version:
+        type: string
         description: 'Quarkus version to test (branch, tag, commit, or "latest")'
         # "latest" is replaced by the latest release available in maven
         default: "main"
       quarkus-repo:
+        type: string
         description: 'The Quarkus repository to be used'
         default: 'quarkusio/quarkus'
       version:
+        type: string
         description: 'Mandrel version to test (branch, tag, or commit)'
         default: "graal/master"
       repo:
+        type: string
         description: 'The Mandrel/Graal repository to be used'
         default: 'graalvm/mandrel'
       distribution:
+        type: string
         description: 'Distribution to build, mandrel or graalvm'
         default: "mandrel"
       mandrel-packaging-version:
+        type: string
         description: 'Mandrel packaging version to test (branch, tag, or commit)'
         default: "master"
+      mandrel-packaging-repo:
+        type: string
+        description: 'Mandrel packaging repository to be used'
+        default: "graalvm/mandrel-packaging"
       build-from-source:
         type: boolean
         description: 'Build Mandrel from source instead of grabing a release'
         default: true
       jdk:
-        type: choice
+        type: string
         description: 'OpenJDK 11 to use, ga or ea (only needed when building from source)'
         default: "ga"
-        options:
-          - "ga"
-          - "ea"
       # Builder image can't be tested on Windows due to https://github.com/actions/virtual-environments/issues/1143
       # builder-image:
       #   description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
@@ -60,188 +64,19 @@ env:
   MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
 
 jobs:
-  name:
-    name: ${{ github.event.inputs.name }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "${{ toJson(github.event.inputs) }}"
-
-  build-mandrel:
-    name: Mandrel ${{ github.event.inputs.version }} build - OpenJDK11-${{ github.event.inputs.jdk }}
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' #&& github.event.inputs.builder-image == 'null'
-      with:
-        repository: ${{ github.event.inputs.repo }}
-        fetch-depth: 1
-        ref: ${{ github.event.inputs.version }}
-        path: ${{ env.MANDREL_REPO }}
-    - name: Checkout MX
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' #&& github.event.inputs.builder-image == 'null'
-      run: |
-        VERSION=$(find ${MANDREL_REPO} -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
-        git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
-        ./mx/mx --version
-      shell: bash
-    - uses: actions/checkout@v2
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' #&& github.event.inputs.builder-image == 'null'
-      with:
-        repository: graalvm/mandrel-packaging
-        ref: ${{ github.event.inputs.mandrel-packaging-version }}
-        path: ${{ env.MANDREL_PACKAGING_REPO }}
-    - uses: actions/cache@v2.1.5
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' #&& github.event.inputs.builder-image == 'null'
-      with:
-        path: ~/.mx
-        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
-        restore-keys: ${{ runner.os }}-mx-
-    - name: Get OpenJDK 11 with static libs
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' #&& github.event.inputs.builder-image == 'null'
-      run: |
-        $wc = New-Object System.Net.WebClient
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/11/${{ github.event.inputs.jdk }}/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
-        Expand-Archive "$Env:temp\jdk.zip" -DestinationPath "$Env:temp"
-        Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
-        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/11/${{ github.event.inputs.jdk }}/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
-        Expand-Archive "$Env:temp\jdk-staticlibs.zip" -DestinationPath "$Env:temp"
-        Move-Item -Path "$Env:temp\jdk-*\lib\static" -Destination $Env:JAVA_HOME\lib\
-        Remove-Item -Recurse "$Env:temp\jdk-*"
-        & $Env:JAVA_HOME\bin\java -version
-    - name: Build Mandrel
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' #&& github.event.inputs.builder-image == 'null'
-      run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
-        Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
-          if ($_ -match "^(.*?)=(.*)$") {
-            Set-Content "Env:\$($matches[1])" $matches[2]
-          }
-        }
-        & $Env:JAVA_HOME\bin\java -ea $Env:MANDREL_PACKAGING_REPO\build.java `
-          --mx-home $Env:MX_PATH `
-          --mandrel-repo $Env:MANDREL_REPO `
-          --mandrel-home $Env:MANDREL_HOME
-        & $Env:MANDREL_HOME\bin\native-image --version
-        Remove-Item -Recurse $Env:JAVA_HOME
-        Move-Item -Path $Env:MANDREL_HOME -Destination $Env:JAVA_HOME
-    - name: Archive JDK
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' #&& github.event.inputs.builder-image == 'null'
-      shell: bash
-      run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
-    - name: Persist Mandrel build
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' #&& github.event.inputs.builder-image == 'null'
-      uses: actions/upload-artifact@v2
-      with:
-        name: jdk
-        path: jdk.tgz
-
-  build-graal:
-    name: GraalVM CE ${{ github.event.inputs.version }} build
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' #&& github.event.inputs.builder-image == 'null'
-      with:
-        repository: ${{ github.event.inputs.repo }}
-        fetch-depth: 1
-        ref: ${{ github.event.inputs.version }}
-        path: graal
-    - name: Checkout MX
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' #&& github.event.inputs.builder-image == 'null'
-      run: |
-        VERSION=$(find graal -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
-        git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
-        ./mx/mx --version
-      shell: bash
-    - uses: actions/cache@v2.1.5
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' #&& github.event.inputs.builder-image == 'null'
-      with:
-        path: ~/.mx
-        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
-        restore-keys: ${{ runner.os }}-mx-
-    - name: Build graalvm native-image
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' #&& github.event.inputs.builder-image == 'null'
-      run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
-        Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
-          if ($_ -match "^(.*?)=(.*)$") {
-            Set-Content "Env:\$($matches[1])" $matches[2]
-          }
-        }
-        Set-Location graal\substratevm
-        mkdir -p "$Env:temp\jdk-dl"
-        & $Env:MX_PATH\mx.cmd --java-home= fetch-jdk --java-distribution labsjdk-ce-11 --to "$Env:temp\jdk-dl" --alias $Env:JAVA_HOME
-        & $Env:JAVA_HOME\bin\java --version
-        & $Env:MX_PATH\mx.cmd --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" build
-        ${graalvm-home} = @(& $Env:MX_PATH\mx.cmd --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" graalvm-home)
-        rm -Recurse -Force $Env:JAVA_HOME
-        mv ${graalvm-home} $Env:JAVA_HOME
-        & $Env:JAVA_HOME\bin\native-image --version
-    - name: Archive JDK
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' #&& github.event.inputs.builder-image == 'null'
-      shell: bash
-      run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
-    - name: Persist GraalVM CE build
-      if: github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' #&& github.event.inputs.builder-image == 'null'
-      uses: actions/upload-artifact@v2
-      with:
-        name: jdk
-        path: jdk.tgz
-
-  get-jdk:
-    name: Get Mandrel/GraalVM CE ${{ github.event.inputs.version }} #or OpenJDK11-${{ github.event.inputs.jdk }}
-    runs-on: windows-latest
-    steps:
-    - name: Get Mandrel ${{ github.event.inputs.version }}
-      if: github.event.inputs.build-from-source == 'false' && github.event.inputs.distribution == 'mandrel' #&& github.event.inputs.builder-image == 'null'
-      run: |
-        $VERSION="${{ github.event.inputs.version }}"
-        $VERSION_SHORT=@($VERSION -replace 'mandrel-')
-        $wc = New-Object System.Net.WebClient
-        $url="$Env:GITHUB_SERVER_URL/graalvm/mandrel/releases/download/${VERSION}/mandrel-java11-windows-amd64-${VERSION_SHORT}.zip"
-        $wc.DownloadFile($($url), "mandrel.zip")
-        Expand-Archive "mandrel.zip" -DestinationPath "$Env:temp"
-        Move-Item -Path "$Env:temp\mandrel-*" -Destination $Env:JAVA_HOME
-        & $Env:JAVA_HOME\bin\native-image --version
-    - name: Get GraalVM CE ${{ github.event.inputs.version }}
-      if: github.event.inputs.build-from-source == 'false' && github.event.inputs.distribution == 'graalvm' #&& github.event.inputs.builder-image == 'null'
-      run: |
-        $VERSION="${{ github.event.inputs.version }}"
-        $VERSION_SHORT=@($VERSION -replace 'vm-')
-        $wc = New-Object System.Net.WebClient
-        $url="$Env:GITHUB_SERVER_URL/graalvm/graalvm-ce-builds/releases/download/${VERSION}/graalvm-ce-java11-windows-amd64-${VERSION_SHORT}.zip"
-        $wc.DownloadFile($($url), "graalvm.zip")
-        Expand-Archive "graalvm.zip" -DestinationPath "$Env:temp"
-        Move-Item -Path "$Env:temp\graalvm-*" -Destination $Env:JAVA_HOME
-        & $Env:JAVA_HOME\bin\gu install native-image
-        & $Env:JAVA_HOME\bin\native-image --version
-    # - name: Get OpenJDK11-${{ github.event.inputs.jdk }}
-    #   if: github.event.inputs.builder-image != 'null'
-    #   run: |
-    #     $wc = New-Object System.Net.WebClient
-    #     $url="https://api.adoptium.net/v3/binary/latest/11/${{ github.event.inputs.jdk }}/windows/x64/jdk/hotspot/normal/eclipse"
-    #     $wc.DownloadFile($($url), "jdk.zip")
-    #     Expand-Archive "jdk.zip" -DestinationPath "$Env:temp"
-    #     Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
-    #     & $Env:JAVA_HOME\bin\java -version
-    - name: Archive JDK
-      if: github.event.inputs.build-from-source == 'false' #|| github.event.inputs.builder-image != 'null'
-      shell: bash
-      run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
-    - name: Persist Mandrel/GraalVM or OpenJDK
-      if: github.event.inputs.build-from-source == 'false' #|| github.event.inputs.builder-image != 'null'
-      uses: actions/upload-artifact@v2
-      with:
-        name: jdk
-        path: jdk.tgz
-
   get-test-matrix:
     name: Get test matrix
     runs-on: ubuntu-latest
     outputs:
       quarkus-version: ${{ steps.version.outputs.quarkus-version }}
       tests-matrix: ${{ steps.version.outputs.tests-matrix }}
+      artifacts-suffix: ${{ steps.suffix.outputs.suffix }}
     steps:
+    - id: suffix
+      run: |
+        export SUFFIX=$(echo '${{ toJson(inputs) }}' | jq -j '. | to_entries[] | "-\(.value)"' | tr '":<>|*?\\r\n\/' '-')
+        echo $SUFFIX
+        echo "::set-output name=suffix::$SUFFIX"
     - name: Get Quarkus version and test matrix
       id: version
       run: |
@@ -262,8 +97,183 @@ jobs:
         echo ${tests_json}
         echo "::set-output name=tests-matrix::${tests_json}"
 
+  build-mandrel:
+    name: Mandrel ${{ inputs.version }} build - OpenJDK11-${{ inputs.jdk }}
+    runs-on: windows-latest
+    needs:
+      - get-test-matrix
+    steps:
+    - uses: actions/checkout@v2
+      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      with:
+        repository: ${{ inputs.repo }}
+        fetch-depth: 1
+        ref: ${{ inputs.version }}
+        path: ${{ env.MANDREL_REPO }}
+    - name: Checkout MX
+      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      run: |
+        VERSION=$(find ${MANDREL_REPO} -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
+        git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
+        ./mx/mx --version
+      shell: bash
+    - uses: actions/checkout@v2
+      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      with:
+        repository: ${{ inputs.mandrel-packaging-repo }}
+        ref: ${{ inputs.mandrel-packaging-version }}
+        path: ${{ env.MANDREL_PACKAGING_REPO }}
+    - uses: actions/cache@v2.1.5
+      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      with:
+        path: ~/.mx
+        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+        restore-keys: ${{ runner.os }}-mx-
+    - name: Get OpenJDK 11 with static libs
+      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      run: |
+        $wc = New-Object System.Net.WebClient
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/11/${{ inputs.jdk }}/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
+        Expand-Archive "$Env:temp\jdk.zip" -DestinationPath "$Env:temp"
+        Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
+        $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/11/${{ inputs.jdk }}/windows/x64/staticlibs/hotspot/normal/eclipse", "$Env:temp\jdk-staticlibs.zip")
+        Expand-Archive "$Env:temp\jdk-staticlibs.zip" -DestinationPath "$Env:temp"
+        Move-Item -Path "$Env:temp\jdk-*\lib\static" -Destination $Env:JAVA_HOME\lib\
+        Remove-Item -Recurse "$Env:temp\jdk-*"
+        & $Env:JAVA_HOME\bin\java -version
+    - name: Build Mandrel
+      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      run: |
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+        Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
+          if ($_ -match "^(.*?)=(.*)$") {
+            Set-Content "Env:\$($matches[1])" $matches[2]
+          }
+        }
+        & $Env:JAVA_HOME\bin\java -ea $Env:MANDREL_PACKAGING_REPO\build.java `
+          --mx-home $Env:MX_PATH `
+          --mandrel-repo $Env:MANDREL_REPO `
+          --mandrel-home $Env:MANDREL_HOME
+        & $Env:MANDREL_HOME\bin\native-image --version
+        Remove-Item -Recurse $Env:JAVA_HOME
+        Move-Item -Path $Env:MANDREL_HOME -Destination $Env:JAVA_HOME
+    - name: Archive JDK
+      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      shell: bash
+      run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
+    - name: Persist Mandrel build
+      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      uses: actions/upload-artifact@v2
+      with:
+        name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+        path: jdk.tgz
+
+  build-graal:
+    name: GraalVM CE ${{ inputs.version }} build
+    runs-on: windows-latest
+    needs:
+      - get-test-matrix
+    steps:
+    - uses: actions/checkout@v2
+      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      with:
+        repository: ${{ inputs.repo }}
+        fetch-depth: 1
+        ref: ${{ inputs.version }}
+        path: graal
+    - name: Checkout MX
+      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      run: |
+        VERSION=$(find graal -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
+        git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
+        ./mx/mx --version
+      shell: bash
+    - uses: actions/cache@v2.1.5
+      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      with:
+        path: ~/.mx
+        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+        restore-keys: ${{ runner.os }}-mx-
+    - name: Build graalvm native-image
+      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      run: |
+        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+        Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
+          if ($_ -match "^(.*?)=(.*)$") {
+            Set-Content "Env:\$($matches[1])" $matches[2]
+          }
+        }
+        Set-Location graal\substratevm
+        mkdir -p "$Env:temp\jdk-dl"
+        & $Env:MX_PATH\mx.cmd --java-home= fetch-jdk --java-distribution labsjdk-ce-11 --to "$Env:temp\jdk-dl" --alias $Env:JAVA_HOME
+        & $Env:JAVA_HOME\bin\java --version
+        & $Env:MX_PATH\mx.cmd --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" build
+        ${graalvm-home} = @(& $Env:MX_PATH\mx.cmd --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" graalvm-home)
+        rm -Recurse -Force $Env:JAVA_HOME
+        mv ${graalvm-home} $Env:JAVA_HOME
+        & $Env:JAVA_HOME\bin\native-image --version
+    - name: Archive JDK
+      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      shell: bash
+      run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
+    - name: Persist GraalVM CE build
+      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      uses: actions/upload-artifact@v2
+      with:
+        name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+        path: jdk.tgz
+
+  get-jdk:
+    name: Get Mandrel/GraalVM CE ${{ inputs.version }} #or OpenJDK11-${{ inputs.jdk }}
+    runs-on: windows-latest
+    needs:
+      - get-test-matrix
+    steps:
+    - name: Get Mandrel ${{ inputs.version }}
+      if: inputs.build-from-source == false && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      run: |
+        $VERSION="${{ inputs.version }}"
+        $VERSION_SHORT=@($VERSION -replace 'mandrel-')
+        $wc = New-Object System.Net.WebClient
+        $url="$Env:GITHUB_SERVER_URL/graalvm/mandrel/releases/download/${VERSION}/mandrel-java11-windows-amd64-${VERSION_SHORT}.zip"
+        $wc.DownloadFile($($url), "mandrel.zip")
+        Expand-Archive "mandrel.zip" -DestinationPath "$Env:temp"
+        Move-Item -Path "$Env:temp\mandrel-*" -Destination $Env:JAVA_HOME
+        & $Env:JAVA_HOME\bin\native-image --version
+    - name: Get GraalVM CE ${{ inputs.version }}
+      if: inputs.build-from-source == false && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      run: |
+        $VERSION="${{ inputs.version }}"
+        $VERSION_SHORT=@($VERSION -replace 'vm-')
+        $wc = New-Object System.Net.WebClient
+        $url="$Env:GITHUB_SERVER_URL/graalvm/graalvm-ce-builds/releases/download/${VERSION}/graalvm-ce-java11-windows-amd64-${VERSION_SHORT}.zip"
+        $wc.DownloadFile($($url), "graalvm.zip")
+        Expand-Archive "graalvm.zip" -DestinationPath "$Env:temp"
+        Move-Item -Path "$Env:temp\graalvm-*" -Destination $Env:JAVA_HOME
+        & $Env:JAVA_HOME\bin\gu install native-image
+        & $Env:JAVA_HOME\bin\native-image --version
+    # - name: Get OpenJDK11-${{ inputs.jdk }}
+    #   if: inputs.builder-image != 'null'
+    #   run: |
+    #     $wc = New-Object System.Net.WebClient
+    #     $url="https://api.adoptium.net/v3/binary/latest/11/${{ inputs.jdk }}/windows/x64/jdk/hotspot/normal/eclipse"
+    #     $wc.DownloadFile($($url), "jdk.zip")
+    #     Expand-Archive "jdk.zip" -DestinationPath "$Env:temp"
+    #     Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
+    #     & $Env:JAVA_HOME\bin\java -version
+    - name: Archive JDK
+      if: inputs.build-from-source == false #|| inputs.builder-image != 'null'
+      shell: bash
+      run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
+    - name: Persist Mandrel/GraalVM or OpenJDK
+      if: inputs.build-from-source == false #|| inputs.builder-image != 'null'
+      uses: actions/upload-artifact@v2
+      with:
+        name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+        path: jdk.tgz
+
   build-quarkus:
-    name: Quarkus ${{ github.event.inputs.quarkus-version }} - OpenJDK11-${{ github.event.inputs.jdk }}
+    name: Quarkus ${{ inputs.quarkus-version }} - OpenJDK11-${{ inputs.jdk }}
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
@@ -276,7 +286,7 @@ jobs:
         path: workflow-mandrel
     - uses: actions/checkout@v2
       with:
-        repository: ${{ github.event.inputs.quarkus-repo }}
+        repository: ${{ inputs.quarkus-repo }}
         fetch-depth: 1
         ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
         path: quarkus
@@ -289,10 +299,10 @@ jobs:
       # See https://github.com/Karm/mandrel-integration-tests/pull/64
       shell: bash
       run: |
-        if [ "${{ github.event.inputs.quarkus-version }}" == "2.2" ]
+        if [ "${{ inputs.quarkus-version }}" == "2.2" ]
         then
           cd quarkus
-          bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ github.event.inputs.quarkus-version }}
+          bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ inputs.quarkus-version }}
         fi
     - name: Build quarkus
       run: |
@@ -306,18 +316,18 @@ jobs:
         ./mvnw ${COMMON_MAVEN_ARGS} -Dquickly
     - name: Tar Maven Repo
       shell: bash
-      run: tar -I 'pigz -9' -cf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~ .m2/repository
+      run: tar -I 'pigz -9' -cf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}.tgz -C ~ .m2/repository
     - name: Persist Maven Repo
       uses: actions/upload-artifact@v2
       with:
-        name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
-        path: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz
+        name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+        path: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}.tgz
     - name: Delete Local Artifacts From Cache
       shell: bash
       run: rm -r ~/.m2/repository/io/quarkus
 
   native-tests:
-    name: Q ${{ github.event.inputs.quarkus-version }} - ${{ matrix.category }} - OpenJDK11-${{ github.event.inputs.jdk }}
+    name: Q ${{ inputs.quarkus-version }} - ${{ matrix.category }} - OpenJDK11-${{ inputs.jdk }}
     needs:
       - build-quarkus
       - build-mandrel
@@ -339,16 +349,16 @@ jobs:
         if: startsWith(matrix.os-name, 'windows')
         uses: actions/download-artifact@v1
         with:
-          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
+          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract Maven Repo
         if: startsWith(matrix.os-name, 'windows')
         shell: bash
-        run: tar -xzf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~
+        run: tar -xzf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}.tgz -C ~
       - uses: actions/checkout@v2
         if: startsWith(matrix.os-name, 'windows')
         with:
-          repository: ${{ github.event.inputs.quarkus-repo }}
+          repository: ${{ inputs.quarkus-repo }}
           fetch-depth: 1
           ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
           path: ${{ env.QUARKUS_PATH }}
@@ -362,7 +372,7 @@ jobs:
         if: startsWith(matrix.os-name, 'windows')
         uses: actions/download-artifact@v1
         with:
-          name: jdk
+          name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract JDK
         if: startsWith(matrix.os-name, 'windows')
@@ -385,10 +395,10 @@ jobs:
         # See https://github.com/Karm/mandrel-integration-tests/pull/64
         shell: bash
         run: |
-          if [ "${{ github.event.inputs.quarkus-version }}" == "2.2" ]
+          if [ "${{ inputs.quarkus-version }}" == "2.2" ]
           then
             cd quarkus
-            bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ github.event.inputs.quarkus-version }}
+            bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ inputs.quarkus-version }}
           fi
       - name: Build with Maven
         if: startsWith(matrix.os-name, 'windows')
@@ -410,10 +420,10 @@ jobs:
           }
           $opts=@()
           -split $Env:NATIVE_TEST_MAVEN_OPTS | foreach { $opts += "`"$_`"" }
-          #if ( "${{ github.event.inputs.builder-image }}" -eq "null" ) {
+          #if ( "${{ inputs.builder-image }}" -eq "null" ) {
           mvn -f integration-tests -pl "$Env:TEST_MODULES" $opts install
           #} else {
-          #  mvn -pl $do_modules "-Dquarkus.native.container-build=true" "-Dquarkus.native.builder-image=${{ github.event.inputs.builder-image }}" $opts package
+          #  mvn -pl $do_modules "-Dquarkus.native.container-build=true" "-Dquarkus.native.builder-image=${{ inputs.builder-image }}" $opts package
           #}
       - name: Prepare failure archive (if maven failed)
         if: failure()
@@ -423,7 +433,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: test-reports-native-${{matrix.category}}
+          name: test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports.tgz'
 
   mandrel-integration-tests:
@@ -451,15 +461,15 @@ jobs:
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
-          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
+          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract Maven Repo
         shell: bash
-        run: tar -xzvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~
+        run: tar -xzvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}.tgz -C ~
       - name: Download Mandrel or OpenJDK11
         uses: actions/download-artifact@v1
         with:
-          name: jdk
+          name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract JDK
         shell: bash
@@ -487,7 +497,7 @@ jobs:
             Write-Host "Cannot find native-image tool. Quitting..."
             exit 1
           }
-          $QUARKUS_VERSION=${{ github.event.inputs.quarkus-version }}
+          $QUARKUS_VERSION=${{ inputs.quarkus-version }}
           # Don't use SNAPSHOT version for 2.2 and release tags
           if (! ($QUARKUS_VERSION -match "^(2\.2|.*\.(Final|CR|Alpha|Beta)[0-9]?)$")) {
             $QUARKUS_VERSION="999-SNAPSHOT"
@@ -502,5 +512,5 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: test-reports-mandrel-it
+          name: test-reports-mandrel-it-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports-mandrel-it.tgz'

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -98,7 +98,7 @@ jobs:
         echo "::set-output name=tests-matrix::${tests_json}"
 
   build-mandrel:
-    name: Mandrel ${{ inputs.version }} build - OpenJDK11-${{ inputs.jdk }}
+    name: Mandrel build
     runs-on: windows-latest
     needs:
       - get-test-matrix
@@ -169,7 +169,7 @@ jobs:
         path: jdk.tgz
 
   build-graal:
-    name: GraalVM CE ${{ inputs.version }} build
+    name: GraalVM CE build
     runs-on: windows-latest
     needs:
       - get-test-matrix
@@ -224,7 +224,7 @@ jobs:
         path: jdk.tgz
 
   get-jdk:
-    name: Get Mandrel/GraalVM CE ${{ inputs.version }} #or OpenJDK11-${{ inputs.jdk }}
+    name: Get JDK
     runs-on: windows-latest
     needs:
       - get-test-matrix
@@ -273,7 +273,7 @@ jobs:
         path: jdk.tgz
 
   build-quarkus:
-    name: Quarkus ${{ inputs.quarkus-version }} - OpenJDK11-${{ inputs.jdk }}
+    name: Quarkus build
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
@@ -327,7 +327,7 @@ jobs:
       run: rm -r ~/.m2/repository/io/quarkus
 
   native-tests:
-    name: Q ${{ inputs.quarkus-version }} - ${{ matrix.category }} - OpenJDK11-${{ inputs.jdk }}
+    name: Q IT ${{ matrix.category }}
     needs:
       - build-quarkus
       - build-mandrel

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -1,0 +1,69 @@
+# Enable base.yml to be executed as a dispatch workflow with:
+#
+# gh workflow run base-wrapper.yml \
+#  -f quarkus-repo=gsmet/quarkus -f quarkus-version=2.2.4-backports-1 \
+#  -f builder-image="quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"
+name: Mandrel-Quarkus tests wrapper
+
+on:
+  workflow_dispatch:
+    inputs:
+      quarkus-version:
+        type: string
+        description: 'Quarkus version to test (branch, tag, commit, or "latest")'
+        # "latest" is replaced by the latest release available in maven
+        default: "main"
+      quarkus-repo:
+        type: string
+        description: 'The Quarkus repository to be used'
+        default: 'quarkusio/quarkus'
+      repo:
+        type: string
+        description: 'The Mandrel/Graal repository to be used'
+        default: 'graalvm/mandrel'
+      version:
+        type: string
+        description: 'Mandrel version to test (branch, tag, or commit)'
+        default: "graal/master"
+      mandrel-packaging-version:
+        type: string
+        description: 'Mandrel packaging version to test (branch, tag, or commit)'
+        default: "master"
+      mandrel-packaging-repo:
+        type: string
+        description: 'Mandrel packaging repository to be used'
+        default: "graalvm/mandrel-packaging"
+      distribution:
+        type: string
+        description: 'Distribution to build, mandrel or graalvm'
+        default: "mandrel"
+      build-from-source:
+        type: boolean
+        description: 'Build Mandrel from source instead of grabing a release'
+        default: true
+      jdk:
+        type: choice
+        description: 'OpenJDK 11 to use, ga or ea (only needed when building from source)'
+        default: "ga"
+        options:
+          - "ga"
+          - "ea"
+      builder-image:
+        type: string
+        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
+        default: "null"
+
+jobs:
+  delegate:
+    uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+    with:
+      quarkus-version: ${{ github.event.inputs.quarkus-version }}
+      quarkus-repo: ${{ github.event.inputs.quarkus-repo }}
+      repo: ${{ github.event.inputs.repo }}
+      version: ${{ github.event.inputs.version }}
+      mandrel-packaging-version: ${{ github.event.inputs.mandrel-packaging-version }}
+      mandrel-packaging-repo: ${{ github.event.inputs.mandrel-packaging-repo }}
+      distribution: ${{ github.event.inputs.distribution }}
+      build-from-source: ${{ github.event.inputs.build-from-source }}
+      jdk: ${{ github.event.inputs.jdk }}
+      builder-image: ${{ github.event.inputs.builder-image }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -97,7 +97,7 @@ jobs:
         echo "::set-output name=tests-matrix::${tests_json}"
 
   build-mandrel:
-    name: Mandrel ${{ inputs.version }} build - OpenJDK11-${{ inputs.jdk }}
+    name: Mandrel build
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
@@ -155,7 +155,7 @@ jobs:
         path: jdk.tgz
 
   build-graal:
-    name: GraalVM CE ${{ inputs.version }} build
+    name: GraalVM CE build
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
@@ -202,7 +202,7 @@ jobs:
         path: jdk.tgz
 
   get-jdk:
-    name: Get Mandrel/GraalVM CE ${{ inputs.version }} or OpenJDK11-${{ inputs.jdk }}
+    name: Get JDK
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
@@ -238,7 +238,7 @@ jobs:
         path: jdk.tgz
 
   build-quarkus:
-    name: Quarkus ${{ inputs.quarkus-version }} - OpenJDK11-${{ inputs.jdk }}
+    name: Quarkus build
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,28 +1,35 @@
 name: Mandrel-Quarkus tests
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      name:
-        description: 'The human-friendly name of this workflow'
-        default: "Mandrel-Quarkus tests"
       quarkus-version:
+        type: string
         description: 'Quarkus version to test (branch, tag, commit, or "latest")'
         # "latest" is replaced by the latest release available in maven
         default: "main"
       quarkus-repo:
+        type: string
         description: 'The Quarkus repository to be used'
         default: 'quarkusio/quarkus'
       repo:
+        type: string
         description: 'The Mandrel/Graal repository to be used'
         default: 'graalvm/mandrel'
       version:
+        type: string
         description: 'Mandrel version to test (branch, tag, or commit)'
         default: "graal/master"
       mandrel-packaging-version:
+        type: string
         description: 'Mandrel packaging version to test (branch, tag, or commit)'
         default: "master"
+      mandrel-packaging-repo:
+        type: string
+        description: 'Mandrel packaging repository to be used'
+        default: "graalvm/mandrel-packaging"
       distribution:
+        type: string
         description: 'Distribution to build, mandrel or graalvm'
         default: "mandrel"
       build-from-source:
@@ -30,13 +37,11 @@ on:
         description: 'Build Mandrel from source instead of grabing a release'
         default: true
       jdk:
-        type: choice
+        type: string
         description: 'OpenJDK 11 to use, ga or ea (only needed when building from source)'
         default: "ga"
-        options:
-          - "ga"
-          - "ea"
       builder-image:
+        type: string
         description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
         default: "null"
 
@@ -58,53 +63,82 @@ env:
   MANDREL_PACKAGING_REPO: ${{ github.workspace }}/mandrel-packaging
 
 jobs:
-  name:
-    name: ${{ github.event.inputs.name }}
+  get-test-matrix:
+    name: Get test matrix
     runs-on: ubuntu-latest
+    outputs:
+      quarkus-version: ${{ steps.version.outputs.quarkus-version }}
+      tests-matrix: ${{ steps.version.outputs.tests-matrix }}
+      artifacts-suffix: ${{ steps.suffix.outputs.suffix }}
     steps:
-      - run: echo "${{ toJson(github.event.inputs) }}"
+    - id: suffix
+      run: |
+        export SUFFIX=$(echo '${{ toJson(inputs) }}' | jq -j '. | to_entries[] | "-\(.value)"' | tr '":<>|*?\\r\n\/' '-')
+        echo $SUFFIX
+        echo "::set-output name=suffix::$SUFFIX"
+    - name: Get Quarkus version and test matrix
+      id: version
+      run: |
+        if [ ${{ inputs.quarkus-version }} == "latest" ]
+        then
+          export QUARKUS_VERSION=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
+        else
+          export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ inputs.quarkus-repo }} | grep "refs/heads/${{ inputs.quarkus-version }}$\|refs/tags/${{ inputs.quarkus-version }}$" | cut -f 1)
+        fi
+        if [ "$QUARKUS_VERSION" == "" ]
+        then
+          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
+        fi
+        echo ${QUARKUS_VERSION}
+        echo "::set-output name=quarkus-version::${QUARKUS_VERSION}"
+        curl --output native-tests.json https://raw.githubusercontent.com/${{ inputs.quarkus-repo }}/${QUARKUS_VERSION}/.github/native-tests.json
+        tests_json=$(tr -d '\n' < native-tests.json)
+        echo ${tests_json}
+        echo "::set-output name=tests-matrix::${tests_json}"
 
   build-mandrel:
-    name: Mandrel ${{ github.event.inputs.version }} build - OpenJDK11-${{ github.event.inputs.jdk }}
+    name: Mandrel ${{ inputs.version }} build - OpenJDK11-${{ inputs.jdk }}
     runs-on: ubuntu-latest
+    needs:
+      - get-test-matrix
     steps:
     - uses: actions/checkout@v2
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' && github.event.inputs.builder-image == 'null'}}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       with:
-        repository: ${{ github.event.inputs.repo }}
+        repository: ${{ inputs.repo }}
         fetch-depth: 1
-        ref: ${{ github.event.inputs.version }}
+        ref: ${{ inputs.version }}
         path: ${{ env.MANDREL_REPO }}
     - name: Checkout MX
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
       run: |
         VERSION=$(find ${MANDREL_REPO} -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_PATH}
         ./mx/mx --version
     - uses: actions/checkout@v2
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
       with:
-        repository: graalvm/mandrel-packaging
-        ref: ${{ github.event.inputs.mandrel-packaging-version }}
+        repository: ${{ inputs.mandrel-packaging-repo }}
+        ref: ${{ inputs.mandrel-packaging-version }}
         path: ${{ env.MANDREL_PACKAGING_REPO }}
     - uses: actions/cache@v2.1.5
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
     - name: Get OpenJDK 11 with static libs
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/11/${{ github.event.inputs.jdk }}/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/11/${{ github.event.inputs.jdk }}/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/11/${{ inputs.jdk }}/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/11/${{ inputs.jdk }}/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java --version
     - name: Build Mandrel
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
       run: |
         ${JAVA_HOME}/bin/java -ea ${MANDREL_PACKAGING_REPO}/build.java \
           --mx-home ${MX_PATH} \
@@ -114,72 +148,76 @@ jobs:
         ${MANDREL_HOME}/bin/native-image --version
         mv mandrel-java11-linux-amd64-*.tar.gz ${{ github.workspace }}/jdk.tgz
     - name: Persist Mandrel build
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'mandrel' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
       uses: actions/upload-artifact@v2
       with:
-        name: jdk
+        name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
 
   build-graal:
-    name: GraalVM CE ${{ github.event.inputs.version }} build
+    name: GraalVM CE ${{ inputs.version }} build
     runs-on: ubuntu-latest
+    needs:
+      - get-test-matrix
     steps:
     - uses: actions/checkout@v2
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null'}}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       with:
-        repository: ${{ github.event.inputs.repo }}
+        repository: ${{ inputs.repo }}
         fetch-depth: 1
-        ref: ${{ github.event.inputs.version }}
+        ref: ${{ inputs.version }}
         path: graal
     - name: Checkout MX
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
       run: |
         VERSION=$(find graal -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_PATH}
         ./mx/mx --version
     - uses: actions/cache@v2.1.5
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
     - name: Get labs OpenJDK 11
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
       run: |
         mkdir jdk-dl
         ${MX_PATH}/mx --java-home= fetch-jdk --java-distribution labsjdk-ce-11 --to jdk-dl --alias ${JAVA_HOME}
     - name: Build graalvm native-image
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
       run: |
         cd graal/substratevm
         ${MX_PATH}/mx --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" build
         mv $(${MX_PATH}/mx --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal" graalvm-home) ${MANDREL_HOME}
         ${MANDREL_HOME}/bin/native-image --version
     - name: Tar GraalVM
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
       run: tar czvf jdk.tgz  -C $(dirname ${MANDREL_HOME}) $(basename ${MANDREL_HOME})
     - name: Persist Mandrel build
-      if: ${{ github.event.inputs.build-from-source == 'true' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
+      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
       uses: actions/upload-artifact@v2
       with:
-        name: jdk
+        name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
 
   get-jdk:
-    name: Get Mandrel/GraalVM CE ${{ github.event.inputs.version }} or OpenJDK11-${{ github.event.inputs.jdk }}
+    name: Get Mandrel/GraalVM CE ${{ inputs.version }} or OpenJDK11-${{ inputs.jdk }}
     runs-on: ubuntu-latest
+    needs:
+      - get-test-matrix
     steps:
-    - name: Get Mandrel ${{ github.event.inputs.version }}
-      if: ${{ github.event.inputs.build-from-source == 'false' && github.event.inputs.distribution == 'mandrel' && github.event.inputs.builder-image == 'null' }}
+    - name: Get Mandrel ${{ inputs.version }}
+      if: ${{ inputs.build-from-source == false && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
       run: |
-        VERSION=${{ github.event.inputs.version }}
+        VERSION=${{ inputs.version }}
         curl \
           -sL ${GITHUB_SERVER_URL}/graalvm/mandrel/releases/download/${VERSION}/mandrel-java11-linux-amd64-${VERSION##mandrel-}.tar.gz \
           -o jdk.tgz
-    - name: Get GraalVM CE ${{ github.event.inputs.version }}
-      if: ${{ github.event.inputs.build-from-source == 'false' && github.event.inputs.distribution == 'graalvm' && github.event.inputs.builder-image == 'null' }}
+    - name: Get GraalVM CE ${{ inputs.version }}
+      if: ${{ inputs.build-from-source == false && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
       run: |
-        VERSION=${{ github.event.inputs.version }}
+        VERSION=${{ inputs.version }}
         curl \
           -sL ${GITHUB_SERVER_URL}/graalvm/graalvm-ce-builds/releases/download/${VERSION}/graalvm-ce-java11-linux-amd64-${VERSION##vm-}.tar.gz \
           -o graalvm.tgz
@@ -188,46 +226,19 @@ jobs:
         ${JAVA_HOME}/bin/gu install native-image
         ${JAVA_HOME}/bin/native-image --version
         tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
-    - name: Get OpenJDK11-${{ github.event.inputs.jdk }}
-      if: ${{ github.event.inputs.builder-image != 'null' }}
+    - name: Get OpenJDK11-${{ inputs.jdk }}
+      if: ${{ inputs.builder-image != 'null' }}
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/11/${{ github.event.inputs.jdk }}/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tgz
+        curl -sL https://api.adoptium.net/v3/binary/latest/11/${{ inputs.jdk }}/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tgz
     - name: Persist Mandrel or OpenJDK
-      if: ${{ github.event.inputs.build-from-source == 'false' || github.event.inputs.builder-image != 'null' }}
+      if: ${{ inputs.build-from-source == false || inputs.builder-image != 'null' }}
       uses: actions/upload-artifact@v2
       with:
-        name: jdk
+        name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
 
-  get-test-matrix:
-    name: Get test matrix
-    runs-on: ubuntu-latest
-    outputs:
-      quarkus-version: ${{ steps.version.outputs.quarkus-version }}
-      tests-matrix: ${{ steps.version.outputs.tests-matrix }}
-    steps:
-    - name: Get Quarkus version and test matrix
-      id: version
-      run: |
-        if [ ${{ github.event.inputs.quarkus-version }} == "latest" ]
-        then
-          export QUARKUS_VERSION=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
-        else
-          export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ github.event.inputs.quarkus-repo }} | grep "refs/heads/${{ github.event.inputs.quarkus-version }}$\|refs/tags/${{ github.event.inputs.quarkus-version }}$" | cut -f 1)
-        fi
-        if [ "$QUARKUS_VERSION" == "" ]
-        then
-          export QUARKUS_VERSION=${{ github.event.inputs.quarkus-version }}
-        fi
-        echo ${QUARKUS_VERSION}
-        echo "::set-output name=quarkus-version::${QUARKUS_VERSION}"
-        curl --output native-tests.json https://raw.githubusercontent.com/${{ github.event.inputs.quarkus-repo }}/${QUARKUS_VERSION}/.github/native-tests.json
-        tests_json=$(tr -d '\n' < native-tests.json)
-        echo ${tests_json}
-        echo "::set-output name=tests-matrix::${tests_json}"
-
   build-quarkus:
-    name: Quarkus ${{ github.event.inputs.quarkus-version }} - OpenJDK11-${{ github.event.inputs.jdk }}
+    name: Quarkus ${{ inputs.quarkus-version }} - OpenJDK11-${{ inputs.jdk }}
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
@@ -243,7 +254,7 @@ jobs:
         path: workflow-mandrel
     - uses: actions/checkout@v2
       with:
-        repository: ${{ github.event.inputs.quarkus-repo }}
+        repository: ${{ inputs.quarkus-repo }}
         fetch-depth: 1
         ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
         path: ${{ env.QUARKUS_PATH }}
@@ -255,7 +266,7 @@ jobs:
     - name: Download Mandrel or OpenJDK11
       uses: actions/download-artifact@v1
       with:
-        name: jdk
+        name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: .
     - name: Extract Mandrel or OpenJDK11
       shell: bash
@@ -266,10 +277,10 @@ jobs:
     - name: Change quarkus.version for Quarkus 2.2 to make mandrel-integration-test not apply quarkus_main.patch
       # See https://github.com/Karm/mandrel-integration-tests/pull/64
       run: |
-        if [ "${{ github.event.inputs.quarkus-version }}" == "2.2" ]
+        if [ "${{ inputs.quarkus-version }}" == "2.2" ]
         then
           cd quarkus
-          bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ github.event.inputs.quarkus-version }}
+          bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ inputs.quarkus-version }}
         fi
     - name: Build quarkus
       run: |
@@ -277,12 +288,12 @@ jobs:
         mvn -e -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml  -Dquickly
     - name: Tar Maven Repo
       shell: bash
-      run: tar -czvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~ .m2/repository
+      run: tar -czvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}.tgz -C ~ .m2/repository
     - name: Persist Maven Repo
       uses: actions/upload-artifact@v2
       with:
-        name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
-        path: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz
+        name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+        path: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}.tgz
     - name: Delete Local Artifacts From Cache
       shell: bash
       run: rm -r ~/.m2/repository/io/quarkus
@@ -310,17 +321,17 @@ jobs:
         if: "!startsWith(matrix.os-name, 'windows')"
         uses: actions/download-artifact@v1
         with:
-          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
+          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract Maven Repo
         if: "!startsWith(matrix.os-name, 'windows')"
         shell: bash
-        run: tar -xzvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~
+        run: tar -xzvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}.tgz -C ~
       - name: Download Mandrel or OpenJDK11
         if: "!startsWith(matrix.os-name, 'windows')"
         uses: actions/download-artifact@v1
         with:
-          name: jdk
+          name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract Mandrel or OpenJDK11
         if: "!startsWith(matrix.os-name, 'windows')"
@@ -331,7 +342,7 @@ jobs:
       - uses: actions/checkout@v2
         if: "!startsWith(matrix.os-name, 'windows')"
         with:
-          repository: ${{ github.event.inputs.quarkus-repo }}
+          repository: ${{ inputs.quarkus-repo }}
           fetch-depth: 1
           ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
           path: ${{ env.QUARKUS_PATH }}
@@ -347,10 +358,10 @@ jobs:
         if: "!startsWith(matrix.os-name, 'windows')"
         # See https://github.com/Karm/mandrel-integration-tests/pull/64
         run: |
-          if [ "${{ github.event.inputs.quarkus-version }}" == "2.2" ]
+          if [ "${{ inputs.quarkus-version }}" == "2.2" ]
           then
             cd quarkus
-            bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ github.event.inputs.quarkus-version }}
+            bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ inputs.quarkus-version }}
           fi
       - name: Build with Maven
         if: "!startsWith(matrix.os-name, 'windows')"
@@ -361,12 +372,12 @@ jobs:
         run: |
           cd ${QUARKUS_PATH}
           export GRAALVM_HOME="${JAVA_HOME}"
-          if [[ ${{ github.event.inputs.builder-image }} == "null" ]]
+          if [[ ${{ inputs.builder-image }} == "null" ]]
           then
             export BUILDER_IMAGE=""
             ${GRAALVM_HOME}/bin/native-image --version
           else
-            export BUILDER_IMAGE="-Dquarkus.native.container-build=true -Dquarkus.native.builder-image=${{ github.event.inputs.builder-image }}"
+            export BUILDER_IMAGE="-Dquarkus.native.container-build=true -Dquarkus.native.builder-image=${{ inputs.builder-image }}"
           fi
           # Backwards compatibility with Quarkus < 2.x native-tests.json
           if ! echo $TEST_MODULES | grep ',' > /dev/null
@@ -392,15 +403,12 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: test-reports-native-${{matrix.category}}
+          name: test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports.tgz'
 
   mandrel-integration-tests:
     name: Q Mandrel IT
     needs:
-      - build-mandrel
-      - build-graal
-      - get-jdk
       - build-quarkus
       - get-test-matrix
     runs-on: ubuntu-latest
@@ -421,14 +429,14 @@ jobs:
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
-          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}
+          name: maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract Maven Repo
-        run: tar -xzvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ github.event.inputs.jdk }}.tgz -C ~
+        run: tar -xzvf maven-repo-${{ needs.get-test-matrix.outputs.quarkus-version }}-${{ inputs.jdk }}.tgz -C ~
       - name: Download Mandrel or OpenJDK11
         uses: actions/download-artifact@v1
         with:
-          name: jdk
+          name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract Mandrel or OpenJDK11
         run: |
@@ -444,14 +452,14 @@ jobs:
           cd ${MANDREL_IT_PATH}
           export GRAALVM_HOME="${JAVA_HOME}"
           export PATH="${GRAALVM_HOME}/bin:$PATH"
-          export QUARKUS_VERSION=${{ github.event.inputs.quarkus-version }}
+          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
           # Don't use SNAPSHOT version for 2.2 and release tags
           if ! $(expr match "$QUARKUS_VERSION" "^\(2\.2\|.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?\)$" > /dev/null)
           then
             export QUARKUS_VERSION="999-SNAPSHOT"
           fi
           echo $QUARKUS_VERSION
-          if [[ ${{ github.event.inputs.builder-image }} == "null" ]]
+          if [[ ${{ inputs.builder-image }} == "null" ]]
           then
             ${GRAALVM_HOME}/bin/native-image --version
             mvn clean verify -Dquarkus.native.native-image-xmx=5g \
@@ -460,7 +468,7 @@ jobs:
           else
             mvn clean verify -Dquarkus.native.native-image-xmx=5g \
               -Dquarkus.version=$QUARKUS_VERSION \
-              -Dquarkus.native.builder-image=${{ github.event.inputs.builder-image }} \
+              -Dquarkus.native.builder-image=${{ inputs.builder-image }} \
               -Ptestsuite-builder-image
           fi
       - name: Prepare failure archive (if maven failed)
@@ -470,5 +478,5 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: test-reports-mandrel-it
+          name: test-reports-mandrel-it-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports-mandrel-it.tgz'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,8 +6,27 @@ on:
       - '.github/workflows/nightly.yml'
       - '.github/workflows/base.yml'
       - '.github/workflows/base-windows.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/nightly.yml'
+      - '.github/workflows/base.yml'
+      - '.github/workflows/base-windows.yml'
   schedule:
   - cron: '0 2 * * *'
+  workflow_dispatch: []
+
+# The following aims to reduce CI CPU cycles by:
+# 1. Cancelling any previous builds of this PR when pushing new changes to it
+# 2. Cancelling any previous builds of a branch when pushing new changes to it in a fork
+# 3. Cancelling any pending builds, but not active ones, when pushing to a branch in the main
+#    repository. This prevents us from constantly cancelling CI runs, while being able to skip
+#    intermediate builds. E.g., if we perform two pushes the first one will start a CI job and
+#    the second one will add another one to the queue; if we perform a third push while the
+#    first CI job is still running the previously queued CI job (for the second push) will be
+#    cancelled and a new CI job will be queued for the latest (third) push.
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'graalvm/mandrel' }}
 
 jobs:
   ####

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,21 +14,21 @@ jobs:
   # Test Quarkus main with latest graal sources built as Mandrel and GraalVM
   ####
   q-main-mandrel-latest:
-    name: "Q main Mandrel build of latest graal"
+    name: "Q main M latest"
     uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
     with:
       quarkus-version: "main"
       version: "graal/master"
       jdk: "ea"
   q-main-mandrel-latest-win:
-    name: "Q main Mandrel build of latest graal on windows"
+    name: "Q main M latest windows"
     uses: zakkak/mandrel/.github/workflows/base-windows.yml@reusable-workflows
     with:
       quarkus-version: "main"
       version: "graal/master"
       jdk: "ea"
   q-main-graal-latest:
-    name: "Q main GraalVM CE build of latest graal"
+    name: "Q main G latest"
     uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
     with:
       quarkus-version: "main"
@@ -38,7 +38,7 @@ jobs:
   # Test Quarkus main with 22_0-dev built as Mandrel and GraalVM
   ####
   q-main-mandrel-22_0-dev:
-    name: "Q main Mandrel build of 22.0-dev"
+    name: "Q main M 22.0-dev"
     uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
     with:
       quarkus-version: "main"
@@ -46,7 +46,7 @@ jobs:
       jdk: "ea"
       mandrel-packaging-version: "22.0"
   q-main-mandrel-22_0-dev-win:
-    name: "Q main Mandrel build of 22.0-dev on windows"
+    name: "Q main M 22.0-dev windows"
     uses: zakkak/mandrel/.github/workflows/base-windows.yml@reusable-workflows
     with:
       quarkus-version: "main"
@@ -54,7 +54,7 @@ jobs:
       jdk: "ea"
       mandrel-packaging-version: "22.0"
   q-main-graal-22_0-dev:
-    name: "Q main GraalVM CE build of 22.0-dev"
+    name: "Q main G 22.0-dev"
     uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
     with:
       quarkus-version: "main"
@@ -65,19 +65,19 @@ jobs:
   # Test Quarkus with supported Mandrel versions using the Quay.io images
   ####
   # q-2_2-mandrel-21_2-quayio:
-  #   name: "Q 2.2 Mandrel 21.2 image from quay.io"
+  #   name: "Q 2.2 M 21.2 image"
   #   uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
   #   with:
   #     quarkus-version: "2.2"
   #     builder-image: "quay.io/quarkus/ubi-quarkus-mandrel:21.2-java11"
   q-2_2-mandrel-21_3-quayio:
-    name: "Q 2.2 Mandrel 21.3 image from quay.io"
+    name: "Q 2.2 M 21.3 image"
     uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
     with:
       quarkus-version: "2.2"
       builder-image: "quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"
   q-main-mandrel-21_2-quayio:
-    name: "Q main Mandrel 21.3 image from quay.io"
+    name: "Q main M 21.3 image"
     uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
     with:
       quarkus-version: "main"
@@ -86,14 +86,14 @@ jobs:
   # Test Quarkus main with supported Mandrel versions using the release archives
   ####
   #q-main-mandrel-20_3-release
-  #  name: "Q main Mandrel 20.3 release"
+  #  name: "Q main M 20.3 release"
   #  uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
   #  with:
   #    quarkus-version: "main"
   #     version: "mandrel-20.3.1.2-Final"
   #     build-from-source: "false"
   #q-main-mandrel-21_0-release
-  #  name: "Q main Mandrel 21.0 release"
+  #  name: "Q main M 21.0 release"
   #  uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
   #  with:
   #    quarkus-version: "main"
@@ -103,7 +103,7 @@ jobs:
   # Test Quarkus main with supported GraalVM versions using the release archives
   ####
   #q-main-graal-20_3-release
-  #  name: "Q main GraalVM-CE 20.3 release"
+  #  name: "Q main G 20.3 release"
   #  uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
   #  with:
   #    quarkus-version: "main"
@@ -111,7 +111,7 @@ jobs:
   #     build-from-source: "false"
   #     distribution: "graalvm"
   #q-main-graal-21_0-release
-  #  name: "Q main GraalVM-CE 21.0 release"
+  #  name: "Q main G 21.0 release"
   #  uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
   #  with:
   #    quarkus-version: "main"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,126 +4,117 @@ on:
   push:
     paths:
       - '.github/workflows/nightly.yml'
+      - '.github/workflows/base.yml'
+      - '.github/workflows/base-windows.yml'
   schedule:
   - cron: '0 2 * * *'
 
-env:
-  WORKFLOW_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-
 jobs:
-  dispatch:
-    name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        include:
-          ####
-          # Test Quarkus main with latest graal sources built as Mandrel and GraalVM
-          ####
-          - name: "Q main Mandrel build of latest graal"
-            inputs: '{"quarkus-version": "main", "version": "graal/master", "jdk": "ea"}'
-            workflow: 'base.yml'
-          - name: "Q main Mandrel build of latest graal on windows"
-            inputs: '{"quarkus-version": "main", "version": "graal/master", "jdk": "ea"}'
-            workflow: 'base-windows.yml'
-          - name: "Q main GraalVM CE build of latest graal"
-            inputs: '{"quarkus-version": "main", "version": "graal/master", "distribution": "graalvm"}'
-            workflow: 'base.yml'
-          ####
-          # Test Quarkus main with 22.0-dev built as Mandrel and GraalVM
-          ####
-          - name: "Q main Mandrel build of 22.0-dev"
-            inputs: '{"quarkus-version": "main", "version": "mandrel/22.0", "jdk": "ea", "mandrel-packaging-version": "22.0"}'
-            workflow: 'base.yml'
-          - name: "Q main Mandrel build of 22.0-dev on windows"
-            inputs: '{"quarkus-version": "main", "version": "mandrel/22.0", "jdk": "ea", "mandrel-packaging-version": "22.0"}'
-            workflow: 'base-windows.yml'
-          - name: "Q main GraalVM CE build of 22.0-dev"
-            inputs: '{"quarkus-version": "main", "repo": "oracle/graal", "version": "release/graal-vm/22.0", "distribution": "graalvm"}'
-            workflow: 'base.yml'
-          ####
-          # Test Quarkus with supported Mandrel versions using the Quay.io images
-          ####
-          # - name: "Q 2.2 Mandrel 21.2 image from quay.io"
-          #   inputs: '{"quarkus-version": "2.2", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:21.2-java11"}'
-          #   workflow: 'base.yml'
-          - name: "Q 2.2 Mandrel 21.3 image from quay.io"
-            inputs: '{"quarkus-version": "2.2", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"}'
-            workflow: 'base.yml'
-          - name: "Q main Mandrel 21.3 image from quay.io"
-            inputs: '{"quarkus-version": "main", "builder-image": "quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"}'
-            workflow: 'base.yml'
-          ####
-          # Test Quarkus main with supported Mandrel versions using the release archives
-          ####
-          #- name: "Q main Mandrel 20.3 release"
-          #  inputs: '{"quarkus-version": "main", "version": "mandrel-20.3.1.2-Final", "build-from-source": "false"}'
-          #  workflow: 'base.yml'
-          #- name: "Q main Mandrel 21.0 release"
-          #  inputs: '{"quarkus-version": "main", "version": "mandrel-21.0.0.0-Final", "build-from-source": "false"}'
-          #  workflow: 'base.yml'
-          ####
-          # Test Quarkus main with supported GraalVM versions using the release archives
-          ####
-          #- name: "Q main GraalVM-CE 20.3 release"
-          #  inputs: '{"quarkus-version": "main", "version": "vm-20.3.2", "build-from-source": "false", "distribution": "graalvm"}'
-          #  workflow: 'base.yml'
-          #- name: "Q main GraalVM-CE 21.0 release"
-          #  inputs: '{"quarkus-version": "main", "version": "vm-21.1.0", "build-from-source": "false", "distribution": "graalvm"}'
-          #  workflow: 'base.yml'
-    steps:
-    - name: Start workflow ${{ matrix.workflow }}
-      timeout-minutes: 10
-      run: |
-        WF_RESULT="500"
-        INPUTS=$(jq -c '. += {name: "${{ matrix.name }}"}' <<<$(echo '${{ matrix.inputs }}'))
-        echo ${INPUTS}
-        while [[ ${WF_RESULT} == "500" ]]
-        do
-          WF_RESULT=$(curl -s -X POST "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/workflows/${{ matrix.workflow }}/dispatches" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${WORKFLOW_TOKEN}" \
-            -d "{\"ref\":\"${GITHUB_REF}\",\"inputs\":${INPUTS}}" \
-            -w "%{http_code}")
-          sleep 30 # back off
-        done
-        if [[ ${WF_RESULT} == "204" ]]
-        then
-          WF_ID=$(curl -s -X GET "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/workflows/${{ matrix.workflow }}/runs" \
-            -H 'Accept: application/vnd.github.antiope-preview+json' \
-            -H "Authorization: Bearer ${WORKFLOW_TOKEN}" | jq '[.workflow_runs[]] | first | .id')
-          echo "Started ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${WF_ID}"
-          echo "WF_ID=${WF_ID}" >> ${GITHUB_ENV}
-        else
-          echo -e "Failed with:\n ${WF_RESULT}\n"
-          exit 1
-        fi
-    - name: Wait workflow ${{ matrix.workflow }}
-      if: false
-      run: |
-        WF_CONCLUSION="null"
-        WF_STATUS="inprogress"
-
-        while [[ ${WF_CONCLUSION} == "null" && ${WF_STATUS} != "\"completed\"" ]]
-        do
-          sleep 60
-          WF_RESULT=$(curl -s -X GET "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/workflows/${{ matrix.workflow }}/runs" \
-            -H 'Accept: application/vnd.github.antiope-preview+json' \
-            -H "Authorization: Bearer ${WORKFLOW_TOKEN}" | jq '.workflow_runs[] | select(.id == '${{ env.WF_ID }}')'
-          WF_CONCLUSION=$(echo ${WF_RESULT} | jq '.conclusion')
-          WF_STATUS=$(echo ${WF_RESULT} | jq '.status')
-          echo "Waiting for ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${{ env.WF_ID }}"
-          echo "Conclusion: ${WF_CONCLUSION}"
-          echo "Status: ${WF_STATUS}"
-        done
-
-        if [[ ${WF_CONCLUSION == "\"success\"" && ${WF_STATUS} == "\"completed\"" ]]
-        then
-          echo "Succeeded"
-        else
-          echo "Failed with: ${WF_CONCLUSION}"
-          exit 1
-        fi
+  ####
+  # Test Quarkus main with latest graal sources built as Mandrel and GraalVM
+  ####
+  q-main-mandrel-latest:
+    name: "Q main Mandrel build of latest graal"
+    uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+    with:
+      quarkus-version: "main"
+      version: "graal/master"
+      jdk: "ea"
+  q-main-mandrel-latest-win:
+    name: "Q main Mandrel build of latest graal on windows"
+    uses: zakkak/mandrel/.github/workflows/base-windows.yml@reusable-workflows
+    with:
+      quarkus-version: "main"
+      version: "graal/master"
+      jdk: "ea"
+  q-main-graal-latest:
+    name: "Q main GraalVM CE build of latest graal"
+    uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+    with:
+      quarkus-version: "main"
+      version: "graal/master"
+      distribution: "graalvm"
+  ####
+  # Test Quarkus main with 22_0-dev built as Mandrel and GraalVM
+  ####
+  q-main-mandrel-22_0-dev:
+    name: "Q main Mandrel build of 22.0-dev"
+    uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+    with:
+      quarkus-version: "main"
+      version: "mandrel/22.0"
+      jdk: "ea"
+      mandrel-packaging-version: "22.0"
+  q-main-mandrel-22_0-dev-win:
+    name: "Q main Mandrel build of 22.0-dev on windows"
+    uses: zakkak/mandrel/.github/workflows/base-windows.yml@reusable-workflows
+    with:
+      quarkus-version: "main"
+      version: "mandrel/22.0"
+      jdk: "ea"
+      mandrel-packaging-version: "22.0"
+  q-main-graal-22_0-dev:
+    name: "Q main GraalVM CE build of 22.0-dev"
+    uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+    with:
+      quarkus-version: "main"
+      repo: "oracle/graal"
+      version: "release/graal-vm/22.0"
+      distribution: "graalvm"
+  ####
+  # Test Quarkus with supported Mandrel versions using the Quay.io images
+  ####
+  # q-2_2-mandrel-21_2-quayio:
+  #   name: "Q 2.2 Mandrel 21.2 image from quay.io"
+  #   uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+  #   with:
+  #     quarkus-version: "2.2"
+  #     builder-image: "quay.io/quarkus/ubi-quarkus-mandrel:21.2-java11"
+  q-2_2-mandrel-21_3-quayio:
+    name: "Q 2.2 Mandrel 21.3 image from quay.io"
+    uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+    with:
+      quarkus-version: "2.2"
+      builder-image: "quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"
+  q-main-mandrel-21_2-quayio:
+    name: "Q main Mandrel 21.3 image from quay.io"
+    uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+    with:
+      quarkus-version: "main"
+      builder-image: "quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"
+  ####
+  # Test Quarkus main with supported Mandrel versions using the release archives
+  ####
+  #q-main-mandrel-20_3-release
+  #  name: "Q main Mandrel 20.3 release"
+  #  uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+  #  with:
+  #    quarkus-version: "main"
+  #     version: "mandrel-20.3.1.2-Final"
+  #     build-from-source: "false"
+  #q-main-mandrel-21_0-release
+  #  name: "Q main Mandrel 21.0 release"
+  #  uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+  #  with:
+  #    quarkus-version: "main"
+  #     version: "mandrel-21.0.0.0-Final"
+  #     build-from-source: "false"
+  ####
+  # Test Quarkus main with supported GraalVM versions using the release archives
+  ####
+  #q-main-graal-20_3-release
+  #  name: "Q main GraalVM-CE 20.3 release"
+  #  uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+  #  with:
+  #    quarkus-version: "main"
+  #     version: "vm-20.3.2"
+  #     build-from-source: "false"
+  #     distribution: "graalvm"
+  #q-main-graal-21_0-release
+  #  name: "Q main GraalVM-CE 21.0 release"
+  #  uses: zakkak/mandrel/.github/workflows/base.yml@reusable-workflows
+  #  with:
+  #    quarkus-version: "main"
+  #     version: "vm-21.1.0"
+  #     build-from-source: "false"
+  #     distribution: "graalvm"


### PR DESCRIPTION
* Allows the whole matrix to run under a single CI run while making the base workflow reusable by other branches so that we can stop replicating CI pipelines in release branches. This has the following benefits:
  1. The whole matrix runs a lot faster (~4h for all combinations instead of ~2h per combination in some cases)
     
     **Before**:
![image](https://user-images.githubusercontent.com/1435395/146616461-985ca22c-e04f-438c-9f32-b5b6fe01ccae.png)
     
     **After**: 
![image](https://user-images.githubusercontent.com/1435395/146616344-6162b4cf-0730-479e-8324-c14349e9ee23.png)
    
     
  2. It's much easier to understand what fails in the whole matrix by inspecting a single page (it used to be 8)
  3. We can now test the workflow in PRs that affect it
* Adds wrappers for workflow_dispatch, so that we can still run custom jobs with `gh workflow run`...
* Makes artifacts unique per reusable workflow inputs. This is necessary since when using reusable workflows and calling a reusable workflow multiple times from the same caller workflow will result in artifact-name collisions.
  
Special thanks to @gvre for:
* Making me aware of the GA of reusable workflows
* Reading my rants while I was exploring the uncharted waters of reusable workflows
* Helping me overcome some of the obstacles I faced while transitioning our pipeline from `workflow_dispatch` to `workflow_call`