### PR TITLE
CI: Make native tests depend on Mandrel/GraalVM build and get JDK jobs

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -595,7 +595,6 @@ jobs:
     needs:
       - build-vars
       - build-mandrel
-      - build-graal
       - get-jdk
       - build-quarkus
       - get-test-matrix

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -369,6 +369,9 @@ jobs:
   native-tests:
     name: Q IT ${{ matrix.category }}
     needs:
+      - build-mandrel
+      - build-graal
+      - get-jdk
       - build-quarkus
       - get-test-matrix
     runs-on: ubuntu-latest
@@ -553,6 +556,8 @@ jobs:
     if: ${{ needs.build-vars.outputs.distribution == 'mandrel' }}
     needs:
       - build-vars
+      - build-mandrel
+      - get-jdk
       - build-quarkus
       - get-test-matrix
     runs-on: ubuntu-latest


### PR DESCRIPTION
Avoids running tests (that will inevitably fail) when building Mandrel or GraalVM fails