### PR TITLE
Set default value for mandrel-it-issue-number job input

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -529,7 +529,7 @@ jobs:
 
   native-tests-report:
     name: Report results on GitHub
-    if: ${{ always() && inputs.issue-number != 'null' && inputs.issue-number != '' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' }}
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' }}
     needs:
       - native-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -51,6 +51,7 @@ on:
       mandrel-it-issue-number:
         type: string
         description: 'The issue number to report results to mandrel-integration-tests'
+        default: "null"
       build-stats-tag:
         type: string
         description: 'The tag to use for build stats upload of native tests (e.g. 22.3.0-dev-jdk17-mytest-patch-before)'

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -495,7 +495,7 @@ jobs:
 
   native-tests-report:
     name: Report results on GitHub
-    if: ${{ always() && inputs.issue-number != 'null' && inputs.issue-number != '' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' }}
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' }}
     needs:
       - native-tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes GHA failures due to the following error:

```
Invalid value for option 'issueNumber': '' is not an int
```

Reverts #422 