### PR TITLE
[23.0] Restore ability to disable debuginfo stripping

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoStripFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoStripFeature.java
@@ -51,7 +51,7 @@ public class NativeImageDebugInfoStripFeature implements InternalFeature {
 
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
-        return SubstrateOptions.useDebugInfoGeneration() || SubstrateOptions.UseOldDebugInfo.getValue();
+        return (SubstrateOptions.useDebugInfoGeneration() || SubstrateOptions.UseOldDebugInfo.getValue())  && SubstrateOptions.StripDebugInfo.getValue();
     }
 
     @SuppressWarnings("try")


### PR DESCRIPTION
(cherry picked from commit 218b2519e8decf93f141176cb4289725c9072738)

Resolves issue mentioned in https://github.com/oracle/graal/issues/6995#issuecomment-1638274284