### PR TITLE
CI: Use 2.2.999 as the Quarkus version for 2.2 branch

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -303,7 +303,7 @@ jobs:
         if [ "${{ inputs.quarkus-version }}" == "2.2" ]
         then
           cd quarkus
-          bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ inputs.quarkus-version }}
+          bash ../workflow-mandrel/.github/update_quarkus_version.sh 2.2.999
         fi
     - name: Build quarkus
       run: |
@@ -400,7 +400,7 @@ jobs:
           if [ "${{ inputs.quarkus-version }}" == "2.2" ]
           then
             cd quarkus
-            bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ inputs.quarkus-version }}
+            bash ../workflow-mandrel/.github/update_quarkus_version.sh 2.2.999
           fi
       - name: Build with Maven
         if: startsWith(matrix.os-name, 'windows')

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -281,7 +281,7 @@ jobs:
         if [ "${{ inputs.quarkus-version }}" == "2.2" ]
         then
           cd quarkus
-          bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ inputs.quarkus-version }}
+          bash ../workflow-mandrel/.github/update_quarkus_version.sh 2.2.999
         fi
     - name: Build quarkus
       run: |
@@ -363,7 +363,7 @@ jobs:
           if [ "${{ inputs.quarkus-version }}" == "2.2" ]
           then
             cd quarkus
-            bash ../workflow-mandrel/.github/update_quarkus_version.sh ${{ inputs.quarkus-version }}
+            bash ../workflow-mandrel/.github/update_quarkus_version.sh 2.2.999
           fi
       - name: Build with Maven
         if: "!startsWith(matrix.os-name, 'windows')"


### PR DESCRIPTION
As of
https://github.com/Karm/mandrel-integration-tests/commit/672ddd28e13b3395938ac4963f5e911e18570b5d
mandrel-integration-tests expects the quarkus version to match
X.Y.Z.suffix