### PR TITLE
Reduce set of inputs for workflow dispatch

### DIFF
--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -33,14 +33,15 @@ on:
         type: string
         description: 'Mandrel packaging repository to be used'
         default: "graalvm/mandrel-packaging"
-      distribution:
-        type: string
-        description: 'Distribution to build, mandrel or graalvm'
-        default: "mandrel"
-      build-from-source:
-        type: boolean
-        description: 'Build Mandrel from source instead of grabing a release'
-        default: true
+      build-type:
+        type: choice
+        description: 'Build distribution (mandrel/graal) from source or use released binaries'
+        default: "mandrel-source"
+        options:
+          - "mandrel-source"
+          - "graal-source"
+          - "mandrel-release"
+          - "graal-release"
       jdk:
         type: choice
         description: 'OpenJDK to use. One of 11/ga, 11/ea, 17/ga, 17/ea (/ga and /ea suffixes are only relevant when building from source)'
@@ -65,7 +66,6 @@ jobs:
       version: ${{ github.event.inputs.version }}
       mandrel-packaging-version: ${{ github.event.inputs.mandrel-packaging-version }}
       mandrel-packaging-repo: ${{ github.event.inputs.mandrel-packaging-repo }}
-      distribution: ${{ github.event.inputs.distribution }}
-      build-from-source: ${{ fromJson(github.event.inputs.build-from-source) }}
+      build-type: ${{ github.event.inputs.build-type }}
       jdk: ${{ github.event.inputs.jdk }}
       # builder-image: ${{ github.event.inputs.builder-image }}

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -20,10 +20,6 @@ on:
         type: string
         description: 'The Mandrel/Graal repository to be used'
         default: 'graalvm/mandrel'
-      distribution:
-        type: string
-        description: 'Distribution to build, mandrel or graalvm'
-        default: "mandrel"
       mandrel-packaging-version:
         type: string
         description: 'Mandrel packaging version to test (branch, tag, or commit)'
@@ -32,10 +28,10 @@ on:
         type: string
         description: 'Mandrel packaging repository to be used'
         default: "graalvm/mandrel-packaging"
-      build-from-source:
-        type: boolean
-        description: 'Build Mandrel from source instead of grabing a release'
-        default: true
+      build-type:
+        type: string
+        description: 'Build distribution (Mandrel/GraalVM) from source or grab a release'
+        default: "mandrel-source"
       jdk:
         type: string
         description: 'OpenJDK to use. One of 11/ga, 11/ea, 17/ga, 17/ea (/ga and /ea suffixes are only relevant when building from source)'
@@ -80,6 +76,47 @@ env:
   MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
 
 jobs:
+  build-vars:
+    name: Set distribution and build-from-source variables based on build-type
+    runs-on: ubuntu-latest
+    outputs:
+      build-from-source: ${{ steps.source-build.outputs.build-from-source }}
+      distribution: ${{ steps.distro.outputs.distribution }}
+    steps:
+    - name: Set build-from-source output
+      id: source-build
+      run: |
+        echo "${{ inputs.build-type }}"
+        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f2)
+        if [ "${bfs_token}" == "release" ]
+        then
+          source_build=false
+        elif [ "${bfs_token}" == "source" ]
+        then
+          source_build=true
+        else
+          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
+          exit 1
+        fi
+        echo "source_build=$source_build"
+        echo "::set-output name=build-from-source::$source_build"
+    - name: Set distribution output
+      id: distro
+      run: |
+        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f1)
+        if [ "${bfs_token}" == "graal" ]
+        then
+          distro="graalvm"
+        elif [ "${bfs_token}" == "mandrel" ]
+        then
+          distro="mandrel"
+        else
+          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
+          exit 1
+        fi
+        echo "distro=$distro"
+        echo "::set-output name=distribution::$distro"
+
   get-test-matrix:
     name: Get test matrix
     runs-on: ubuntu-latest
