### PR TITLE
Make updating of timing stats optional

### DIFF
--- a/.github/import_stats.sh
+++ b/.github/import_stats.sh
@@ -33,7 +33,9 @@ for bs in $(find $DIR -name \*build-output-stats.json); do
   # import the stat
   stat_id=$(curl -s -w '\n' -H "Content-Type: application/json" \
             -H "token: $TOKEN" --post302 --data "@$(pwd)/$bs" "$URL/import?t=$TAG" | jq .id)
-  # update timing info
-  curl -s -w '\n' -H "Content-Type: application/json" -H "token: $TOKEN" \
-	  -X PUT --data "@$ts" "$URL/$stat_id" > /dev/null
+  # update timing info if present
+  if [ -e "$ts" ]; then
+    curl -s -w '\n' -H "Content-Type: application/json" -H "token: $TOKEN" \
+	    -X PUT --data "@$ts" "$URL/$stat_id" > /dev/null
+  fi
 done


### PR DESCRIPTION
GraalVM 23.0 will have the stats in the build output and we'll upload it that way once https://github.com/Karm/collector/pull/12 is merged.

For GraalVM 22.3 we'll use the timing stats file.