### PR TITLE
[CI] Fix quarkus version in weekly builds for image-based testing

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -67,7 +67,7 @@ jobs:
     name: "Q 2.13 M 22.3 image"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
-      quarkus-version: "2.13"
+      quarkus-version: "2.13.4.Final"
       builder-image: "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17"
   q-main-mandrel-22_3-quayio:
     name: "Q main M 22.3 image"
@@ -82,7 +82,7 @@ jobs:
     name: "Q 2.7 M 21.3 image"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
-      quarkus-version: "2.7"
+      quarkus-version: "2.7.5.Final"
       builder-image: "quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"
   ####
   # Test Quarkus main with supported Mandrel versions using the release archives


### PR DESCRIPTION
The weekly CI builds using the builder images should use versions with a `.Final` suffix so that the expression in https://github.com/graalvm/mandrel/blob/default/.github/workflows/base.yml#L619 matches and `999-SNAPSHOT` isn't being used as the quarkus version when running tests.

Example of such an instance:
https://github.com/graalvm/mandrel/actions/runs/4642679968/jobs/8216983792#step:10:47

Although, `2.13` got passed earlier. See:
https://github.com/graalvm/mandrel/actions/runs/4642679968/jobs/8216983792#step:10:7