### PR TITLE
Fix CI workflows

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -492,7 +492,6 @@ jobs:
             }
           }
           cd $Env:QUARKUS_PATH
-          $Env:GRAALVM_HOME="$Env:JAVA_HOME"
           Write-Host "$Env:GRAALVM_HOME"
           if (Test-Path "$Env:GRAALVM_HOME/bin/native-image" -PathType leaf) {
             & "$Env:GRAALVM_HOME/bin/native-image" --version

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -448,13 +448,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Mandrel or GraalVM
-        if: startsWith(matrix.os-name, 'windows')
+        if: "!startsWith(matrix.os-name, 'windows') && inputs.builder-image != 'null'"
         uses: actions/download-artifact@v3
         with:
           name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract Mandrel or GraalVM
-        if: startsWith(matrix.os-name, 'windows')
+        if: "!startsWith(matrix.os-name, 'windows') && inputs.builder-image != 'null'"
         shell: bash
         run: |
           mkdir -p "${GRAALVM_HOME}"

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -406,13 +406,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Mandrel or GraalVM
-        if: "!startsWith(matrix.os-name, 'windows')"
+        if: "!startsWith(matrix.os-name, 'windows') && inputs.builder-image != 'null'"
         uses: actions/download-artifact@v3
         with:
           name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract Mandrel or GraalVM
-        if: "!startsWith(matrix.os-name, 'windows')"
+        if: "!startsWith(matrix.os-name, 'windows') && inputs.builder-image != 'null'"
         shell: bash
         run: |
           mkdir -p ${GRAALVM_HOME}
@@ -599,13 +599,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Mandrel or GraalVM
-        if: "!startsWith(matrix.os-name, 'windows')"
+        if: "!startsWith(matrix.os-name, 'windows') && inputs.builder-image != 'null'"
         uses: actions/download-artifact@v3
         with:
           name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
       - name: Extract Mandrel or GraalVM
-        if: "!startsWith(matrix.os-name, 'windows')"
+        if: "!startsWith(matrix.os-name, 'windows') && inputs.builder-image != 'null'"
         shell: bash
         run: |
           mkdir -p ${GRAALVM_HOME}


### PR DESCRIPTION
- [CI] Only download and unpack Mandrel/GraalVM when needed
- [CI] Don't override GRAALVM_HOME in windows workflow
