### PR TITLE
Only report failures to mandrel-integration-tests when Mandrel IT runs

### DIFF
--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -56,8 +56,8 @@ class Report implements Runnable {
 	public void run() {
 		try {
 			final boolean succeed = "success".equalsIgnoreCase(status);
-			if ("cancelled".equalsIgnoreCase(status)) {
-				System.out.println("Job status is `cancelled` - exiting");
+			if ("cancelled".equalsIgnoreCase(status) || "skipped".equalsIgnoreCase(status)) {
+				System.out.println("Job status is `cancelled` or `skipped` - exiting");
 				System.exit(0);
 			}
 

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -584,7 +584,7 @@ jobs:
 
   mandrel-integration-tests-report:
     name: Report results on GitHub
-    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' }}
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' && needs.mandrel-integration-tests.result != 'skipped' }}
     needs:
       - mandrel-integration-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -552,7 +552,7 @@ jobs:
 
   mandrel-integration-tests-report:
     name: Report results on GitHub
-    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' }}
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' && needs.mandrel-integration-tests.result != 'skipped' }}
     needs:
       - mandrel-integration-tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Failures to build Mandrel/Graal or Quarkus should not result in openning GH issues to mandrel-integration-tests