### PR TITLE
Backport: Add support for CgroupMetrics.getTotalMemory0

### DIFF
--- a/common.json
+++ b/common.json
@@ -1,6 +1,8 @@
 {
   "README": "This file contains definitions that are useful for the hocon and jsonnet CI files of multiple repositories.",
 
+  "mx_version" : "5.310.0",
+
   "jdks": {
     "openjdk8":           {"name": "openjdk",   "version": "8u302+06-jvmci-21.3-b05", "platformspecific": true },
     "oraclejdk8":         {"name": "oraclejdk", "version": "8u341+10-jvmci-21.3-b19", "platformspecific": true },

--- a/graal-common.json
+++ b/graal-common.json
@@ -2,6 +2,5 @@
   "README": "This file contains definitions that are useful for the hocon and jsonnet CI files of the graal and graal-enterprise repositories.",
   "ci": {
     "overlay": "2c62a756dfc673f932d83fc5545e1cc43834e45c"
-  },
-  "mx_version" : "5.310.0"
+  }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/PhysicalMemory.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/PhysicalMemory.java
@@ -44,7 +44,7 @@ import com.oracle.svm.core.util.VMError;
 public class PhysicalMemory {
 
     /** Implemented by operating-system specific code. */
-    protected interface PhysicalMemorySupport {
+    public interface PhysicalMemorySupport {
 
         default boolean hasSize() {
             throw VMError.shouldNotReachHere("Unused, will be removed");

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/CgroupMetricsJDK.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/CgroupMetricsJDK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,22 +22,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.core.jdk17;
 
-import static com.oracle.svm.core.Containers.Options.UseContainerSupport;
+package com.oracle.svm.core.jdk;
 
-import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.Platforms;
+import java.util.function.BooleanSupplier;
 
-import com.oracle.svm.core.annotate.Substitute;
-import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK17OrLater;
+public class CgroupMetricsJDK implements BooleanSupplier {
 
-@Platforms(Platform.LINUX.class)
-@TargetClass(className = "jdk.internal.platform.CgroupMetrics", onlyWith = JDK17OrLater.class)
-public final class Target_jdk_internal_platform_CgroupMetrics_JDK17OrLater {
-    @Substitute
-    public static boolean isUseContainerSupport() {
-        return UseContainerSupport.getValue();
+    static final String CGROUP_METRICS_CLASS = "jdk.internal.platform.CgroupMetrics";
+
+    @Override
+    public boolean getAsBoolean() {
+        Module javaBase = ModuleLayer.boot().findModule("java.base").orElseThrow();
+        Class<?> cgroupMetrics = Class.forName(javaBase, CGROUP_METRICS_CLASS);
+        return cgroupMetrics != null;
     }
+
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/HasGetTotalMemorySize0.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/HasGetTotalMemorySize0.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * A predicate that returns {@code true} iff
+ * {@code boolean jdk.internal.platform.CgroupMetrics.getTotalMemorySize0()} exists. It should only
+ * be used in conjunction with {@link CgroupMetricsJDK} as {@code CgroupMetrics} isn't available in
+ * all JDKs.
+ */
+public class HasGetTotalMemorySize0 implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        Module javaBase = ModuleLayer.boot().findModule("java.base").orElseThrow();
+        Class<?> cgroupMetrics = Class.forName(javaBase, CgroupMetricsJDK.CGROUP_METRICS_CLASS);
+        if (cgroupMetrics != null) {
+            try {
+                cgroupMetrics.getDeclaredMethod("getTotalMemorySize0");
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_internal_platform_CgroupMetrics.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_internal_platform_CgroupMetrics.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import static com.oracle.svm.core.Containers.Options.UseContainerSupport;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.annotate.TargetElement;
+import com.oracle.svm.core.heap.PhysicalMemory.PhysicalMemorySupport;
+
+@Platforms(Platform.LINUX.class)
+@TargetClass(className = "jdk.internal.platform.CgroupMetrics", onlyWith = CgroupMetricsJDK.class)
+public final class Target_jdk_internal_platform_CgroupMetrics {
+    @Substitute
+    public static boolean isUseContainerSupport() {
+        return UseContainerSupport.getValue();
+    }
+
+    @Substitute
+    @TargetElement(onlyWith = HasGetTotalMemorySize0.class)
+    public static long getTotalMemorySize0() {
+        // We ought not to use PhysicalMemory.size() here since that might return the
+        // container memory which we explicitly want to avoid for this method. It serves
+        // as an upper bound of the container memory.
+        return ImageSingletons.lookup(PhysicalMemorySupport.class).size().rawValue();
+    }
+}


### PR DESCRIPTION
Backports https://github.com/oracle/graal/pull/5390. The only difference being making interface `PhysicalMemorySupport` public, which seems fine to me.

When running the reproducer on a patched GraalVM build the JFR warning is gone.

Thoughts?