### PR TITLE
Bump version to 21.3.4.0 [skip ci]

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -4,7 +4,7 @@ suite = {
   "sourceinprojectwhitelist" : [],
 
   "groupId" : "org.graalvm.compiler",
-  "version" : "21.3.3.1",
+  "version" : "21.3.4.0",
   "release" : False,
   "url" : "http://www.graalvm.org/",
   "developer" : {

--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -23,7 +23,7 @@
 suite = {
     "mxversion": "5.280.5",
     "name": "espresso",
-    "version" : "21.3.3.1",
+    "version" : "21.3.4.0",
     "release" : False,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",

--- a/regex/mx.regex/suite.py
+++ b/regex/mx.regex/suite.py
@@ -43,7 +43,7 @@ suite = {
 
   "name" : "regex",
 
-  "version" : "21.3.3.1",
+  "version" : "21.3.4.0",
   "release" : False,
   "groupId" : "org.graalvm.regex",
   "url" : "http://www.graalvm.org/",

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -41,7 +41,7 @@
 suite = {
   "mxversion" : "5.309.1",
   "name" : "sdk",
-  "version" : "21.3.3.1",
+  "version" : "21.3.4.0",
   "release" : False,
   "sourceinprojectwhitelist" : [],
   "url" : "https://github.com/oracle/graal",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -2,7 +2,7 @@
 suite = {
     "mxversion": "5.308.1",
     "name": "substratevm",
-    "version" : "21.3.3.1",
+    "version" : "21.3.4.0",
     "release" : False,
     "url" : "https://github.com/oracle/graal/tree/master/substratevm",
 

--- a/tools/mx.tools/suite.py
+++ b/tools/mx.tools/suite.py
@@ -26,7 +26,7 @@ suite = {
     "defaultLicense" : "GPLv2-CPE",
 
     "groupId" : "org.graalvm.tools",
-    "version" : "21.3.3.1",
+    "version" : "21.3.4.0",
     "release" : False,
     "url" : "http://openjdk.java.net/projects/graal",
     "developer" : {

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -41,7 +41,7 @@
 suite = {
   "mxversion" : "5.300.4",
   "name" : "truffle",
-  "version" : "21.3.3.1",
+  "version" : "21.3.4.0",
   "release" : False,
   "groupId" : "org.graalvm.truffle",
   "sourceinprojectwhitelist" : [],

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -1,6 +1,6 @@
 suite = {
     "name": "vm",
-    "version" : "21.3.3.1",
+    "version" : "21.3.4.0",
     "mxversion" : "5.309.2",
     "release" : False,
     "groupId" : "org.graalvm",

--- a/wasm/mx.wasm/suite.py
+++ b/wasm/mx.wasm/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion" : "5.301.0",
   "name" : "wasm",
   "groupId" : "org.graalvm.wasm",
-  "version" : "21.3.3.1",
+  "version" : "21.3.4.0",
   "versionConflictResolution" : "latest",
   "url" : "http://graalvm.org/",
   "developer" : {


### PR DESCRIPTION
Simple version bump in prep for the October 2022 OpenJDK CPU update.