### PR TITLE
CI: Run build.java from mandrel-packaging directory

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -219,7 +219,8 @@ jobs:
             Set-Content "Env:\$($matches[1])" $matches[2]
           }
         }
-        & $Env:JAVA_HOME\bin\java -ea $Env:MANDREL_PACKAGING_REPO\build.java `
+        Set-Location -Path $Env:MANDREL_PACKAGING_REPO
+        & $Env:JAVA_HOME\bin\java -ea build.java `
           --mx-home $Env:MX_PATH `
           --mandrel-repo $Env:MANDREL_REPO `
           --mandrel-home $Env:MANDREL_HOME

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -209,7 +209,8 @@ jobs:
     - name: Build Mandrel
       if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       run: |
-        ${JAVA_HOME}/bin/java -ea ${MANDREL_PACKAGING_REPO}/build.java \
+        cd ${MANDREL_PACKAGING_REPO}
+        ${JAVA_HOME}/bin/java -ea build.java \
           --mx-home ${MX_PATH} \
           --mandrel-repo ${MANDREL_REPO} \
           --mandrel-home ${MANDREL_HOME} \


### PR DESCRIPTION
Running from a different directory results in:

```
error: can't open patch '/home/runner/work/mandrel/mandrel/resources/truffle-api-removal.patch': No such file or directory
```

when using [branch `22.3`](https://github.com/graalvm/mandrel-packaging/tree/22.3)