### PR TITLE
Add workflow additions for uploading build stats

### DIFF
--- a/.github/import_stats.sh
+++ b/.github/import_stats.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Import graal stats into collector
+#
+# Usage:
+#     DIR=quarkus/ TAG=gha-jdk11-mandrel-22.3.0-dev URL=http://127.0.0.1:8080/api/v1/image-stats bash import_stats.sh
+#
+
+#set -e
+
+usage() {
+  local missing="$1"
+  echo "Error: '$missing' must be specified!" 1>&2
+  echo 1>&2
+  echo "usage:" 1>&2
+  echo "  DIR=quarkus/ TAG=gha-jdk11-mandrel-22.3.0-dev TOKEN=<token> URL=http://127.0.0.1:8080/api/v1/image-stats bash import_stats.sh" 1>&2
+  exit 1   
+}
+
+if [ "${DIR}_" == "_" ]; then
+  usage "DIR"
+elif [ "${TAG}_" == "_" ]; then
+  usage "TAG"
+elif [ "${URL}_" == "_" ]; then
+  usage "URL"
+elif [ "${TOKEN}_" == "_" ]; then
+  usage "TOKEN"
+fi
+
+for bs in $(find $DIR -name \*build-output-stats.json); do
+  f=$(echo "$bs" | sed 's/\(.*\)-build-output-stats\.json/\1/g')
+  d=$(dirname $bs)
+  ts="${f}-timing-stats.json"
+  # import the stat
+  stat_id=$(curl -s -w '\n' -H "Content-Type: application/json" \
+            -H "token: $TOKEN" --post302 --data "@$(pwd)/$bs" "$URL/import?t=$TAG" | jq .id)
+  # update timing info
+  curl -s -w '\n' -H "Content-Type: application/json" -H "token: $TOKEN" \
+	  -X PUT --data "@$ts" "$URL/$stat_id" > /dev/null
+done

--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -55,6 +55,10 @@ on:
         type: string
         description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
         default: "null"
+      build-stats-tag:
+        type: string
+        description: 'The tag to use for build stats uploads of native tests (e.g. 22.3.0-dev-jdk17-prepatch-x)'
+        default: "null"
 
 jobs:
   delegate:
@@ -69,3 +73,6 @@ jobs:
       build-type: ${{ github.event.inputs.build-type }}
       jdk: ${{ github.event.inputs.jdk }}
       # builder-image: ${{ github.event.inputs.builder-image }}
+      build-stats-tag: ${{ github.event.inputs.build-stats-tag }}
+    secrets:
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -52,9 +52,16 @@ on:
         type: string
         description: 'The issue number to report results to mandrel-integration-tests'
         default: "null"
+      build-stats-tag:
+        type: string
+        description: 'The tag to use for build stats upload of native tests (e.g. 22.3.0-dev-jdk17-mytest-patch-before)'
+        default: "null"
     secrets:
       ISSUE_BOT_TOKEN:
         description: 'A token used to report results in GH issues'
+        required: false
+      UPLOAD_COLLECTOR_TOKEN:
+        description: 'A token used to report build statistics to a collector'
         required: false
 
 env:
@@ -74,6 +81,7 @@ env:
   QUARKUS_PATH: ${{ github.workspace }}\quarkus
   MANDREL_PACKAGING_REPO: ${{ github.workspace }}\mandrel-packaging
   MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
+  COLLECTOR_URL: https://stage-collector.foci.life/api/v1/image-stats
 
 jobs:
   build-vars:
@@ -508,6 +516,16 @@ jobs:
         with:
           name: win-test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports.tgz'
