### PR TITLE
CI: Re-enable running image-builder on module path

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -359,8 +359,8 @@ jobs:
       - get-jdk
       - get-test-matrix
     runs-on: windows-2019
-    env:
-      USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
+    # env:
+    #   USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:
@@ -509,7 +509,7 @@ jobs:
       MAVEN_OPTS: -Xmx1g
       # Don't perform performance checks since GH runners are not that stable
       FAIL_ON_PERF_REGRESSION: false
-      USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
+      # USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -331,7 +331,7 @@ jobs:
     env:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g
-      USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
+      # USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:
@@ -475,7 +475,7 @@ jobs:
       MAVEN_OPTS: -Xmx1g
       # Don't perform performance checks since GH runners are not that stable
       FAIL_ON_PERF_REGRESSION: false
-      USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
+      # USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
     timeout-minutes: 40
     strategy:
       fail-fast: false


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/25986 allows Quarkus native to
work with the image-builder running on module path.

Reverts: #388, #390, #391

Closes: #389