### PR TITLE
CI: Use maven wrapper to build Quarkus

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -309,7 +309,7 @@ jobs:
     - name: Build quarkus
       run: |
         cd ${QUARKUS_PATH}
-        mvn -e -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml  -Dquickly
+        ./mvnw -e -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml  -Dquickly
     - name: Tar Maven Repo
       shell: bash
       run: tar -czvf maven-repo.tgz -C ~ .m2/repository


### PR DESCRIPTION
Fixes build failures for Gradle Plugin

```
FAILURE: Build failed with an exception.
> Task :gradle-application-plugin:compileJava FAILED
* What went wrong:
Execution failed for task ':gradle-application-plugin:compileJava'.
> Could not resolve all files for configuration ':gradle-application-plugin:compileClasspath'.
   > Could not find plexus-utils-3.4.1.jar (org.codehaus.plexus:plexus-utils:3.4.1).
     Searched in the following locations:
         file:/home/runner/.m2/repository/org/codehaus/plexus/plexus-utils/3.4.1/plexus-utils-3.4.1.jar
```