### PR TITLE
CI: Don't use commit hash for release tags to handle latest in mandrel IT

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -83,6 +83,9 @@ jobs:
         if [ ${{ github.event.inputs.quarkus-version }} == "latest" ]
         then
           export QUARKUS_VERSION=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
+        elif $(expr match "${{ inputs.quarkus-version }}" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
+        then
+          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
         else
           export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ github.event.inputs.quarkus-repo }} | grep "refs/heads/${{ github.event.inputs.quarkus-version }}$\|refs/tags/${{ github.event.inputs.quarkus-version }}$" | cut -f 1)
         fi
@@ -499,7 +502,7 @@ jobs:
             Write-Host "Cannot find native-image tool. Quitting..."
             exit 1
           }
-          $QUARKUS_VERSION=${{ inputs.quarkus-version }}
+          $QUARKUS_VERSION=${{ needs.get-test-matrix.outputs.quarkus-version }}
           # Don't use SNAPSHOT version for 2.2 and release tags
           if (! ($QUARKUS_VERSION -match "^(2\.2|.*\.(Final|CR|Alpha|Beta)[0-9]?)$")) {
             $QUARKUS_VERSION="999-SNAPSHOT"

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -82,6 +82,9 @@ jobs:
         if [ ${{ inputs.quarkus-version }} == "latest" ]
         then
           export QUARKUS_VERSION=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
+        elif $(expr match "${{ inputs.quarkus-version }}" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
+        then
+          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
         else
           export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ inputs.quarkus-repo }} | grep "refs/heads/${{ inputs.quarkus-version }}$\|refs/tags/${{ inputs.quarkus-version }}$" | cut -f 1)
         fi
@@ -454,7 +457,7 @@ jobs:
           cd ${MANDREL_IT_PATH}
           export GRAALVM_HOME="${JAVA_HOME}"
           export PATH="${GRAALVM_HOME}/bin:$PATH"
-          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
+          export QUARKUS_VERSION=${{ needs.get-test-matrix.outputs.quarkus-version }}
           # Don't use SNAPSHOT version for 2.2 and release tags
           if ! $(expr match "$QUARKUS_VERSION" "^\(2\.2\|.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?\)$" > /dev/null)
           then


### PR DESCRIPTION
This allows job "mandrel-integration-tests" to run with the "latest" Quarkus release by using its tag as defined by job "get-test-matrix".