+      - name: Collect build JSON stats
+        if: ${{ always() && inputs.build-stats-tag != 'null' }}
+        shell: bash
+        run: find . -name '*runner*.json' | tar czvf build-stats.tgz -T -
+      - name: Upload build JSON stats
+        if: ${{ always() && inputs.build-stats-tag != 'null' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-stats-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+          path: 'build-stats.tgz'
 
   native-tests-report:
     name: Report results on GitHub
@@ -540,6 +558,36 @@ jobs:
             issueNumber="${{ inputs.issue-number }}" \
             thisRepo="${GITHUB_REPOSITORY}" \
             runId="${GITHUB_RUN_ID}"
+
+  native-tests-stats-upload:
+    name: Upload build stats to collector
+    if: ${{ always() && inputs.build-stats-tag != 'null' }}
+    needs:
+      - native-tests
+      - get-test-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-test-matrix.outputs.tests-matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: graalvm/mandrel
+          fetch-depth: 1
+          path: workflow-mandrel
+      - uses: actions/download-artifact@v1
+        with:
+          name: build-stats-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+          path: .
+      - name: Extract and import build stats
+        env:
+          UPLOAD_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+        shell: bash
+        run: |
+          tar -xf build-stats.tgz
+          export BUILD_STATS_TAG="$(echo ${{ inputs.build-stats-tag }})"
+          echo "Tag for stat upload is going to be: '${BUILD_STATS_TAG}'"
+          DIR=quarkus/ TAG="${BUILD_STATS_TAG}" TOKEN="${UPLOAD_TOKEN}" URL="${COLLECTOR_URL}" bash workflow-mandrel/.github/import_stats.sh
 
   mandrel-integration-tests:
     name: Q Mandrel IT

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -55,6 +55,10 @@ on:
         type: string
         description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
         default: "null"
+      build-stats-tag:
+        type: string
+        description: 'The tag to use for build stats uploads of native tests (e.g. 22.3.0-dev-jdk17-prepatch-x)'
+        default: "null"
 
 jobs:
   delegate:
@@ -69,3 +73,6 @@ jobs:
       build-type: ${{ github.event.inputs.build-type }}
       jdk: ${{ github.event.inputs.jdk }}
       builder-image: ${{ github.event.inputs.builder-image }}
+      build-stats-tag: ${{ github.event.inputs.build-stats-tag }}
+    secrets:
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -51,10 +51,16 @@ on:
       mandrel-it-issue-number:
         type: string
         description: 'The issue number to report results to mandrel-integration-tests'
+      build-stats-tag:
+        type: string
+        description: 'The tag to use for build stats upload of native tests (e.g. 22.3.0-dev-jdk17-mytest-patch-before)'
         default: "null"
     secrets:
       ISSUE_BOT_TOKEN:
         description: 'A token used to report results in GH issues'
+        required: false
+      UPLOAD_COLLECTOR_TOKEN:
+        description: 'A token used to report build statistics to a collector'
         required: false
 
 env:
@@ -73,6 +79,7 @@ env:
   QUARKUS_PATH: ${{ github.workspace }}/quarkus
   MANDREL_IT_PATH: ${{ github.workspace }}/mandrel-integration-tests
   MANDREL_PACKAGING_REPO: ${{ github.workspace }}/mandrel-packaging
+  COLLECTOR_URL: https://stage-collector.foci.life/api/v1/image-stats
 
 jobs:
   build-vars:
@@ -475,6 +482,16 @@ jobs:
         with:
           name: test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports.tgz'
+      - name: Collect build JSON stats
+        if: ${{ always() && inputs.build-stats-tag != 'null' }}
+        shell: bash
+        run: find . -name '*runner*.json' | tar czvf build-stats.tgz -T -
+      - name: Upload build JSON stats
+        if: ${{ always() && inputs.build-stats-tag != 'null' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-stats-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+          path: 'build-stats.tgz'
 
   native-tests-report:
     name: Report results on GitHub
@@ -507,6 +524,36 @@ jobs:
             issueNumber="${{ inputs.issue-number }}" \
             thisRepo="${GITHUB_REPOSITORY}" \
             runId="${GITHUB_RUN_ID}"
+
+  native-tests-stats-upload:
+    name: Upload build stats to collector
+    if: ${{ always() && inputs.build-stats-tag != 'null' }}
+    needs:
+      - native-tests
+      - get-test-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-test-matrix.outputs.tests-matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: graalvm/mandrel
+          fetch-depth: 1
+          path: workflow-mandrel
+      - uses: actions/download-artifact@v1
+        with:
+          name: build-stats-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+          path: .
+      - name: Extract and import build stats
+        env:
+          UPLOAD_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+        shell: bash
+        run: |
+          tar -xf build-stats.tgz
+          export BUILD_STATS_TAG="$(echo ${{ inputs.build-stats-tag }})"
+          echo "Tag for stat upload is going to be: '${BUILD_STATS_TAG}'"
+          DIR=quarkus/ TAG="${BUILD_STATS_TAG}" TOKEN="${UPLOAD_TOKEN}" URL="${COLLECTOR_URL}" bash workflow-mandrel/.github/import_stats.sh
 
   mandrel-integration-tests:
     name: Q Mandrel IT

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,8 +42,10 @@ jobs:
       issue-number: "348"
       issue-repo: "graalvm/mandrel"
       mandrel-it-issue-number: "75"
+      build-stats-tag: "gha-linux-qmain-mlatest-jdk11ea"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   q-main-mandrel-latest-win:
     name: "Q main M latest windows"
     uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
@@ -54,8 +56,10 @@ jobs:
       issue-number: "398"
       issue-repo: "graalvm/mandrel"
       mandrel-it-issue-number: "103"
+      build-stats-tag: "gha-win-qmain-mlatest-jdk11ea"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   q-main-graal-latest:
     name: "Q main G latest"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
@@ -63,6 +67,9 @@ jobs:
       quarkus-version: "main"
       version: "graal/master"
       build-type: "graal-source"
+      build-stats-tag: "gha-linux-qmain-glatest-jdk11"
+    secrets:
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   q-main-mandrel-17-latest:
     name: "Q main M 17 latest"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
@@ -73,8 +80,10 @@ jobs:
       issue-number: "399"
       issue-repo: "graalvm/mandrel"
       mandrel-it-issue-number: "102"
+      build-stats-tag: "gha-linux-qmain-mlatest-jdk17ea"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   q-main-mandrel-17-latest-win:
     name: "Q main M 17 latest windows"
     uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
@@ -85,8 +94,10 @@ jobs:
       issue-number: "400"
       issue-repo: "graalvm/mandrel"
       mandrel-it-issue-number: "104"
+      build-stats-tag: "gha-win-qmain-mlatest-jdk17ea"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   q-main-graal-17-latest:
     name: "Q main G 17 latest"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
@@ -95,6 +106,9 @@ jobs:
       version: "graal/master"
       build-type: "graal-source"
       jdk: "17/ea"
+      build-stats-tag: "gha-linux-qmain-glatest-jdk17ea"
+    secrets:
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
   # Test Quarkus main with 22_0-dev built as Mandrel and GraalVM
   ####


### PR DESCRIPTION
Draft PR for now until https://github.com/quarkusio/quarkus/pull/26612 is in. This is a workflow change
that automatically uploads json stats to the collector. Tested in:

https://github.com/jerboaa/graal/actions/runs/2663524344
https://github.com/jerboaa/graal/actions/runs/2662282326

Example stats collected:

```
curl -s -w '\n' -H "Content-Type: application/json" -H "token: $token" https://stage-collector.foci.life/api/v1/image-stats/tag/gha-jdk11-22.3.0-dev-test | jq '.[] | select(.img_name == "quarkus-integration-test-webjars-locator-999-SNAPSHOT-runner")'
{
  "id": 65,
  "created_at": "2022-07-13T10:29:29.881+00:00",
  "tag": "gha-jdk11-22.3.0-dev-test",
  "img_name": "quarkus-integration-test-webjars-locator-999-SNAPSHOT-runner",
  "generator_version": "GraalVM 22.3.0-dev85ecf61e Java 17 Mandrel Distribution",
  "image_size_stats": {
    "id": 65,
    "total_bytes": 52315600,
    "code_cache_bytes": 21003984,
    "heap_bytes": 30965760,
    "other_bytes": 345856,
    "debuginfo_bytes": 0
  },
  "jni_classes_stats": {
    "id": 257,
    "classes": 65,
    "fields": 75,
    "methods": 56
  },
  "reflection_stats": {
    "id": 259,
    "classes": 441,
    "fields": 108,
    "methods": 1620
  },
  "build_perf_stats": {
    "id": 65,
    "total_build_time_sec": 191.293,
    "num_cpu_cores": 2,
    "total_machine_memory": 7283843072,
    "peak_rss_bytes": 3253919744,
    "cpu_load": 1.9418087182823682
  },
  "total_classes_stats": {
    "id": 260,
    "classes": 11965,
    "fields": 26135,
    "methods": 95555
  },
  "reachability_stats": {
    "id": 258,
    "classes": 10716,
    "fields": 15416,
    "methods": 53982
  }
}
```

One limitation of this is that in `base-wrapper.yml` we already specify 10 inputs (10 is max). If we want a custom tag injected, e.g. to test changes of pre/post patches, then we need to get rid of one input.

