### PR TITLE
CI: Move JDK 17 to weekly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,34 +32,6 @@ jobs:
   ####
   # Test Quarkus main with latest graal sources built as Mandrel and GraalVM
   ####
-  q-main-mandrel-17-latest:
-    name: "Q main M 17 latest"
-    uses: graalvm/mandrel/.github/workflows/base.yml@default
-    with:
-      quarkus-version: "main"
-      version: "graal/master"
-      jdk: "17/ea"
-      issue-number: "399"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "102"
-      build-stats-tag: "gha-linux-qmain-mlatest-jdk17ea"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-mandrel-17-latest-win:
-    name: "Q main M 17 latest windows"
-    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
-    with:
-      quarkus-version: "main"
-      version: "graal/master"
-      jdk: "17/ea"
-      issue-number: "400"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "104"
-      build-stats-tag: "gha-win-qmain-mlatest-jdk17ea"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   q-main-graal-20-latest:
     name: "Q main G 20 latest"
     uses: graalvm/mandrel/.github/workflows/base.yml@default

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,14 +30,36 @@ concurrency:
 
 jobs:
   ####
-  # Test Quarkus latest with 22_3 quayio images
+  # Test GraalVM tip with JDK 17
   ####
-  q-latest-mandrel-22_3-quayio:
-    name: "Q latest M 22.3 image"
+  q-main-mandrel-17-latest:
+    name: "Q main M 17 latest"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
-      quarkus-version: "latest"
-      builder-image: "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17"
+      quarkus-version: "main"
+      version: "graal/master"
+      jdk: "17/ea"
+      issue-number: "399"
+      issue-repo: "graalvm/mandrel"
+      mandrel-it-issue-number: "102"
+      build-stats-tag: "gha-linux-qmain-mlatest-jdk17ea"
+    secrets:
+      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+  q-main-mandrel-17-latest-win:
+    name: "Q main M 17 latest windows"
+    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
+    with:
+      quarkus-version: "main"
+      version: "graal/master"
+      jdk: "17/ea"
+      issue-number: "400"
+      issue-repo: "graalvm/mandrel"
+      mandrel-it-issue-number: "104"
+      build-stats-tag: "gha-win-qmain-mlatest-jdk17ea"
+    secrets:
+      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
   # Test Quarkus 2.13 with 22_3 quayio images
   ####


### PR DESCRIPTION
The next feature release of Mandrel will be based on JDK 20. To reduce resource utilization we move the testing of JDK 17 based builds to the weekly workflow.

Furthermore, we stop testing Q main with 22.3 builder images, this testing is performed by Quarkus itself now that Mandrel 22.3 is the default.