### PR TITLE
CI: Pin java version to 17 for Quarkus building

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -381,14 +381,13 @@ jobs:
           cd quarkus
           bash ../workflow-mandrel/.github/update_quarkus_version.sh 2.2.999
         fi
+    # Use Java 17 to build Quarkus as it doesn't build with Java 20
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
     - name: Build quarkus
       run: |
-        curl -L https://api.adoptium.net/v3/binary/latest/${{ inputs.jdk }}/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        export JAVA_HOME=$(pwd)/openjdk
-        echo ${JAVA_HOME}
-        mkdir -p ${JAVA_HOME}
-        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
-        ${JAVA_HOME}/bin/java -version
         cd quarkus
         ./mvnw ${COMMON_MAVEN_ARGS} -Dquickly
     - name: Tar Maven Repo

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -318,9 +318,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - get-test-matrix
-      - build-mandrel
-      - build-graal
-      - get-jdk
     strategy:
       fail-fast: false
     steps:
@@ -340,17 +337,6 @@ jobs:
         path: ~/.m2/repository
         key: ${{ runner.os }}-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-
-    - name: Download Mandrel or OpenJDK
-      uses: actions/download-artifact@v3
-      with:
-        name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
-        path: .
-    - name: Extract Mandrel or OpenJDK
-      shell: bash
-      run: |
-        mkdir -p ${JAVA_HOME}
-        tar xzvf jdk.tgz -C ${JAVA_HOME} --strip-components=1
-        ${JAVA_HOME}/bin/java -version
     - name: Change quarkus.version for Quarkus 2.2 to make mandrel-integration-test not apply quarkus_main.patch
       # See https://github.com/Karm/mandrel-integration-tests/pull/64
       run: |
@@ -359,6 +345,11 @@ jobs:
           cd quarkus
           bash ../workflow-mandrel/.github/update_quarkus_version.sh 2.2.999
         fi
+    # Use Java 17 to build Quarkus as it doesn't build with Java 20
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
     - name: Build quarkus
       run: |
         cd ${QUARKUS_PATH}


### PR DESCRIPTION
When building Quarkus with JDK 20 it fails with:

```
BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 64
```

This is because gradle is not yet JDK 20 compatible.