### PR TITLE
CI: Bump windows host runner to windows-2022

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -163,7 +163,7 @@ jobs:
 
   build-mandrel:
     name: Mandrel build
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs:
       - get-test-matrix
       - build-vars
@@ -213,7 +213,7 @@ jobs:
     - name: Build Mandrel
       if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+        cmd.exe /c "call `"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
         Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
           if ($_ -match "^(.*?)=(.*)$") {
             Set-Content "Env:\$($matches[1])" $matches[2]
@@ -240,7 +240,7 @@ jobs:
 
   build-graal:
     name: GraalVM CE build
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs:
       - get-test-matrix
       - build-vars
@@ -272,7 +272,7 @@ jobs:
     - name: Build graalvm native-image
       if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       run: |
-        cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+        cmd.exe /c "call `"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
         Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
           if ($_ -match "^(.*?)=(.*)$") {
             Set-Content "Env:\$($matches[1])" $matches[2]
@@ -300,7 +300,7 @@ jobs:
 
   get-jdk:
     name: Get JDK ${{ inputs.jdk }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs:
       - get-test-matrix
       - build-vars
@@ -410,7 +410,7 @@ jobs:
       - build-graal
       - get-jdk
       - get-test-matrix
-    runs-on: windows-2019
+    runs-on: windows-2022
     # env:
     #   USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
     # Ignore the following YAML Schema error
@@ -487,7 +487,7 @@ jobs:
           TEST_MODULES: ${{matrix.test-modules}}
           CATEGORY: ${{matrix.category}}
         run: |
-          cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+          cmd.exe /c "call `"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
           Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
             if ($_ -match "^(.*?)=(.*)$") {
               Set-Content "Env:\$($matches[1])" $matches[2]
@@ -598,7 +598,7 @@ jobs:
       - get-jdk
       - build-quarkus
       - get-test-matrix
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g
@@ -643,7 +643,7 @@ jobs:
           cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
       - name: Build with Maven
         run: |
-          cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
+          cmd.exe /c "call `"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"
           Get-Content "$Env:temp\vcvars64.txt" | Foreach-Object {
             if ($_ -match "^(.*?)=(.*)$") {
               Set-Content "Env:\$($matches[1])" $matches[2]


### PR DESCRIPTION
Required by latest GraalVM

```
com.oracle.svm.core.util.UserError$UserException: On Windows, GraalVM Native Image for JDK 20 requires Visual Studio 2022 version 17.1.0 or later (C/C++ Optimizing Compiler Version 19.31 or later).
```

Failure seen in https://github.com/graalvm/mandrel/actions/runs/4463893204/jobs/7839797641#step:12:3416