### PR TITLE
CI: Fix permissions for repo-sync workflow

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -10,7 +10,7 @@ on:
   - cron: '0 0 * * *'
 
 permissions:
-  contents: read|write
+  contents: write
 
 jobs:
   graal-master:


### PR DESCRIPTION
Apparently the syntax is different to what I thought and `write` should suffice for both read and write permissions.