### PR TITLE
CI: Stop testing GraalVM jdk-17 based builds, test jdk-20 based builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,15 +60,15 @@ jobs:
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-graal-17-latest:
-    name: "Q main G 17 latest"
+  q-main-graal-20-latest:
+    name: "Q main G 20 latest"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
       quarkus-version: "main"
       version: "graal/master"
       build-type: "graal-source"
-      jdk: "17/ea"
-      build-stats-tag: "gha-linux-qmain-glatest-jdk17ea"
+      jdk: "20/ea"
+      build-stats-tag: "gha-linux-qmain-glatest-jdk20ea"
     secrets:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   q-main-mandrel-20-latest:


### PR DESCRIPTION
The next GraalVM release will be based on jdk 20, and there is no intend for us to provide GraalVM CE builds based on jdk 17. either way.

Furthermore, `mx` dropped labsjdk-ce-17 from the "jdks" it supports in https://github.com/graalvm/mx/commit/d36dc550ca28e0cfe1b3d0cb4601c54a560b0655