@@ -121,9 +158,10 @@ jobs:
     runs-on: windows-2019
     needs:
       - get-test-matrix
+      - build-vars
     steps:
     - uses: actions/checkout@v2
-      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       with:
         repository: ${{ inputs.repo }}
         fetch-depth: 1
@@ -134,26 +172,26 @@ jobs:
       with:
         python-version: '3.8'
     - name: Checkout MX
-      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       run: |
         VERSION=$(find ${MANDREL_REPO} -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
         ./mx/mx --version
       shell: bash
     - uses: actions/checkout@v2
-      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       with:
         repository: ${{ inputs.mandrel-packaging-repo }}
         ref: ${{ inputs.mandrel-packaging-version }}
         path: ${{ env.MANDREL_PACKAGING_REPO }}
     - uses: actions/cache@v2.1.5
-      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
     - name: Get OpenJDK with static libs
-      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       run: |
         $wc = New-Object System.Net.WebClient
         $wc.DownloadFile("https://api.adoptium.net/v3/binary/latest/${{ inputs.jdk }}/windows/x64/jdk/hotspot/normal/eclipse", "$Env:temp\jdk.zip")
@@ -165,7 +203,7 @@ jobs:
         Remove-Item -Recurse "$Env:temp\jdk-*"
         & $Env:JAVA_HOME\bin\java -version
     - name: Build Mandrel
-      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       run: |
         cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
         Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
@@ -181,11 +219,11 @@ jobs:
         Remove-Item -Recurse $Env:JAVA_HOME
         Move-Item -Path $Env:MANDREL_HOME -Destination $Env:JAVA_HOME
     - name: Archive JDK
-      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       shell: bash
       run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
     - name: Persist Mandrel build
-      if: inputs.build-from-source == true && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       uses: actions/upload-artifact@v2
       with:
         name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -196,9 +234,10 @@ jobs:
     runs-on: windows-2019
     needs:
       - get-test-matrix
+      - build-vars
     steps:
     - uses: actions/checkout@v2
-      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       with:
         repository: ${{ inputs.repo }}
         fetch-depth: 1
@@ -209,20 +248,20 @@ jobs:
       with:
         python-version: '3.8'
     - name: Checkout MX
-      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       run: |
         VERSION=$(find graal -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
         ./mx/mx --version
       shell: bash
     - uses: actions/cache@v2.1.5
-      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
     - name: Build graalvm native-image
-      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       run: |
         cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
         Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
@@ -240,11 +279,11 @@ jobs:
         mv ${graalvm-home} $Env:JAVA_HOME
         & $Env:JAVA_HOME\bin\native-image --version
     - name: Archive JDK
-      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       shell: bash
       run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
     - name: Persist GraalVM CE build
-      if: inputs.build-from-source == true && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       uses: actions/upload-artifact@v2
       with:
         name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -255,9 +294,10 @@ jobs:
     runs-on: windows-2019
     needs:
       - get-test-matrix
+      - build-vars
     steps:
     - name: Get Mandrel ${{ inputs.version }}
-      if: inputs.build-from-source == false && inputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == false && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       run: |
         $VERSION="${{ inputs.version }}"
         $VERSION_SHORT=@($VERSION -replace 'mandrel-')
@@ -268,7 +308,7 @@ jobs:
         Move-Item -Path "$Env:temp\mandrel-*" -Destination $Env:JAVA_HOME
         & $Env:JAVA_HOME\bin\native-image --version
     - name: Get GraalVM CE ${{ inputs.version }}
-      if: inputs.build-from-source == false && inputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == false && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       run: |
         $VERSION="${{ inputs.version }}"
         $VERSION_SHORT=@($VERSION -replace 'vm-')
@@ -289,11 +329,11 @@ jobs:
     #     Move-Item -Path "$Env:temp\jdk-*" -Destination $Env:JAVA_HOME
     #     & $Env:JAVA_HOME\bin\java -version
     - name: Archive JDK
-      if: inputs.build-from-source == false #|| inputs.builder-image != 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == false #|| inputs.builder-image != 'null'
       shell: bash
       run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
     - name: Persist Mandrel/GraalVM or OpenJDK
-      if: inputs.build-from-source == false #|| inputs.builder-image != 'null'
+      if: fromJson(needs.build-vars.outputs.build-from-source) == false #|| inputs.builder-image != 'null'
       uses: actions/upload-artifact@v2
       with:
         name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -33,14 +33,15 @@ on:
         type: string
         description: 'Mandrel packaging repository to be used'
         default: "graalvm/mandrel-packaging"
-      distribution:
-        type: string
-        description: 'Distribution to build, mandrel or graalvm'
-        default: "mandrel"
-      build-from-source:
-        type: boolean
-        description: 'Build Mandrel from source instead of grabing a release'
-        default: true
+      build-type:
+        type: choice
+        description: 'Build distribution (graal/mandrel) from source or use released binaries'
+        default: "mandrel-source"
+        options:
+          - "mandrel-source"
+          - "graal-source"
+          - "mandrel-release"
+          - "graal-release"
       jdk:
         type: choice
         description: 'OpenJDK to use. One of 11/ga, 11/ea, 17/ga, 17/ea (/ga and /ea suffixes are only relevant when building from source)'
@@ -65,7 +66,6 @@ jobs:
       version: ${{ github.event.inputs.version }}
       mandrel-packaging-version: ${{ github.event.inputs.mandrel-packaging-version }}
       mandrel-packaging-repo: ${{ github.event.inputs.mandrel-packaging-repo }}
-      distribution: ${{ github.event.inputs.distribution }}
-      build-from-source: ${{ fromJson(github.event.inputs.build-from-source) }}
+      build-type: ${{ github.event.inputs.build-type }}
       jdk: ${{ github.event.inputs.jdk }}
       builder-image: ${{ github.event.inputs.builder-image }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -28,14 +28,10 @@ on:
         type: string
         description: 'Mandrel packaging repository to be used'
         default: "graalvm/mandrel-packaging"
-      distribution:
+      build-type:
         type: string
-        description: 'Distribution to build, mandrel or graalvm'
-        default: "mandrel"
-      build-from-source:
-        type: boolean
-        description: 'Build Mandrel from source instead of grabing a release'
-        default: true
+        description: 'Build distribution (Mandrel/GraalVM) from source or grab a release'
+        default: "mandrel-source"
       jdk:
         type: string
         description: 'OpenJDK to use. One of 11/ga, 11/ea, 17/ga, 17/ea (/ga and /ea suffixes are only relevant when building from source)'
@@ -79,6 +75,47 @@ env:
   MANDREL_PACKAGING_REPO: ${{ github.workspace }}/mandrel-packaging
 
 jobs:
+  build-vars:
+    name: Set distribution and build-from-source variables based on build-type
+    runs-on: ubuntu-latest
+    outputs:
+      build-from-source: ${{ steps.source-build.outputs.build-from-source }}
+      distribution: ${{ steps.distro.outputs.distribution }}
+    steps:
+    - name: Set build-from-source output
+      id: source-build
+      run: |
+        echo "${{ inputs.build-type }}"
+        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f2)
+        if [ "${bfs_token}" == "release" ]
+        then
+          source_build=false
+        elif [ "${bfs_token}" == "source" ]
+        then
+          source_build=true
+        else
+          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
+          exit 1
+        fi
+        echo "source_build=$source_build"
+        echo "::set-output name=build-from-source::$source_build"
+    - name: Set distribution output
+      id: distro
+      run: |
+        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f1)
+        if [ "${bfs_token}" == "graal" ]
+        then
+          distro="graalvm"
+        elif [ "${bfs_token}" == "mandrel" ]
+        then
+          distro="mandrel"
+        else
+          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
+          exit 1
+        fi
+        echo "distro=$distro"
+        echo "::set-output name=distribution::$distro"
+
   get-test-matrix:
     name: Get test matrix
     runs-on: ubuntu-latest
@@ -120,9 +157,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
+      - build-vars
     steps:
     - uses: actions/checkout@v2
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       with:
         repository: ${{ inputs.repo }}
         fetch-depth: 1
@@ -133,25 +171,25 @@ jobs:
       with:
         python-version: '3.8'
     - name: Checkout MX
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       run: |
         VERSION=$(find ${MANDREL_REPO} -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_PATH}
         ./mx/mx --version
     - uses: actions/checkout@v2
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       with:
         repository: ${{ inputs.mandrel-packaging-repo }}
         ref: ${{ inputs.mandrel-packaging-version }}
         path: ${{ env.MANDREL_PACKAGING_REPO }}
     - uses: actions/cache@v2.1.5
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
     - name: Get OpenJDK with static libs
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       run: |
         curl -sL https://api.adoptium.net/v3/binary/latest/${{ inputs.jdk }}/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
         curl -sL https://api.adoptium.net/v3/binary/latest/${{ inputs.jdk }}/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
@@ -161,7 +199,7 @@ jobs:
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java --version
     - name: Build Mandrel
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       run: |
         ${JAVA_HOME}/bin/java -ea ${MANDREL_PACKAGING_REPO}/build.java \
           --mx-home ${MX_PATH} \
@@ -171,7 +209,7 @@ jobs:
         ${MANDREL_HOME}/bin/native-image --version
         mv mandrel-java*-linux-amd64-*.tar.gz ${{ github.workspace }}/jdk.tgz
     - name: Persist Mandrel build
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       uses: actions/upload-artifact@v2
       with:
         name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -182,9 +220,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
+      - build-vars
     steps:
     - uses: actions/checkout@v2
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       with:
         repository: ${{ inputs.repo }}
         fetch-depth: 1
@@ -195,34 +234,34 @@ jobs:
       with:
         python-version: '3.8'
     - name: Checkout MX
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       run: |
         VERSION=$(find graal -name "suite.py" -exec grep mxversion {} + | cut -d '"' -f 4 | sort --unique --reverse | head -n 1)
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_PATH}
         ./mx/mx --version
     - uses: actions/cache@v2.1.5
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
     - name: Get labs OpenJDK
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       run: |
         mkdir jdk-dl
         ${MX_PATH}/mx --java-home= fetch-jdk --java-distribution labsjdk-ce-$(echo ${{ inputs.jdk }} | cut -d / -f 1) --to jdk-dl --alias ${JAVA_HOME}
     - name: Build graalvm native-image
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       run: |
         cd graal/substratevm
         ${MX_PATH}/mx --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal,svml" build
         mv $(${MX_PATH}/mx --native=native-image,lib:jvmcicompiler,lib:native-image-agent,lib:native-image-diagnostics-agent --components="Native Image,LibGraal,svml" graalvm-home) ${MANDREL_HOME}
         ${MANDREL_HOME}/bin/native-image --version
     - name: Tar GraalVM
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       run: tar czvf jdk.tgz  -C $(dirname ${MANDREL_HOME}) $(basename ${MANDREL_HOME})
-    - name: Persist Mandrel build
-      if: ${{ inputs.build-from-source == true && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
+    - name: Persist GraalVM build
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       uses: actions/upload-artifact@v2
       with:
         name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -233,16 +272,17 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
+      - build-vars
     steps:
     - name: Get Mandrel ${{ inputs.version }}
-      if: ${{ inputs.build-from-source == false && inputs.distribution == 'mandrel' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == false && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       run: |
         VERSION=${{ inputs.version }}
         curl \
           -sL ${GITHUB_SERVER_URL}/graalvm/mandrel/releases/download/${VERSION}/mandrel-java$(echo ${{ inputs.jdk }} | cut -d / -f 1)-linux-amd64-${VERSION##mandrel-}.tar.gz \
           -o jdk.tgz
     - name: Get GraalVM CE ${{ inputs.version }}
-      if: ${{ inputs.build-from-source == false && inputs.distribution == 'graalvm' && inputs.builder-image == 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == false && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       run: |
         VERSION=${{ inputs.version }}
         curl \
@@ -258,7 +298,7 @@ jobs:
       run: |
         curl -sL https://api.adoptium.net/v3/binary/latest/${{ inputs.jdk }}/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tgz
     - name: Persist Mandrel or OpenJDK
-      if: ${{ inputs.build-from-source == false || inputs.builder-image != 'null' }}
+      if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == false || inputs.builder-image == 'null'}}
       uses: actions/upload-artifact@v2
       with:
         name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
     with:
       quarkus-version: "main"
       version: "graal/master"
-      distribution: "graalvm"
+      build-type: "graal-source"
   q-main-mandrel-17-latest:
     name: "Q main M 17 latest"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
@@ -93,7 +93,7 @@ jobs:
     with:
       quarkus-version: "main"
       version: "graal/master"
-      distribution: "graalvm"
+      build-type: "graal-source"
       jdk: "17/ea"
   ####
   # Test Quarkus main with 22_0-dev built as Mandrel and GraalVM
@@ -121,7 +121,7 @@ jobs:
   #     quarkus-version: "main"
   #     repo: "oracle/graal"
   #     version: "release/graal-vm/22.0"
-  #     distribution: "graalvm"
+  #     built-type: "graal-source"
   ####
   # Test Quarkus with supported Mandrel versions using the Quay.io images
   ####
@@ -146,14 +146,14 @@ jobs:
   #  with:
   #    quarkus-version: "main"
   #     version: "mandrel-20.3.1.2-Final"
-  #     build-from-source: "false"
+  #     built-type: "mandrel-release"
   #q-main-mandrel-21_0-release
   #  name: "Q main M 21.0 release"
   #  uses: graalvm/mandrel/.github/workflows/base.yml@default
   #  with:
   #    quarkus-version: "main"
   #     version: "mandrel-21.0.0.0-Final"
-  #     build-from-source: "false"
+  #     built-type: "mandrel-release"
   ####
   # Test Quarkus main with supported GraalVM versions using the release archives
   ####
@@ -163,13 +163,11 @@ jobs:
   #  with:
   #    quarkus-version: "main"
   #     version: "vm-20.3.2"
-  #     build-from-source: "false"
-  #     distribution: "graalvm"
+  #     built-type: "graal-release"
   #q-main-graal-21_0-release
   #  name: "Q main G 21.0 release"
   #  uses: graalvm/mandrel/.github/workflows/base.yml@default
   #  with:
   #    quarkus-version: "main"
   #     version: "vm-21.1.0"
-  #     build-from-source: "false"
-  #     distribution: "graalvm"
+  #     built-type: "graal-release"


### PR DESCRIPTION
This reduces the total number of inputs to 9, which allows us to
use the extra input for something else.

The previous two inputs `distribution` (d) and `build-from-source` (b) are now
combined into `build-type` (bt).

```
Previous value | current value
-------------------------------------------
d = mandrel,   | bt = mandrel-release
b = false      |
-------------------------------------------
d = mandrel,   | bt = mandrel-source
b = true       |
-------------------------------------------
d = graalvm,   | bt = graal-release
b = false      |
-------------------------------------------
d = graalvm,   | bt = graal-source
b = true       |
```

Testing is still running but it looks good:

mandrel-release: https://github.com/jerboaa/graal/actions/runs/2690778996 (Linux)
graal-source: https://github.com/jerboaa/graal/actions/runs/2690935361 (Linux)
graal-release: https://github.com/jerboaa/graal/actions/runs/2690852818 (Linux)
mandrel-source: https://github.com/jerboaa/graal/actions/runs/2690908475 (Windows)