### PR TITLE
CI: Schedule nightly runs earlier and restrict permissions (hardening of CI)

### DIFF
--- a/.github/workflows/mark-stale-issues-and-prs.yml
+++ b/.github/workflows/mark-stale-issues-and-prs.yml
@@ -1,24 +1,24 @@
 name: Mark stale issues and PRs
 
 on:
-  push:
-    branches:
-    - master
-    paths:
-    - .github/workflows/**
   schedule:
-  - cron: '0 3 * * *'
+  - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   mark-stale-issues-and-prs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v6
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue appears to be stale because it has been open 30 days with no activity. This issue will be closed in 7 days unless `Stale` label is removed, a new comment is made, or `not-Stale` label is added.'
         exempt-issue-labels: 'not-Stale'
         stale-pr-message: 'This PR appears to be stale because it has been open 30 days with no activity. This PR will be closed in 7 days unless `Stale` label is removed, a new comment is made, or `not-Stale` label is added.'
         exempt-pr-labels: 'not-Stale'
+        labels-to-remove-when-unstale: 'Stale'
         days-before-stale: 30
         days-before-close: 7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/base.yml'
       - '.github/workflows/base-windows.yml'
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '15 0 * * *'
   workflow_dispatch:
 
 # The following aims to reduce CI CPU cycles by:

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -5,9 +5,12 @@ on:
     branches:
     - default
     paths:
-    - .github/workflows/**
+    - .github/workflows/repo-sync.yml
   schedule:
-  - cron: '45 1 * * *'
+  - cron: '0 0 * * *'
+
+permissions:
+  contents: read|write
 
 jobs:
   graal-master:


### PR DESCRIPTION
This PR will be followed by setting [permissions for the `GITHUB_TOKEN` to restricted](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).