### PR TITLE
CI: Pass `-amd` (also make dependents) when building native-images

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -503,7 +503,7 @@ jobs:
           $opts=@()
           -split $Env:NATIVE_TEST_MAVEN_OPTS | foreach { $opts += "`"$_`"" }
           #if ( "${{ inputs.builder-image }}" -eq "null" ) {
-          mvn -f integration-tests -pl "$Env:TEST_MODULES" $opts install
+          mvn -f integration-tests -pl "$Env:TEST_MODULES" -amd $opts install
           #} else {
           #  mvn -pl $do_modules "-Dquarkus.native.container-build=true" "-Dquarkus.native.builder-image=${{ inputs.builder-image }}" $opts package
           #}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -473,7 +473,7 @@ jobs:
             fi
             unset IFS
           fi
-          ./mvnw -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml -f integration-tests -pl "$TEST_MODULES" $BUILDER_IMAGE $NATIVE_TEST_MAVEN_OPTS
+          ./mvnw -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml -f integration-tests -pl "$TEST_MODULES" -amd $BUILDER_IMAGE $NATIVE_TEST_MAVEN_OPTS
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash


### PR DESCRIPTION
This allows multi-module directories like test-extension to be tested as expected.

Related to discussion in https://github.com/quarkusio/quarkus/pull/30027#issuecomment-1362723823