### PR TITLE
CI: Fix CI issue reporting

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -452,9 +452,15 @@ jobs:
         with:
           name: win-test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports.tgz'
+
+  native-tests-report:
+    name: Report results on GitHub
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel'  }}
+    needs:
+      - native-tests
+    runs-on: ubuntu-latest
+    steps:
       - name: Setup jbang and report results
-        if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' }}
-        shell: bash
         env:
           BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
         run: |
@@ -464,7 +470,7 @@ jobs:
           echo "Attempting to report results"
           ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
             token="${BOT_TOKEN}" \
-            status="${{ job.status }}" \
+            status="${{ needs.native-tests.result }}" \
             issueRepo="${{ inputs.issue-repo }}" \
             issueNumber="${{ inputs.issue-number }}" \
             thisRepo="${GITHUB_REPOSITORY}" \

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -422,8 +422,15 @@ jobs:
         with:
           name: test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports.tgz'
+
+  native-tests-report:
+    name: Report results on GitHub
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel'  }}
+    needs:
+      - native-tests
+    runs-on: ubuntu-latest
+    steps:
       - name: Setup jbang and report results
-        if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel'  }}
         env:
           BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
         run: |
@@ -433,7 +440,7 @@ jobs:
           echo "Attempting to report results"
           ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
             token="${BOT_TOKEN}" \
-            status="${{ job.status }}" \
+            status="${{ needs.native-tests.result }}" \
             issueRepo="${{ inputs.issue-repo }}" \
             issueNumber="${{ inputs.issue-number }}" \
             thisRepo="${GITHUB_REPOSITORY}" \


### PR DESCRIPTION
The native-tests job is run using a matrix which results in multiple
instances of the job being run per workflow run. This resulted in
multiple reports being generated as well. So for instance if the
native-tests job would run 6 times, with only half of them passing the
workflow could end up opening and closing the corresponding GH issue 6
times, while we would like it to only open it once if closed or post a
message that the workflow is still failing if already open. By moving
the report logic to a separate job that depends on the native-tests job
and reports the aggregated result of all the instances of the latter we
achieve our goal.