### PR TITLE
Bump to Quarkus 2.13.8.Final

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -67,7 +67,7 @@ jobs:
     name: "Q 2.13 M 22.3 image"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
-      quarkus-version: "2.13.7.Final"
+      quarkus-version: "2.13.8.Final"
       builder-image: "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17"
   q-main-mandrel-22_3-quayio:
     name: "Q main M 22.3 image"


### PR DESCRIPTION
This fixes the [CI failure](https://github.com/graalvm/mandrel/actions/runs/5135972911/jobs/9242447467#step:12:1224) related to the test extension tests when using the 22.3 builder image.

See https://github.com/quarkusio/quarkus/pull/32278 which is included in the `2.13.8.Final` release.