### PR TITLE
CI: Increase Mandrel IT timeout

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -571,7 +571,7 @@ jobs:
       # Don't perform performance checks since GH runners are not that stable
       FAIL_ON_PERF_REGRESSION: false
       # USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
-    timeout-minutes: 40
+    timeout-minutes: 50
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
40 minutes seems pretty tight resulting in occasional timeouts the last few months.

See https://github.com/Karm/mandrel-integration-tests/issues/102#issuecomment-1293167985