### PR TITLE
Add support for reporting results a la quarkus-ecosystem-ci style

### DIFF
--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//usr/bin/env jbang "$0" "$@" ; exit $?
+
+//DEPS org.kohsuke:github-api:1.101
+//DEPS info.picocli:picocli:4.2.0
+
+import org.kohsuke.github.*;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.TimeUnit;
+
+@Command(name = "report", mixinStandardHelpOptions = true,
+		description = "Takes care of updating an issue depending on the status of the build")
+class Report implements Runnable {
+
+	@Option(names = "token", description = "Github token to use when calling the Github API")
+	private String token;
+
+	@Option(names = "status", description = "The status of the CI run")
+	private String status;
+
+	@Option(names = "issueRepo", description = "The repository where the issue resides (i.e. quarkusio/quarkus)")
+	private String issueRepo;
+
+	@Option(names = "issueNumber", description = "The issue to update")
+	private Integer issueNumber;
+
+	@Option(names = "thisRepo", description = "The repository for which we are reporting the CI status")
+	private String thisRepo;
+
+	@Option(names = "runId", description = "The ID of the Github Action run for  which we are reporting the CI status")
+	private String runId;
+
+	@Override
+	public void run() {
+		try {
+			final boolean succeed = "success".equalsIgnoreCase(status);
+			if ("cancelled".equalsIgnoreCase(status)) {
+				System.out.println("Job status is `cancelled` - exiting");
+				System.exit(0);
+			}
+
+			System.out.println(String.format("The CI build had status %s.", status));
+
+			final GitHub github = new GitHubBuilder().withOAuthToken(token).build();
+			final GHRepository repository = github.getRepository(issueRepo);
+
+			final GHIssue issue = repository.getIssue(issueNumber);
+			if (issue == null) {
+				System.out.println(String.format("Unable to find the issue %s in project %s", issueNumber, issueRepo));
+				System.exit(-1);
+			} else {
+				System.out.println(String.format("Report issue found: %s - %s", issue.getTitle(), issue.getHtmlUrl().toString()));
+				System.out.println(String.format("The issue is currently %s", issue.getState().toString()));
+			}
+
+			if (succeed) {
+				if (issue != null  && isOpen(issue)) {
+					// close issue with a comment
+					final GHIssueComment comment = issue.comment(String.format("Build fixed:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId));
+					issue.close();
+					System.out.println(String.format("Comment added on issue %s - %s, the issue has also been closed", issue.getHtmlUrl().toString(), comment.getHtmlUrl().toString()));
+				} else {
+					System.out.println("Nothing to do - the build passed and the issue is already closed");
+				}
+			} else  {
+				if (isOpen(issue)) {
+					final GHIssueComment comment = issue.comment(String.format("The build is still failing:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId));
+					System.out.println(String.format("Comment added on issue %s - %s", issue.getHtmlUrl().toString(), comment.getHtmlUrl().toString()));
+				} else {
+					issue.reopen();
+					final GHIssueComment comment = issue.comment(String.format("Unfortunately, the build failed:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId));
+					System.out.println(String.format("Comment added on issue %s - %s, the issue has been re-opened", issue.getHtmlUrl().toString(), comment.getHtmlUrl().toString()));
+				}
+			}
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private static boolean isOpen(GHIssue issue) {
+		return (issue.getState() == GHIssueState.OPEN);
+	}
+	
+	public static void main(String... args) {
+		int exitCode = new CommandLine(new Report()).execute(args);
+		System.exit(exitCode);
+	}
+}

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -44,6 +44,18 @@ on:
       # builder-image:
       #   description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
       #   default: "null"
+      issue-number:
+        type: string
+        description: 'The issue number to report results to'
+        default: "null"
+      issue-repo:
+        type: string
+        description: 'The repository to report results to'
+        default: "graalvm/mandrel"
+    secrets:
+      ISSUE_BOT_TOKEN:
+        description: 'A token used to report results in GH issues'
+        required: false
 
 env:
   # Workaround testsuite locale issue
@@ -440,6 +452,23 @@ jobs:
         with:
           name: win-test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports.tgz'
+      - name: Setup jbang and report results
+        if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' }}
+        shell: bash
+        env:
+          BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
+        run: |
+          echo "Installing JBang"
+          wget https://github.com/jbangdev/jbang/releases/download/v0.87.0/jbang.zip
+          unzip jbang.zip
+          echo "Attempting to report results"
+          ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
+            token="${BOT_TOKEN}" \
+            status="${{ job.status }}" \
+            issueRepo="${{ inputs.issue-repo }}" \
+            issueNumber="${{ inputs.issue-number }}" \
+            thisRepo="${GITHUB_REPOSITORY}" \
+            runId="${GITHUB_RUN_ID}"
 
   mandrel-integration-tests:
     name: Q Mandrel IT
@@ -459,6 +488,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: graalvm/mandrel
+          fetch-depth: 1
+          path: workflow-mandrel
       - uses: actions/checkout@v2
         with:
           repository: Karm/mandrel-integration-tests
@@ -521,3 +555,20 @@ jobs:
         with:
           name: win-test-reports-mandrel-it-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports-mandrel-it.tgz'
+      - name: Setup jbang and report results
+        if: ${{ always() && github.repository == 'graalvm/mandrel' }}
+        shell: bash
+        env:
+          BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
+        run: |
+          echo "Installing JBang"
+          wget https://github.com/jbangdev/jbang/releases/download/v0.87.0/jbang.zip
+          unzip jbang.zip
+          echo "Attempting to report results"
+          ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
+            token="${BOT_TOKEN}" \
+            status="${{ job.status }}" \
+            issueRepo="Karm/mandrel-integration-tests" \
+            issueNumber="75" \
+            thisRepo="${GITHUB_REPOSITORY}" \
+            runId="${GITHUB_RUN_ID}"

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -44,6 +44,18 @@ on:
         type: string
         description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
         default: "null"
+      issue-number:
+        type: string
+        description: 'The issue number to report results to'
+        default: "null"
+      issue-repo:
+        type: string
+        description: 'The repository to report results to'
+        default: "graalvm/mandrel"
+    secrets:
+      ISSUE_BOT_TOKEN:
+        description: 'A token used to report results in GH issues'
+        required: false
 
 env:
   # Workaround testsuite locale issue
@@ -410,6 +422,22 @@ jobs:
         with:
           name: test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports.tgz'
+      - name: Setup jbang and report results
+        if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel'  }}
+        env:
+          BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
+        run: |
+          echo "Installing JBang"
+          wget https://github.com/jbangdev/jbang/releases/download/v0.87.0/jbang.zip
+          unzip jbang.zip
+          echo "Attempting to report results"
+          ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
+            token="${BOT_TOKEN}" \
+            status="${{ job.status }}" \
+            issueRepo="${{ inputs.issue-repo }}" \
+            issueNumber="${{ inputs.issue-number }}" \
+            thisRepo="${GITHUB_REPOSITORY}" \
+            runId="${GITHUB_RUN_ID}"
 
   mandrel-integration-tests:
     name: Q Mandrel IT
@@ -426,6 +454,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: graalvm/mandrel
+          fetch-depth: 1
+          path: workflow-mandrel
       - uses: actions/checkout@v2
         with:
           repository: Karm/mandrel-integration-tests
@@ -488,3 +521,19 @@ jobs:
         with:
           name: test-reports-mandrel-it-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports-mandrel-it.tgz'
+      - name: Setup jbang and report results
+        if: ${{ always() && github.repository == 'graalvm/mandrel'  }}
+        env:
+          BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
+        run: |
+          echo "Installing JBang"
+          wget https://github.com/jbangdev/jbang/releases/download/v0.87.0/jbang.zip
+          unzip jbang.zip
+          echo "Attempting to report results"
+          ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
+            token="${BOT_TOKEN}" \
+            status="${{ job.status }}" \
+            issueRepo="Karm/mandrel-integration-tests" \
+            issueNumber="75" \
+            thisRepo="${GITHUB_REPOSITORY}" \
+            runId="${GITHUB_RUN_ID}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,10 @@ jobs:
       quarkus-version: "main"
       version: "graal/master"
       jdk: "11/ea"
+      issue-number: "348"
+      issue-repo: "graalvm/mandrel"
+    secrets:
+      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
   q-main-mandrel-latest-win:
     name: "Q main M latest windows"
     uses: graalvm/mandrel/.github/workflows/base-windows.yml@default


### PR DESCRIPTION
This PR enables our CI runs to report results on github issues like [this one](https://github.com/quarkusio/quarkus/issues/8593) using a [bot account](https://github.com/mandrel-bot). The results can be reported in a per configuration manner, so that we don't have to spam people with false negatives from experimental configurations etc. People responsible for monitoring the stability of a configuration will be able to subscribe to the corresponding issue and get notified of changes.