### PR TITLE
CI: Fix issues related to quarkus-ecosystem-issue script

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -468,7 +468,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: Setup jbang and report results
         env:
           BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
@@ -570,9 +570,24 @@ jobs:
         with:
           name: win-test-reports-mandrel-it-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports-mandrel-it.tgz'
+
+  mandrel-integration-tests-report:
+    name: Report results on GitHub
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel'  }}
+    needs:
+      - mandrel-integration-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: graalvm/mandrel
+          fetch-depth: 1
+          path: workflow-mandrel
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: Setup jbang and report results
-        if: ${{ always() && github.repository == 'graalvm/mandrel' }}
-        shell: bash
         env:
           BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
         run: |
@@ -582,7 +597,7 @@ jobs:
           echo "Attempting to report results"
           ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
             token="${BOT_TOKEN}" \
-            status="${{ job.status }}" \
+            status="${{ needs.mandrel-integration-tests.result }}" \
             issueRepo="Karm/mandrel-integration-tests" \
             issueNumber="75" \
             thisRepo="${GITHUB_REPOSITORY}" \

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -438,7 +438,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: Setup jbang and report results
         env:
           BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
@@ -537,8 +537,24 @@ jobs:
         with:
           name: test-reports-mandrel-it-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports-mandrel-it.tgz'
+
+  mandrel-integration-tests-report:
+    name: Report results on GitHub
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel'  }}
+    needs:
+      - mandrel-integration-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: graalvm/mandrel
+          fetch-depth: 1
+          path: workflow-mandrel
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: Setup jbang and report results
-        if: ${{ always() && github.repository == 'graalvm/mandrel'  }}
         env:
           BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
         run: |
@@ -548,7 +564,7 @@ jobs:
           echo "Attempting to report results"
           ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
             token="${BOT_TOKEN}" \
-            status="${{ job.status }}" \
+            status="${{ needs.mandrel-integration-tests.result }}" \
             issueRepo="Karm/mandrel-integration-tests" \
             issueNumber="75" \
             thisRepo="${GITHUB_REPOSITORY}" \


### PR DESCRIPTION
The script depends on https://github.com/hub4j/github-api which fails with:

```
java.io.UncheckedIOException: java.io.IOException: Failed to set the custom verb
	at Report.run(quarkus-ecosystem-issue.java:99)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1769)
	at picocli.CommandLine.access$900(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2150)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2144)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:1975)
	at picocli.CommandLine.execute(CommandLine.java:1904)
	at Report.main(quarkus-ecosystem-issue.java:108)
Caused by: java.io.IOException: Failed to set the custom verb
	at org.kohsuke.github.Requester.setRequestMethod(Requester.java:759)
	at org.kohsuke.github.Requester.setupConnection(Requester.java:745)
	at org.kohsuke.github.Requester._to(Requester.java:388)
	at org.kohsuke.github.Requester.to(Requester.java:336)
	at org.kohsuke.github.GHIssue.edit(GHIssue.java:239)
	at org.kohsuke.github.GHIssue.close(GHIssue.java:253)
	at Report.run(quarkus-ecosystem-issue.java:82)
	... 8 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field protected java.lang.String java.net.HttpURLConnection.method accessible: module java.base does not "opens java.net" to unnamed module @6c38726a
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at org.kohsuke.github.Requester.setRequestMethod(Requester.java:756)
	... 14 more
```

when using Java 17. This PR forces the use of Java 11 when reporting issues.