### PR TITLE
CI: Invoke fetch-jdk from graal directory to get correct version

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -257,6 +257,7 @@ jobs:
     - name: Get labs OpenJDK
       if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       run: |
+        cd graal
         mkdir jdk-dl
         ${MX_PATH}/mx --java-home= fetch-jdk --java-distribution labsjdk-ce-$(echo ${{ inputs.jdk }} | cut -d / -f 1) --to jdk-dl --alias ${JAVA_HOME}
     - name: Build graalvm native-image


### PR DESCRIPTION
`labsjdk-ce-20` is defined in both [`mx/common.json`](https://github.com/graalvm/mx/blob/9a0cdd61534e0365c1adbe1cef634111935fea5e/common.json#L30) and [`graal/common.json`](https://github.com/oracle/graal/blob/bb78ac5b62c932cce530f73984354fff80aed72d/common.json#L30), since we are building `graal` we need to use the latter.