### PR TITLE
[23.0] Backport: Return to separate CUs per class to improve gdb startup time oracle/graal 6984

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -86,10 +86,37 @@ public class ClassEntry extends StructureTypeEntry {
      */
     private final EconomicMap<Range, CompiledMethodEntry> compiledMethodIndex = EconomicMap.create();
 
+    /**
+     * A list of all files referenced from info associated with this class, including info detailing
+     * inline method ranges.
+     */
+    private ArrayList<FileEntry> files;
+    /**
+     * A list of all directories referenced from info associated with this class, including info
+     * detailing inline method ranges.
+     */
+    private ArrayList<DirEntry> dirs;
+    /**
+     * An index identifying the file table position of every file referenced from info associated
+     * with this class, including info detailing inline method ranges.
+     */
+    private EconomicMap<FileEntry, Integer> fileIndex;
+    /**
+     * An index identifying the dir table position of every directory referenced from info
+     * associated with this class, including info detailing inline method ranges.
+     */
+    private EconomicMap<DirEntry, Integer> dirIndex;
+
     public ClassEntry(String className, FileEntry fileEntry, int size) {
         super(className, size);
         this.fileEntry = fileEntry;
         this.loader = null;
+        // file and dir lists/indexes are populated after all DebugInfo API input has
+        // been received and are only created on demand
+        files = null;
+        dirs = null;
+        this.fileIndex = null;
+        this.dirIndex = null;
     }
 
     @Override
@@ -179,7 +206,33 @@ public class ClassEntry extends StructureTypeEntry {
     }
 
     public int getFileIdx() {
-        return fileEntry.getIdx();
+        return getFileIdx(this.getFileEntry());
+    }
+
+    public int getFileIdx(FileEntry file) {
+        if (file == null || fileIndex == null) {
+            return 0;
+        }
+        return fileIndex.get(file);
+    }
+
+    public DirEntry getDirEntry(FileEntry file) {
+        if (file == null) {
+            return null;
+        }
+        return file.getDirEntry();
+    }
+
+    public int getDirIdx(FileEntry file) {
+        DirEntry dirEntry = getDirEntry(file);
+        return getDirIdx(dirEntry);
+    }
+
+    public int getDirIdx(DirEntry dir) {
+        if (dir == null || dir.getPathString().isEmpty() || dirIndex == null) {
+            return 0;
+        }
+        return dirIndex.get(dir);
     }
 
     public String getLoaderId() {
@@ -187,23 +240,12 @@ public class ClassEntry extends StructureTypeEntry {
     }
 
     /**
-     * Retrieve a stream of all compiled method entries for this class, including both normal and
-     * deopt fallback compiled methods.
+     * Retrieve a stream of all compiled method entries for this class.
      *
      * @return a stream of all compiled method entries for this class.
      */
     public Stream<CompiledMethodEntry> compiledEntries() {
         return compiledEntries.stream();
-    }
-
-    /**
-     * Retrieve a stream of all normal compiled method entries for this class, excluding deopt
-     * fallback compiled methods.
-     *
-     * @return a stream of all normal compiled method entries for this class.
-     */
-    public Stream<CompiledMethodEntry> normalCompiledEntries() {
-        return compiledEntries();
     }
 
     protected void processInterface(ResolvedJavaType interfaceType, DebugInfoBase debugInfoBase, DebugContext debugContext) {
@@ -267,8 +309,17 @@ public class ClassEntry extends StructureTypeEntry {
         return builder.toString();
     }
 
+    public int compiledEntryCount() {
+        return compiledEntries.size();
+    }
+
     public boolean hasCompiledEntries() {
-        return compiledEntries.size() != 0;
+        return compiledEntryCount() != 0;
+    }
+
+    public int compiledEntriesBase() {
+        assert hasCompiledEntries();
+        return compiledEntries.get(0).getPrimary().getLo();
     }
 
     public ClassEntry getSuperClass() {
@@ -313,8 +364,99 @@ public class ClassEntry extends StructureTypeEntry {
      *
      * @return the highest code section offset for compiled method code belonging to this class
      */
+    @SuppressWarnings("unused")
     public int hipc() {
         assert hasCompiledEntries();
         return compiledEntries.get(compiledEntries.size() - 1).getPrimary().getHi();
+    }
+
+    /**
+     * Add a file to the list of files referenced from info associated with this class.
+     * 
+     * @param file The file to be added.
+     */
+    public void includeFile(FileEntry file) {
+        if (files == null) {
+            files = new ArrayList<>();
+        }
+        assert !files.contains(file);
+        // cannot add files after index has been created
+        assert fileIndex == null;
+        files.add(file);
+    }
+
+    /**
+     * Add a directory to the list of firectories referenced from info associated with this class.
+     * 
+     * @param dirEntry The directory to be added.
+     */
+    public void includeDir(DirEntry dirEntry) {
+        if (dirs == null) {
+            dirs = new ArrayList<>();
+        }
+        assert !dirs.contains(dirEntry);
+        // cannot add dirs after index has been created
+        assert dirIndex == null;
+        dirs.add(dirEntry);
+    }
+
+    /**
+     * Populate the file and directory indexes that track positions in the file and dir tables for
+     * this class's line info section.
+     */
+    public void buildFileAndDirIndexes() {
+        // this is a one-off operation
+        assert fileIndex == null;
+        assert dirIndex == null;
+        if (files == null) {
+            // should not have any dirs if we have no files
+            assert dirs == null;
+            return;
+        }
+        int idx = 1;
+        fileIndex = EconomicMap.create(files.size());
+        for (FileEntry file : files) {
+            fileIndex.put(file, idx++);
+        }
+        if (dirs == null) {
+            return;
+        }
+        dirIndex = EconomicMap.create(dirs.size());
+        idx = 1;
+        for (DirEntry dir : dirs) {
+            if (!dir.getPathString().isEmpty()) {
+                dirIndex.put(dir, idx++);
+            } else {
+                assert idx == 1;
+            }
+        }
+    }
+
+    /**
+     * Retrieve a stream of all files referenced from debug info for this class in line info file
+     * table order, starting with the file at index 1.
+     * 
+     * @return a stream of all referenced files
+     */
+    public Stream<FileEntry> fileStream() {
+        if (files != null) {
+            return files.stream();
+        } else {
+            return Stream.empty();
+        }
+    }
+
+    /**
+     * Retrieve a stream of all directories referenced from debug info for this class in line info
+     * directory table order, starting with the directory at index 1.
+     *
+     * @return a stream of all referenced directories
+     */
+    public Stream<DirEntry> dirStream() {
+        if (dirs != null) {
+            return dirs.stream();
+        } else {
+            return Stream.empty();
+        }
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -364,7 +364,6 @@ public class ClassEntry extends StructureTypeEntry {
      *
      * @return the highest code section offset for compiled method code belonging to this class
      */
-    @SuppressWarnings("unused")
     public int hipc() {
         assert hasCompiledEntries();
         return compiledEntries.get(compiledEntries.size() - 1).getPrimary().getHi();
@@ -379,9 +378,8 @@ public class ClassEntry extends StructureTypeEntry {
         if (files == null) {
             files = new ArrayList<>();
         }
-        assert !files.contains(file);
-        // cannot add files after index has been created
-        assert fileIndex == null;
+        assert !files.contains(file) : "caller should ensure file is only included once";
+        assert fileIndex == null : "cannot include files after index has been created";
         files.add(file);
     }
 
@@ -394,9 +392,8 @@ public class ClassEntry extends StructureTypeEntry {
         if (dirs == null) {
             dirs = new ArrayList<>();
         }
-        assert !dirs.contains(dirEntry);
-        // cannot add dirs after index has been created
-        assert dirIndex == null;
+        assert !dirs.contains(dirEntry) : "caller should ensure dir is only included once";
+        assert dirIndex == null : "cannot include dirs after index has been created";
         dirs.add(dirEntry);
     }
 
@@ -406,11 +403,9 @@ public class ClassEntry extends StructureTypeEntry {
      */
     public void buildFileAndDirIndexes() {
         // this is a one-off operation
-        assert fileIndex == null;
-        assert dirIndex == null;
+        assert fileIndex == null && dirIndex == null : "file and indexes can only be generated once";
         if (files == null) {
-            // should not have any dirs if we have no files
-            assert dirs == null;
+            assert dirs == null : "should not have included any dirs if we have no files";
             return;
         }
         int idx = 1;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -90,12 +90,12 @@ public class ClassEntry extends StructureTypeEntry {
      * A list of all files referenced from info associated with this class, including info detailing
      * inline method ranges.
      */
-    private ArrayList<FileEntry> files;
+    private final ArrayList<FileEntry> files;
     /**
      * A list of all directories referenced from info associated with this class, including info
      * detailing inline method ranges.
      */
-    private ArrayList<DirEntry> dirs;
+    private final ArrayList<DirEntry> dirs;
     /**
      * An index identifying the file table position of every file referenced from info associated
      * with this class, including info detailing inline method ranges.
@@ -113,8 +113,9 @@ public class ClassEntry extends StructureTypeEntry {
         this.loader = null;
         // file and dir lists/indexes are populated after all DebugInfo API input has
         // been received and are only created on demand
-        files = null;
-        dirs = null;
+        files = new ArrayList<>();
+        dirs = new ArrayList<>();
+        // create these on demand using the size of the file and dir lists
         this.fileIndex = null;
         this.dirIndex = null;
     }
@@ -375,9 +376,6 @@ public class ClassEntry extends StructureTypeEntry {
      * @param file The file to be added.
      */
     public void includeFile(FileEntry file) {
-        if (files == null) {
-            files = new ArrayList<>();
-        }
         assert !files.contains(file) : "caller should ensure file is only included once";
         assert fileIndex == null : "cannot include files after index has been created";
         files.add(file);
@@ -389,9 +387,6 @@ public class ClassEntry extends StructureTypeEntry {
      * @param dirEntry The directory to be added.
      */
     public void includeDir(DirEntry dirEntry) {
-        if (dirs == null) {
-            dirs = new ArrayList<>();
-        }
         assert !dirs.contains(dirEntry) : "caller should ensure dir is only included once";
         assert dirIndex == null : "cannot include dirs after index has been created";
         dirs.add(dirEntry);
@@ -404,17 +399,13 @@ public class ClassEntry extends StructureTypeEntry {
     public void buildFileAndDirIndexes() {
         // this is a one-off operation
         assert fileIndex == null && dirIndex == null : "file and indexes can only be generated once";
-        if (files == null) {
-            assert dirs == null : "should not have included any dirs if we have no files";
-            return;
+        if (files.isEmpty()) {
+            assert dirs.isEmpty() : "should not have included any dirs if we have no files";
         }
         int idx = 1;
         fileIndex = EconomicMap.create(files.size());
         for (FileEntry file : files) {
             fileIndex.put(file, idx++);
-        }
-        if (dirs == null) {
-            return;
         }
         dirIndex = EconomicMap.create(dirs.size());
         idx = 1;
@@ -434,7 +425,7 @@ public class ClassEntry extends StructureTypeEntry {
      * @return a stream of all referenced files
      */
     public Stream<FileEntry> fileStream() {
-        if (files != null) {
+        if (!files.isEmpty()) {
             return files.stream();
         } else {
             return Stream.empty();
@@ -448,7 +439,7 @@ public class ClassEntry extends StructureTypeEntry {
      * @return a stream of all referenced directories
      */
     public Stream<DirEntry> dirStream() {
-        if (dirs != null) {
+        if (!dirs.isEmpty()) {
             return dirs.stream();
         } else {
             return Stream.empty();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -34,13 +34,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.graalvm.collections.EconomicMap;
+import org.graalvm.collections.EconomicSet;
+import org.graalvm.compiler.debug.DebugContext;
+
 import com.oracle.objectfile.debugentry.range.PrimaryRange;
 import com.oracle.objectfile.debugentry.range.Range;
 import com.oracle.objectfile.debugentry.range.SubRange;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFileInfo;
 import jdk.vm.ci.meta.ResolvedJavaType;
-import org.graalvm.collections.EconomicMap;
-import org.graalvm.compiler.debug.DebugContext;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugCodeInfo;
@@ -76,31 +78,14 @@ import com.oracle.objectfile.elf.dwarf.DwarfDebugInfo;
  * 3) by inlined method (sub range) within top level method, also ordered by ascending address
  *
  * Since clients may need to generate records for classes with no compiled methods, the second
- * traversal order is often employed. In rare cases clients need to sort the class list by address
- * before traversal to ensure the generated debug records are also sorted by address.
+ * traversal order is often employed.
  *
- * n.b. the above strategy relies on the details that methods of a given class always appear in a
- * single continuous address range with no intervening code from other methods or data values. This
- * means we can treat each class as a Compilation Unit, allowing data common to all methods of the
- * class to be referenced using CU-local offsets.
- *
- * Just as an aside, for full disclosure, this is not strictly the full story. Sometimes a class can
- * include speculatively optimized, compiled methods plus deopt fallback compiled variants of those
- * same methods. In such cases the normal and/or speculatively compiled methods occupy one
- * contiguous range and deopt methods occupy a separate higher range. The current compilation
- * strategy ensures that the union across all classes of the normal/speculative ranges and the union
- * across all classes of the deopt ranges lie in two distinct intervals where the highest address in
- * the first union is strictly less than the lowest address in the second union. The implication is
- * twofold. An address order traversal requires generating details for classes, methods and
- * non-deopt primary ranges before generating details for the deopt primary ranges. The former
- * details need to be generated in a distinct CU from deopt method details.
- *
- * A third option appears to be to traverse via files, then top level class within file etc.
- * Unfortunately, files cannot be treated as a compilation unit. A file F may contain multiple
- * classes, say C1 and C2. There is no guarantee that methods for some other class C' in file F'
- * will not be compiled into the address space interleaved between methods of C1 and C2. That is a
- * shame because generating debug info records one file at a time would allow more sharing e.g.
- * enabling all classes in a file to share a single copy of the file and dir tables.
+ * n.b. methods of a given class do not always appear in a single continuous address range. The
+ * compiler choose to interleave intervening code from other classes or data values in order to get
+ * better cache locality. It may also choose to generate deoptimized variants of methods in a
+ * separate range from normal, optimized compiled code. This out of (code addess) order sorting may
+ * make it difficult to use a class by class traversal to generate debug info in separate per-class
+ * units.
  */
 public abstract class DebugInfoBase {
     protected ByteOrder byteOrder;
@@ -361,6 +346,10 @@ public abstract class DebugInfoBase {
             long size = debugDataInfo.getSize();
             debugContext.log(DebugContext.INFO_LEVEL, "Data: address 0x%x size 0x%x type %s partition %s provenance %s ", address, size, typeName, partitionName, provenance);
         }));
+        // populate a file and dir list and associated index for each class entry
+        getInstanceClasses().forEach(classEntry -> {
+            collectFilesAndDirs(classEntry);
+        });
     }
 
     private TypeEntry createTypeEntry(String typeName, String fileName, Path filePath, int size, DebugTypeKind typeKind) {
@@ -578,7 +567,7 @@ public abstract class DebugInfoBase {
             /* Ensure file and cachepath are added to the debug_str section. */
             uniqueDebugString(fileName);
             uniqueDebugString(cachePath);
-            fileEntry = new FileEntry(fileName, dirEntry, files.size() + 1);
+            fileEntry = new FileEntry(fileName, dirEntry);
             files.add(fileEntry);
             /* Index the file entry by file path. */
             filesIndex.put(fileAsPath, fileEntry);
@@ -616,7 +605,7 @@ public abstract class DebugInfoBase {
         if (dirEntry == null) {
             /* Ensure dir path is entered into the debug_str section. */
             uniqueDebugString(filePath.toString());
-            dirEntry = new DirEntry(filePath, dirs.size());
+            dirEntry = new DirEntry(filePath);
             dirsIndex.put(filePath, dirEntry);
             dirs.add(dirEntry);
         }
@@ -688,7 +677,6 @@ public abstract class DebugInfoBase {
      * Indirects this call to the string table.
      *
      * @param string the string whose index is required.
-     *
      * @return the offset of the string in the .debug_str section.
      */
     public int debugStringIndex(String string) {
@@ -737,5 +725,52 @@ public abstract class DebugInfoBase {
 
     public ClassEntry getHubClassEntry() {
         return hubClassEntry;
+    }
+
+    private static void collectFilesAndDirs(ClassEntry classEntry) {
+        // track files and dirs we have already seen so that we only add them once
+        EconomicSet<FileEntry> visitedFiles = EconomicSet.create();
+        EconomicSet<DirEntry> visitedDirs = EconomicSet.create();
+        // add the class's file and dir
+        checkInclude(classEntry, classEntry.getFileEntry(), visitedFiles, visitedDirs);
+        // add files for fields (may differ from class file if we have a substitution)
+        for (FieldEntry fieldEntry : classEntry.fields) {
+            checkInclude(classEntry, fieldEntry.getFileEntry(), visitedFiles, visitedDirs);
+        }
+        // add files for declared methods (may differ from class file if we have a substitution)
+        for (MethodEntry methodEntry : classEntry.getMethods()) {
+            checkInclude(classEntry, methodEntry.getFileEntry(), visitedFiles, visitedDirs);
+        }
+        // add files for top level compiled and inline methods
+        classEntry.compiledEntries().forEachOrdered(compiledMethodEntry -> {
+            checkInclude(classEntry, compiledMethodEntry.getPrimary().getFileEntry(), visitedFiles, visitedDirs);
+            // we need files for leaf ranges and for inline caller ranges
+            //
+            // add leaf range files first because they get searched for linearly
+            // during line info processing
+            compiledMethodEntry.leafRangeIterator().forEachRemaining(subRange -> {
+                checkInclude(classEntry, subRange.getFileEntry(), visitedFiles, visitedDirs);
+            });
+            // now the non-leaf range files
+            compiledMethodEntry.topDownRangeIterator().forEachRemaining(subRange -> {
+                if (!subRange.isLeaf()) {
+                    checkInclude(classEntry, subRange.getFileEntry(), visitedFiles, visitedDirs);
+                }
+            });
+        });
+        // now all files and dirs are known build an index for them
+        classEntry.buildFileAndDirIndexes();
+    }
+
+    private static void checkInclude(ClassEntry classEntry, FileEntry fileEntry, EconomicSet<FileEntry> visitedFiles, EconomicSet<DirEntry> visitedDirs) {
+        if (fileEntry != null && !visitedFiles.contains(fileEntry)) {
+            visitedFiles.add(fileEntry);
+            classEntry.includeFile(fileEntry);
+            DirEntry dirEntry = fileEntry.getDirEntry();
+            if (dirEntry != null && !dirEntry.getPathString().isEmpty() && !visitedDirs.contains(dirEntry)) {
+                visitedDirs.add(dirEntry);
+                classEntry.includeDir(dirEntry);
+            }
+        }
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -732,29 +732,29 @@ public abstract class DebugInfoBase {
         EconomicSet<FileEntry> visitedFiles = EconomicSet.create();
         EconomicSet<DirEntry> visitedDirs = EconomicSet.create();
         // add the class's file and dir
-        checkInclude(classEntry, classEntry.getFileEntry(), visitedFiles, visitedDirs);
+        includeOnce(classEntry, classEntry.getFileEntry(), visitedFiles, visitedDirs);
         // add files for fields (may differ from class file if we have a substitution)
         for (FieldEntry fieldEntry : classEntry.fields) {
-            checkInclude(classEntry, fieldEntry.getFileEntry(), visitedFiles, visitedDirs);
+            includeOnce(classEntry, fieldEntry.getFileEntry(), visitedFiles, visitedDirs);
         }
         // add files for declared methods (may differ from class file if we have a substitution)
         for (MethodEntry methodEntry : classEntry.getMethods()) {
-            checkInclude(classEntry, methodEntry.getFileEntry(), visitedFiles, visitedDirs);
+            includeOnce(classEntry, methodEntry.getFileEntry(), visitedFiles, visitedDirs);
         }
         // add files for top level compiled and inline methods
         classEntry.compiledEntries().forEachOrdered(compiledMethodEntry -> {
-            checkInclude(classEntry, compiledMethodEntry.getPrimary().getFileEntry(), visitedFiles, visitedDirs);
+            includeOnce(classEntry, compiledMethodEntry.getPrimary().getFileEntry(), visitedFiles, visitedDirs);
             // we need files for leaf ranges and for inline caller ranges
             //
             // add leaf range files first because they get searched for linearly
             // during line info processing
             compiledMethodEntry.leafRangeIterator().forEachRemaining(subRange -> {
-                checkInclude(classEntry, subRange.getFileEntry(), visitedFiles, visitedDirs);
+                includeOnce(classEntry, subRange.getFileEntry(), visitedFiles, visitedDirs);
             });
             // now the non-leaf range files
             compiledMethodEntry.topDownRangeIterator().forEachRemaining(subRange -> {
                 if (!subRange.isLeaf()) {
-                    checkInclude(classEntry, subRange.getFileEntry(), visitedFiles, visitedDirs);
+                    includeOnce(classEntry, subRange.getFileEntry(), visitedFiles, visitedDirs);
                 }
             });
         });
@@ -762,7 +762,17 @@ public abstract class DebugInfoBase {
         classEntry.buildFileAndDirIndexes();
     }
 
-    private static void checkInclude(ClassEntry classEntry, FileEntry fileEntry, EconomicSet<FileEntry> visitedFiles, EconomicSet<DirEntry> visitedDirs) {
+    /**
+     * Ensure the supplied file entry and associated directory entry are included, but only once, in
+     * a class entry's file and dir list.
+     * 
+     * @param classEntry the class entry whose file and dir list may need to be updated
+     * @param fileEntry a file entry which may need to be added to the class entry's file list or
+     *            whose dir may need adding to the class entry's dir list
+     * @param visitedFiles a set tracking current file list entries, updated if a file is added
+     * @param visitedDirs a set tracking current dir list entries, updated if a dir is added
+     */
+    private static void includeOnce(ClassEntry classEntry, FileEntry fileEntry, EconomicSet<FileEntry> visitedFiles, EconomicSet<DirEntry> visitedDirs) {
         if (fileEntry != null && !visitedFiles.contains(fileEntry)) {
             visitedFiles.add(fileEntry);
             classEntry.includeFile(fileEntry);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DirEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DirEntry.java
@@ -37,11 +37,9 @@ import java.nio.file.Path;
  */
 public class DirEntry {
     private final Path path;
-    private final int idx;
 
-    public DirEntry(Path path, int idx) {
+    public DirEntry(Path path) {
         this.path = path;
-        this.idx = idx;
     }
 
     public Path getPath() {
@@ -51,14 +49,4 @@ public class DirEntry {
     public String getPathString() {
         return path.toString();
     }
-
-    /**
-     * Retrieve the index of the dir entry in the list of all known dirs.
-     *
-     * @return the index of the file entry.
-     */
-    public int getIdx() {
-        return idx;
-    }
-
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
@@ -32,12 +32,10 @@ package com.oracle.objectfile.debugentry;
 public class FileEntry {
     private final String fileName;
     private final DirEntry dirEntry;
-    private final int idx;
 
-    public FileEntry(String fileName, DirEntry dirEntry, int idx) {
+    public FileEntry(String fileName, DirEntry dirEntry) {
         this.fileName = fileName;
         this.dirEntry = dirEntry;
-        this.idx = idx;
     }
 
     /**
@@ -45,15 +43,6 @@ public class FileEntry {
      */
     public String getFileName() {
         return fileName;
-    }
-
-    /**
-     * Retrieve the index of the file entry in the list of all known files.
-     *
-     * @return the index of the file entry.
-     */
-    public int getIdx() {
-        return idx;
     }
 
     public String getPathName() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
@@ -82,7 +82,12 @@ public abstract class MemberEntry {
     }
 
     public int getFileIdx() {
-        return fileEntry.getIdx();
+        if (ownerType instanceof ClassEntry) {
+            return ((ClassEntry) ownerType).getFileIdx(fileEntry);
+        }
+        // should not be asking for a file for header fields
+        assert false : "not expecting a file lookup for header fields";
+        return 1;
     }
 
     public int getLine() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/Range.java
@@ -211,10 +211,6 @@ public abstract class Range {
         return methodEntry.getFileEntry();
     }
 
-    public int getFileIndex() {
-        return getFileEntry().getIdx();
-    }
-
     public int getModifiers() {
         return methodEntry.getModifiers();
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
@@ -53,6 +53,7 @@ import com.oracle.objectfile.elf.dwarf.DwarfDebugInfo;
 import com.oracle.objectfile.elf.dwarf.DwarfFrameSectionImpl;
 import com.oracle.objectfile.elf.dwarf.DwarfInfoSectionImpl;
 import com.oracle.objectfile.elf.dwarf.DwarfLineSectionImpl;
+import com.oracle.objectfile.elf.dwarf.DwarfRangesSectionImpl;
 import com.oracle.objectfile.elf.dwarf.DwarfStrSectionImpl;
 import com.oracle.objectfile.io.AssemblyBuffer;
 import com.oracle.objectfile.io.OutputAssembler;
@@ -1180,6 +1181,7 @@ public class ELFObjectFile extends ObjectFile {
         DwarfLocSectionImpl elfLocSectionImpl = dwarfSections.getLocSectionImpl();
         DwarfInfoSectionImpl elfInfoSectionImpl = dwarfSections.getInfoSectionImpl();
         DwarfARangesSectionImpl elfARangesSectionImpl = dwarfSections.getARangesSectionImpl();
+        DwarfRangesSectionImpl elfRangesSectionImpl = dwarfSections.getRangesSectionImpl();
         DwarfLineSectionImpl elfLineSectionImpl = dwarfSections.getLineSectionImpl();
         /* Now we can create the section elements with empty content. */
         newUserDefinedSection(elfStrSectionImpl.getSectionName(), elfStrSectionImpl);
@@ -1188,6 +1190,7 @@ public class ELFObjectFile extends ObjectFile {
         newUserDefinedSection(elfLocSectionImpl.getSectionName(), elfLocSectionImpl);
         newUserDefinedSection(elfInfoSectionImpl.getSectionName(), elfInfoSectionImpl);
         newUserDefinedSection(elfARangesSectionImpl.getSectionName(), elfARangesSectionImpl);
+        newUserDefinedSection(elfRangesSectionImpl.getSectionName(), elfRangesSectionImpl);
         newUserDefinedSection(elfLineSectionImpl.getSectionName(), elfLineSectionImpl);
         /*
          * Add symbols for the base of all DWARF sections whose content may need to be referenced
@@ -1199,6 +1202,7 @@ public class ELFObjectFile extends ObjectFile {
         createDefinedSymbol(elfInfoSectionImpl.getSectionName(), elfInfoSectionImpl.getElement(), 0, 0, false, false);
         createDefinedSymbol(elfLineSectionImpl.getSectionName(), elfLineSectionImpl.getElement(), 0, 0, false, false);
         createDefinedSymbol(elfStrSectionImpl.getSectionName(), elfStrSectionImpl.getElement(), 0, 0, false, false);
+        createDefinedSymbol(elfRangesSectionImpl.getSectionName(), elfRangesSectionImpl.getElement(), 0, 0, false, false);
         createDefinedSymbol(elfLocSectionImpl.getSectionName(), elfLocSectionImpl.getElement(), 0, 0, false, false);
         /*
          * The byte[] for each implementation's content are created and written under
@@ -1215,6 +1219,7 @@ public class ELFObjectFile extends ObjectFile {
         elfInfoSectionImpl.getOrCreateRelocationElement(0);
         elfLocSectionImpl.getOrCreateRelocationElement(0);
         elfARangesSectionImpl.getOrCreateRelocationElement(0);
+        elfRangesSectionImpl.getOrCreateRelocationElement(0);
         elfLineSectionImpl.getOrCreateRelocationElement(0);
         /* Ok now we can populate the debug info model. */
         dwarfSections.installDebugInfo(debugInfoProvider);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -76,8 +76,19 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * For the moment we only use one abbrev table and one CU. It employs the following top level and
- * nested DIES
+ * For the moment we only use one abbrev table with two types of CU. There is one occurrence of the
+ * <code>builtin_unit</code> CU which includes definitions of Java primitive value types and the
+ * struct type used to model a Java object header. There are multiple occurrences of the
+ * <code>class_unit</code> CU, one for each Java class, interface or array class included in the
+ * generated native image binary. The latter describes the class, array or interface layout and
+ * defines a class, interface or array reference pointer type. It provides declarations for instance
+ * and static methods and static fields of a class, and methods of an interface. In the case of a
+ * class it may also include definitions of static fields (i.e. location info) and for a class or
+ * interface definitions of compiled methods (i.e. code address locations). The latter may include
+ * details of inlined method frames and top level or inlined parameter or local variable locations.
+ * <p>
+ *
+ * These two CUs include the following top level and nested DIES
  * <p>
  *
  * Level 0 DIEs
@@ -86,8 +97,11 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>code = null, tag == null</code> - empty terminator
  *
- * <li><code>code = class_unit, tag == compile_unit</code> - CU that defines the Java object header
- * struct, all Java primitive and object types and all Java compiled code.
+ * <li><code>code = builtin_unit, tag == class_unit</code> - CU that defines the Java object header
+ * struct and all Java primitive types.
+ *
+ * <li><code>code = class_unit, tag == class_unit</code> - CU that defines a specific Java object,
+ * interface or array type.
  *
  * </ul>
  *
@@ -95,12 +109,13 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <ul>
  *
- * <li><code>code = primitive_type, tag == base_type, parent = class_unit</code> - Java primitive
+ * <li><code>code = primitive_type, tag == base_type, parent = builtin_unit</code> - Java primitive
  * type (non-void)
  *
- * <li><code>code = void_type, tag == unspecified_type, parent = class_unit</code> - Java void type
+ * <li><code>code = void_type, tag == unspecified_type, parent = builtin_unit</code> - Java void
+ * type
  *
- * <li><code>code = object_header, tag == structure_type, parent = class_unit</code> - Java object
+ * <li><code>code = object_header, tag == structure_type, parent = builtin_unit</code> - Java object
  * header
  *
  * <li><code>code = class_layout, tag == class_type, parent = class_unit</code> - Java instance type
@@ -115,10 +130,10 @@ import org.graalvm.compiler.debug.DebugContext;
  * <li><code>code = static_field_location, tag == variable, parent = class_unit</code> - Java static
  * field definition (i.e. location of data)
  *
- * <li><code>code = array_layout, tag == structure_type, parent = array_unit</code> - Java array
+ * <li><code>code = array_layout, tag == structure_type, parent = class_unit</code> - Java array
  * type structure definition
  *
- * <li><code>code = array_pointer, tag == pointer_type, parent = array_unit</code> - Java array ref
+ * <li><code>code = array_pointer, tag == pointer_type, parent = class_unit</code> - Java array ref
  * type
  *
  * <li><code>code = interface_layout, tag == union_type, parent = class_unit</code> - Java array
@@ -127,25 +142,23 @@ import org.graalvm.compiler.debug.DebugContext;
  * <li><code>code = interface_pointer, tag == pointer_type, parent = class_unit</code> - Java
  * interface ref type
  *
- * <li><code>code = indirect_layout, tag == class_type, parent = class_unit, array_unit,
- * interface_unit</code> - wrapper layout attaches address rewriting logic to the layout types that
- * it wraps using a data_location attribute
+ * <li><code>code = indirect_layout, tag == class_type, parent = class_unit</code> - wrapper layout
+ * attaches address rewriting logic to the layout types that it wraps using a
+ * <code>data_location</code> attribute
  *
- * <li><code>code = indirect_pointer, tag == pointer_type, parent = class_unit, array_unit,
- * interface_unit</code> - indirect ref type used to type indirect oops that encode the address of
- * an object, whether by adding tag bits or representing the address as an offset from some base
- * address. these are used to type object references stored in static and instance fields. They are
- * not needed when typing local vars and parameters held in registers or on the stack as they appear
- * as raw addresses.
+ * <li><code>code = indirect_pointer, tag == pointer_type, parent = class_unit</code> - indirect ref
+ * type used to type indirect oops that encode the address of an object, whether by adding tag bits
+ * or representing the address as an offset from some base address. these are used to type object
+ * references stored in static and instance fields. They are not needed when typing local vars and
+ * parameters held in registers or on the stack as they appear as raw addresses.
  *
- * <li><code>code = namespace, tag == namespace, parent = class_unit, array_unit,
- * interface_unit</code> - a wrap-around DIE that is used to embed all the normal level 1 DIEs of a
- * <code>class_unit</code> or <code>array_unit</code> in a namespace. This is needed when the
- * corresponding class/interface or array base element type have been loaded by a loader with a
- * non-empty loader in order to ensure that mangled names for the class and its members can
- * legitimately employ the loader id as a namespace prefix. Note that use of a namespace wrapper DIE
- * causes all the embedded level 1+ DIEs documented above and all their children to be generated at
- * a level one greater than documented here.
+ * <li><code>code = namespace, tag == namespace, parent = class_unit</code> - a wrap-around DIE that
+ * is used to embed all the normal level 1 DIEs of a <code>class_unit</code> in a namespace. This is
+ * needed when the corresponding class/interface or array base element type have been loaded by a
+ * loader with a non-empty loader in order to ensure that mangled names for the class and its
+ * members can legitimately employ the loader id as a namespace prefix. Note that use of a namespace
+ * wrapper DIE causes all the embedded level 1+ DIEs documented above and all their children to be
+ * generated at a level one greater than documented here.
  *
  * </ul>
  *
@@ -156,7 +169,7 @@ import org.graalvm.compiler.debug.DebugContext;
  * <li><code>code = header_field, tag == member, parent = object_header</code> - object/array header
  * field
  *
- * <li><code>code == method_declaration1/2, tag == subprogram, parent = class_layout</code>
+ * <li><code>code == method_declaration1/2, tag == subprogram, parent = class_layout, interface_layout</code>
  *
  * <li><code>code = field_declaration1/2/3/4, tag == member, parent = class_layout</code> - instance
  * field declaration (i.e. specification of properties)
@@ -192,12 +205,28 @@ import org.graalvm.compiler.debug.DebugContext;
  * Detailed layouts of the DIEs listed above are as follows:
  * <p>
  *
- * A single instance of the level 0 <code>class_unit</code> compile unit provides details of the
- * object header struct, all Java primitive and object types and all Java compiled code.
+ * A single instance of the level 0 <code>builtin_unit</code> compile unit provide details of all
+ * Java primitive types and the struct type used to model a Java object header
  *
  * <ul>
  *
- * <li><code>abbrev_code == class_unit, tag == DW_TAG_compilation_unit,
+ * <li><code>abbrev_code == built_unit, tag == DW_TAG_compilation_unit,
+ * has_children</code>
+ *
+ * <li><code>DW_AT_language : ... DW_FORM_data1</code>
+ *
+ * <li><code>DW_AT_name : ....... DW_FORM_strp</code>
+ *
+ * <li><code>DW_AT_use_UTF8 : ... DW_FORM_flag</code>
+ *
+ * </ul>
+ *
+ * Instances of the level 0 <code>class_unit</code> compile unit provide details of all Java object
+ * types and compiled code.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == class_unit1/2, tag == DW_TAG_compilation_unit,
  * has_children</code>
  *
  * <li><code>DW_AT_language : ... DW_FORM_data1</code>
@@ -206,18 +235,15 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>DW_AT_comp_dir : ... DW_FORM_strp</code>
  *
- * <li><code>DW_AT_low_pc : ..... DW_FORM_address</code>
+ * <li><code>DW_AT_low_pc : ..... DW_FORM_address</code> only for class_unit1
  *
- * <li><code>DW_AT_hi_pc : ...... DW_FORM_address</code>
+ * <li><code>DW_AT_hi_pc : ...... DW_FORM_address</code> only for class_unit1
  *
  * <li><code>DW_AT_use_UTF8 : ... DW_FORM_flag</code>
  *
  * <li><code>DW_AT_stmt_list : .. DW_FORM_sec_offset</code>
  *
  * </ul>
- *
- * All other Java derived DIEs are embedded within this top level CU.
- * <p>
  *
  * Primitive Types: For each non-void Java primitive type there is a level 1 DIE defining a base
  * type
@@ -812,7 +838,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
 
     public int writeAbbrevs(DebugContext context, byte[] buffer, int p) {
         int pos = p;
-        pos = writeClassUnitAbbrev(context, buffer, pos);
+        pos = writeCompileUnitAbbrevs(context, buffer, pos);
 
         pos = writePrimitiveTypeAbbrev(context, buffer, pos);
         pos = writeVoidTypeAbbrev(context, buffer, pos);
@@ -880,9 +906,17 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         return writeSLEB(code, buffer, pos);
     }
 
-    private int writeClassUnitAbbrev(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
+    private int writeCompileUnitAbbrevs(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
         int pos = p;
-        pos = writeAbbrevCode(DwarfDebugInfo.DW_ABBREV_CODE_class_unit, buffer, pos);
+        pos = writeCompileUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_builtin_unit, buffer, pos);
+        pos = writeCompileUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit1, buffer, pos);
+        pos = writeCompileUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit2, buffer, pos);
+        return pos;
+    }
+
+    private int writeCompileUnitAbbrev(@SuppressWarnings("unused") DebugContext context, int abbrevCode, byte[] buffer, int p) {
+        int pos = p;
+        pos = writeAbbrevCode(abbrevCode, buffer, pos);
         pos = writeTag(DwarfDebugInfo.DW_TAG_compile_unit, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_yes, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_language, buffer, pos);
@@ -893,12 +927,14 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_comp_dir, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_low_pc, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_hi_pc, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_stmt_list, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
+        if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_class_unit2) {
+            pos = writeAttrType(DwarfDebugInfo.DW_AT_ranges, buffer, pos);
+            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
+            pos = writeAttrType(DwarfDebugInfo.DW_AT_low_pc, buffer, pos);
+            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
+            pos = writeAttrType(DwarfDebugInfo.DW_AT_stmt_list, buffer, pos);
+            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
+        }
         /*
          * Now terminate.
          */
@@ -1574,7 +1610,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeTag(DwarfDebugInfo.DW_TAG_formal_parameter, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_parameter_location2) {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_location, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
@@ -1593,7 +1629,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeTag(DwarfDebugInfo.DW_TAG_variable, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_local_location2) {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_location, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
@@ -1618,7 +1654,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeTag(DwarfDebugInfo.DW_TAG_inlined_subroutine, buffer, pos);
         pos = writeFlag(withChildren ? DwarfDebugInfo.DW_CHILDREN_yes : DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_low_pc, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_hi_pc, buffer, pos);
@@ -1634,9 +1670,9 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
     }
 
     /**
-     * The debug_abbrev section depends on debug_aranges section.
+     * The debug_abbrev section depends on debug_ranges section.
      */
-    private static final String TARGET_SECTION_NAME = DwarfDebugInfo.DW_ARANGES_SECTION_NAME;
+    private static final String TARGET_SECTION_NAME = DwarfDebugInfo.DW_RANGES_SECTION_NAME;
 
     @Override
     public String targetSectionName() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -388,12 +388,12 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>DW_AT_declaration : ....... DW_FORM_flag</code>
  *
- * <li><code>Dw_AT_object_pointer : .... DW_FORM_ref_addr</code> n.b. only for method_declaration1,
+ * <li><code>Dw_AT_object_pointer : .... DW_FORM_ref4</code> n.b. only for method_declaration1,
  * points to param 0 DIE
  *
  * <li><code>DW_AT_virtuality : ........ DW_FORM_data1<code> (for override methods)
  *
- * <li><code>DW_AT_containing_type : ... DW_FORM_ref_addr</code> (for override methods)
+ * <li><code>DW_AT_containing_type : ... DW_FORM_ref4</code> (for override methods)
  *
  * </ul>
  *
@@ -519,7 +519,7 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
  *
- * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
+ * <li><code>Dw_AT_type : ........ DW_FORM_ref4</code>
  *
  * </ul>
  *
@@ -529,7 +529,7 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
  *
- * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
+ * <li><code>Dw_AT_type : ........ DW_FORM_ref4</code>
  *
  * </ul>
  *
@@ -569,7 +569,7 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>DW_AT_external : ........ DW_FORM_flag</code>
  *
- * <li><code>DW_AT_specification : ... DW_FORM_ref_addr</code>
+ * <li><code>DW_AT_specification : ... DW_FORM_ref4</code>
  *
  * </ul>
  *
@@ -638,7 +638,7 @@ import org.graalvm.compiler.debug.DebugContext;
  * <li><code>abbrev_code == static_field_location, tag == DW_TAG_variable,
  * no_children</code>
  *
- * <li><code>DW_AT_specification : ... DW_FORM_ref_addr</code>
+ * <li><code>DW_AT_specification : ... DW_FORM_ref4</code>
  *
  * <li><code>DW_AT_linkage_name : .... DW_FORM_strp</code>
  *
@@ -697,7 +697,7 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
  *
- * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
+ * <li><code>Dw_AT_type : ........ DW_FORM_ref4</code>
  *
  * </ul>
  *
@@ -765,7 +765,7 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
  *
- * <li><code>DW_AT_TYPE : ....... DW_FORM_ref_addr</code>
+ * <li><code>DW_AT_TYPE : ....... DW_FORM_ref4</code>
  *
  * </ul>
  *
@@ -1060,7 +1060,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrType(DwarfDebugInfo.DW_AT_byte_size, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_type, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         /*
          * Now terminate.
          */
@@ -1103,10 +1103,10 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         // pos = writeAttrType(DwarfDebugInfo.DW_AT_virtuality, buffer, pos);
         // pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_containing_type, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_declaration) {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_object_pointer, buffer, pos);
-            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         }
         /*
          * Now terminate.
@@ -1221,7 +1221,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrType(DwarfDebugInfo.DW_AT_byte_size, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_type, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         /*
          * Now terminate.
          */
@@ -1255,7 +1255,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrType(DwarfDebugInfo.DW_AT_byte_size, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_type, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         /*
          * Now terminate.
          */
@@ -1293,6 +1293,9 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_byte_size, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
+        // n.b we use a (relocatable) ref_addr here rather than a (CU-relative) ref4
+        // because an unknown foreign pointer type will reference void which is not
+        // local to the current CU.
         pos = writeAttrType(DwarfDebugInfo.DW_AT_type, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
         /*
@@ -1313,7 +1316,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrType(DwarfDebugInfo.DW_AT_name, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_type, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         /*
          * Now terminate.
          */
@@ -1381,6 +1384,9 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_byte_size, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data4, buffer, pos);
         }
+        // n.b we use a (relocatable) ref_addr here rather than a (CU-relative) ref4
+        // because a foreign array type can reference another foreign type which is
+        // not in the current CU.
         pos = writeAttrType(DwarfDebugInfo.DW_AT_type, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
         /*
@@ -1420,7 +1426,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrType(DwarfDebugInfo.DW_AT_external, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_flag, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_specification, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         /*
          * Now terminate.
          */
@@ -1509,7 +1515,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrType(DwarfDebugInfo.DW_AT_byte_size, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_type, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         /*
          * Now terminate.
          */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -588,10 +588,40 @@ import org.graalvm.compiler.debug.DebugContext;
  * <li><code>abbrev_code == DW_ABBREV_CODE_method_local_location1/2, tag ==
  * DW_TAG_formal_parameter, no_children</code>
  *
- * <li><code>DW_AT_specification : .......... DW_FORM_ref_addr</code>
+ * <li><code>DW_AT_specification : .......... DW_FORM_ref4</code>
  *
  * <li><code>DW_AT_location: ................ DW_FORM_sec_offset</code> n.b. only for
  * method_local_location2
+ *
+ * </ul>
+ *
+ * Abstract Inline Methods: For any method m' which has been inlined into a top level
+ * compiled method m there will be an abstract_inline_method DIE for m' at level 1 DIE in
+ * the CU to which m belongs. The declaration serves as an abstract_origin for any
+ * corresponding inlined method DIEs appearing as children of m. The abstract_inline_method
+ * DIE will inherit attributes from the method_definition DIE referenced as its
+ * specification attribute without the need to repeat them, including attributes specified
+ * in child DIEs of the method_definition. However, it is actually necessary to replicate
+ * the method_parameter/local_declaration DIEs of the specification as children of the
+ * abstract_inline_method DIE. This provides a CU-local target for references from the
+ * corresponding method_parameter/local_location DIEs that sit below the inlined_subroutine
+ * DIEs in the concrete inlined subroutine tree. This is needed because some tools require
+ * the location DIEs abstract_origin attribute that links the location to specification to
+ * be a CU-relative offset (FORM_Ref4) rather than a relcoatabel cross-CU info section
+ * offset. This has the added benefit that repeated reference to abstract inline methods or
+ * parameters from concrete inline method DIEs or parameter or local location DIES only
+ * avoids the cost of tracking separate relocatable reference.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == DW_ABBREV_CODE_abstract_inline_method, tag == DW_TAG_subprogram,
+ * has_children</code>
+ *
+ * <li><code>DW_AT_inline : .......... DW_FORM_data1</code>
+ *
+ * <li><code>DW_AT_external : ........ DW_FORM_flag</code>
+ *
+ * <li><code>DW_AT_specification : ... DW_FORM_ref_addr</code>
  *
  * </ul>
  *
@@ -618,7 +648,7 @@ import org.graalvm.compiler.debug.DebugContext;
  * <li><code>abbrev_code == DW_ABBREV_CODE_inlined_subroutine_with_children, tag ==
  * DW_TAG_subprogram, has_children</code>
  *
- * <li><code>DW_AT_abstract_origin : ... DW_FORM_ref_addr</code>
+ * <li><code>DW_AT_abstract_origin : ... DW_FORM_ref4</code>
  *
  * <li><code>DW_AT_low_pc : ............ DW_FORM_addr</code>
  *
@@ -866,6 +896,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeArrayDataTypeAbbrevs(context, buffer, pos);
         pos = writeArraySubrangeTypeAbbrev(context, buffer, pos);
         pos = writeMethodLocationAbbrev(context, buffer, pos);
+        pos = writeAbstractInlineMethodAbbrev(context, buffer, pos);
         pos = writeStaticFieldLocationAbbrev(context, buffer, pos);
         pos = writeSuperReferenceAbbrev(context, buffer, pos);
         pos = writeInterfaceImplementorAbbrev(context, buffer, pos);
@@ -1435,6 +1466,24 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
+    private int writeAbstractInlineMethodAbbrev(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
+        int pos = p;
+        pos = writeAbbrevCode(DwarfDebugInfo.DW_ABBREV_CODE_abstract_inline_method, buffer, pos);
+        pos = writeTag(DwarfDebugInfo.DW_TAG_subprogram, buffer, pos);
+        pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_yes, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_inline, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_external, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_flag, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_specification, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        /*
+         * Now terminate.
+         */
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_null, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_null, buffer, pos);
+        return pos;
+    }
     private int writeStaticFieldLocationAbbrev(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
         int pos = p;
 
@@ -1616,7 +1665,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeTag(DwarfDebugInfo.DW_TAG_formal_parameter, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_parameter_location2) {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_location, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
@@ -1635,7 +1684,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeTag(DwarfDebugInfo.DW_TAG_variable, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_local_location2) {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_location, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
@@ -1660,7 +1709,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeTag(DwarfDebugInfo.DW_TAG_inlined_subroutine, buffer, pos);
         pos = writeFlag(withChildren ? DwarfDebugInfo.DW_CHILDREN_yes : DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_low_pc, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_hi_pc, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -595,22 +595,21 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Abstract Inline Methods: For any method m' which has been inlined into a top level
- * compiled method m there will be an abstract_inline_method DIE for m' at level 1 DIE in
- * the CU to which m belongs. The declaration serves as an abstract_origin for any
- * corresponding inlined method DIEs appearing as children of m. The abstract_inline_method
- * DIE will inherit attributes from the method_definition DIE referenced as its
- * specification attribute without the need to repeat them, including attributes specified
- * in child DIEs of the method_definition. However, it is actually necessary to replicate
- * the method_parameter/local_declaration DIEs of the specification as children of the
- * abstract_inline_method DIE. This provides a CU-local target for references from the
- * corresponding method_parameter/local_location DIEs that sit below the inlined_subroutine
- * DIEs in the concrete inlined subroutine tree. This is needed because some tools require
- * the location DIEs abstract_origin attribute that links the location to specification to
- * be a CU-relative offset (FORM_Ref4) rather than a relcoatabel cross-CU info section
- * offset. This has the added benefit that repeated reference to abstract inline methods or
- * parameters from concrete inline method DIEs or parameter or local location DIES only
- * avoids the cost of tracking separate relocatable reference.
+ * Abstract Inline Methods: For any method m' which has been inlined into a top level compiled
+ * method m there will be an abstract_inline_method DIE for m' at level 1 DIE in the CU to which m
+ * belongs. The declaration serves as an abstract_origin for any corresponding inlined method DIEs
+ * appearing as children of m. The abstract_inline_method DIE will inherit attributes from the
+ * method_definition DIE referenced as its specification attribute without the need to repeat them,
+ * including attributes specified in child DIEs of the method_definition. However, it is actually
+ * necessary to replicate the method_parameter/local_declaration DIEs of the specification as
+ * children of the abstract_inline_method DIE. This provides a CU-local target for references from
+ * the corresponding method_parameter/local_location DIEs that sit below the inlined_subroutine DIEs
+ * in the concrete inlined subroutine tree. This is needed because some tools require the location
+ * DIEs abstract_origin attribute that links the location to specification to be a CU-relative
+ * offset (FORM_Ref4) rather than a relcoatabel cross-CU info section offset. This has the added
+ * benefit that repeated reference to abstract inline methods or parameters from concrete inline
+ * method DIEs or parameter or local location DIES only avoids the cost of tracking separate
+ * relocatable reference.
  *
  * <ul>
  *
@@ -1484,6 +1483,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_null, buffer, pos);
         return pos;
     }
+
     private int writeStaticFieldLocationAbbrev(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
         int pos = p;
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -58,6 +58,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final String DW_INFO_SECTION_NAME = ".debug_info";
     public static final String DW_LOC_SECTION_NAME = ".debug_loc";
     public static final String DW_ARANGES_SECTION_NAME = ".debug_aranges";
+    public static final String DW_RANGES_SECTION_NAME = ".debug_ranges";
 
     /**
      * Currently generated debug info relies on DWARF spec version 4.
@@ -70,54 +71,56 @@ public class DwarfDebugInfo extends DebugInfoBase {
      */
     @SuppressWarnings("unused") public static final int DW_ABBREV_CODE_null = 0;
     /* Level 0 DIEs. */
-    public static final int DW_ABBREV_CODE_class_unit = 1;
+    public static final int DW_ABBREV_CODE_builtin_unit = 1;
+    public static final int DW_ABBREV_CODE_class_unit1 = 2;
+    public static final int DW_ABBREV_CODE_class_unit2 = 3;
     /* Level 1 DIEs. */
-    public static final int DW_ABBREV_CODE_primitive_type = 2;
-    public static final int DW_ABBREV_CODE_void_type = 3;
-    public static final int DW_ABBREV_CODE_object_header = 4;
-    public static final int DW_ABBREV_CODE_namespace = 5;
-    public static final int DW_ABBREV_CODE_class_layout1 = 6;
-    public static final int DW_ABBREV_CODE_class_layout2 = 7;
-    public static final int DW_ABBREV_CODE_class_pointer = 8;
-    public static final int DW_ABBREV_CODE_foreign_pointer = 9;
-    public static final int DW_ABBREV_CODE_foreign_typedef = 10;
-    public static final int DW_ABBREV_CODE_foreign_struct = 11;
-    public static final int DW_ABBREV_CODE_method_location = 12;
-    public static final int DW_ABBREV_CODE_static_field_location = 13;
-    public static final int DW_ABBREV_CODE_array_layout = 14;
-    public static final int DW_ABBREV_CODE_array_pointer = 15;
-    public static final int DW_ABBREV_CODE_interface_layout = 16;
-    public static final int DW_ABBREV_CODE_interface_pointer = 17;
-    public static final int DW_ABBREV_CODE_indirect_layout = 18;
-    public static final int DW_ABBREV_CODE_indirect_pointer = 19;
+    public static final int DW_ABBREV_CODE_primitive_type = 4;
+    public static final int DW_ABBREV_CODE_void_type = 5;
+    public static final int DW_ABBREV_CODE_object_header = 6;
+    public static final int DW_ABBREV_CODE_namespace = 7;
+    public static final int DW_ABBREV_CODE_class_layout1 = 8;
+    public static final int DW_ABBREV_CODE_class_layout2 = 9;
+    public static final int DW_ABBREV_CODE_class_pointer = 10;
+    public static final int DW_ABBREV_CODE_foreign_pointer = 11;
+    public static final int DW_ABBREV_CODE_foreign_typedef = 12;
+    public static final int DW_ABBREV_CODE_foreign_struct = 13;
+    public static final int DW_ABBREV_CODE_method_location = 14;
+    public static final int DW_ABBREV_CODE_static_field_location = 15;
+    public static final int DW_ABBREV_CODE_array_layout = 16;
+    public static final int DW_ABBREV_CODE_array_pointer = 17;
+    public static final int DW_ABBREV_CODE_interface_layout = 18;
+    public static final int DW_ABBREV_CODE_interface_pointer = 19;
+    public static final int DW_ABBREV_CODE_indirect_layout = 20;
+    public static final int DW_ABBREV_CODE_indirect_pointer = 21;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_declaration = 20;
-    public static final int DW_ABBREV_CODE_method_declaration_static = 21;
-    public static final int DW_ABBREV_CODE_field_declaration1 = 22;
-    public static final int DW_ABBREV_CODE_field_declaration2 = 23;
-    public static final int DW_ABBREV_CODE_field_declaration3 = 24;
-    public static final int DW_ABBREV_CODE_field_declaration4 = 25;
-    public static final int DW_ABBREV_CODE_class_constant = 26;
-    public static final int DW_ABBREV_CODE_header_field = 27;
-    public static final int DW_ABBREV_CODE_array_data_type1 = 28;
-    public static final int DW_ABBREV_CODE_array_data_type2 = 29;
-    public static final int DW_ABBREV_CODE_array_subrange = 30;
-    public static final int DW_ABBREV_CODE_super_reference = 31;
-    public static final int DW_ABBREV_CODE_interface_implementor = 32;
+    public static final int DW_ABBREV_CODE_method_declaration = 22;
+    public static final int DW_ABBREV_CODE_method_declaration_static = 23;
+    public static final int DW_ABBREV_CODE_field_declaration1 = 24;
+    public static final int DW_ABBREV_CODE_field_declaration2 = 25;
+    public static final int DW_ABBREV_CODE_field_declaration3 = 26;
+    public static final int DW_ABBREV_CODE_field_declaration4 = 27;
+    public static final int DW_ABBREV_CODE_class_constant = 28;
+    public static final int DW_ABBREV_CODE_header_field = 29;
+    public static final int DW_ABBREV_CODE_array_data_type1 = 30;
+    public static final int DW_ABBREV_CODE_array_data_type2 = 31;
+    public static final int DW_ABBREV_CODE_array_subrange = 32;
+    public static final int DW_ABBREV_CODE_super_reference = 33;
+    public static final int DW_ABBREV_CODE_interface_implementor = 34;
     /* Level 2+K DIEs (where inline depth K >= 0) */
-    public static final int DW_ABBREV_CODE_inlined_subroutine = 33;
-    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 34;
+    public static final int DW_ABBREV_CODE_inlined_subroutine = 35;
+    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 36;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 35;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 36;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 37;
-    public static final int DW_ABBREV_CODE_method_local_declaration1 = 38;
-    public static final int DW_ABBREV_CODE_method_local_declaration2 = 39;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 37;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 38;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 39;
+    public static final int DW_ABBREV_CODE_method_local_declaration1 = 40;
+    public static final int DW_ABBREV_CODE_method_local_declaration2 = 41;
     /* Level 3 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_location1 = 40;
-    public static final int DW_ABBREV_CODE_method_parameter_location2 = 41;
-    public static final int DW_ABBREV_CODE_method_local_location1 = 42;
-    public static final int DW_ABBREV_CODE_method_local_location2 = 43;
+    public static final int DW_ABBREV_CODE_method_parameter_location1 = 42;
+    public static final int DW_ABBREV_CODE_method_parameter_location2 = 43;
+    public static final int DW_ABBREV_CODE_method_local_location1 = 44;
+    public static final int DW_ABBREV_CODE_method_local_location2 = 45;
 
     /*
      * Define all the Dwarf tags we need for our DIEs.
@@ -155,7 +158,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_AT_language = 0x13;
     public static final int DW_AT_comp_dir = 0x1b;
     public static final int DW_AT_containing_type = 0x1d;
-    public static final int DW_AT_inline = 0x20;
+    @SuppressWarnings("unused") public static final int DW_AT_inline = 0x20;
     public static final int DW_AT_abstract_origin = 0x31;
     public static final int DW_AT_accessibility = 0x32;
     public static final int DW_AT_artificial = 0x34;
@@ -173,6 +176,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_AT_type = 0x49;
     public static final int DW_AT_data_location = 0x50;
     public static final int DW_AT_use_UTF8 = 0x53;
+    public static final int DW_AT_ranges = 0x55;
     public static final int DW_AT_call_file = 0x58;
     public static final int DW_AT_call_line = 0x59;
     public static final int DW_AT_object_pointer = 0x64;
@@ -324,6 +328,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     private final DwarfInfoSectionImpl dwarfInfoSection;
     private final DwarfLocSectionImpl dwarfLocSection;
     private final DwarfARangesSectionImpl dwarfARangesSection;
+    private final DwarfRangesSectionImpl dwarfRangesSection;
     private final DwarfLineSectionImpl dwarfLineSection;
     private final DwarfFrameSectionImpl dwarfFameSection;
     public final ELFMachine elfMachine;
@@ -361,6 +366,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
         dwarfInfoSection = new DwarfInfoSectionImpl(this);
         dwarfLocSection = new DwarfLocSectionImpl(this);
         dwarfARangesSection = new DwarfARangesSectionImpl(this);
+        dwarfRangesSection = new DwarfRangesSectionImpl(this);
         dwarfLineSection = new DwarfLineSectionImpl(this);
 
         if (elfMachine == ELFMachine.AArch64) {
@@ -396,6 +402,10 @@ public class DwarfDebugInfo extends DebugInfoBase {
 
     public DwarfARangesSectionImpl getARangesSectionImpl() {
         return dwarfARangesSection;
+    }
+
+    public DwarfRangesSectionImpl getRangesSectionImpl() {
+        return dwarfRangesSection;
     }
 
     public DwarfLineSectionImpl getLineSectionImpl() {
@@ -470,6 +480,10 @@ public class DwarfDebugInfo extends DebugInfoBase {
 
     static class DwarfClassProperties extends DwarfTypeProperties {
         /**
+         * Index of the class entry's compile unit in the debug_info section.
+         */
+        private int cuIndex;
+        /**
          * Index of the class entry's class_layout DIE in the debug_info section.
          */
         private int layoutIndex;
@@ -478,14 +492,30 @@ public class DwarfDebugInfo extends DebugInfoBase {
          */
         private int indirectLayoutIndex;
         /**
+         * Index of the class entry's code ranges data in the debug_ranges section.
+         */
+        private int codeRangesIndex;
+        /**
+         * Index of the class entry's line data in the debug_line section.
+         */
+        private int lineIndex;
+        /**
+         * Size of the class entry's prologue in the debug_line section.
+         */
+        private int linePrologueSize;
+        /**
          * Map from field names to info section index for the field declaration.
          */
         private EconomicMap<String, Integer> fieldDeclarationIndex;
 
         DwarfClassProperties(StructureTypeEntry entry) {
             super(entry);
+            this.cuIndex = -1;
             this.layoutIndex = -1;
             this.indirectLayoutIndex = -1;
+            this.codeRangesIndex = -1;
+            this.lineIndex = -1;
+            this.linePrologueSize = -1;
             fieldDeclarationIndex = null;
         }
     }
@@ -614,6 +644,22 @@ public class DwarfDebugInfo extends DebugInfoBase {
         return typeProperties.getIndirectTypeInfoIndex();
     }
 
+    public void setCUIndex(ClassEntry classEntry, int idx) {
+        assert idx >= 0;
+        DwarfClassProperties classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        assert classProperties.cuIndex == -1 || classProperties.cuIndex == idx;
+        classProperties.cuIndex = idx;
+    }
+
+    public int getCUIndex(ClassEntry classEntry) {
+        DwarfClassProperties classProperties;
+        classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        assert classProperties.cuIndex >= 0;
+        return classProperties.cuIndex;
+    }
+
     void setLayoutIndex(ClassEntry classEntry, int idx) {
         assert idx >= 0 || idx == -1;
         DwarfClassProperties classProperties = lookupClassProperties(classEntry);
@@ -656,6 +702,54 @@ public class DwarfDebugInfo extends DebugInfoBase {
         assert classProperties.getTypeEntry() == classEntry;
         assert classProperties.indirectLayoutIndex >= 0;
         return classProperties.indirectLayoutIndex;
+    }
+
+    public void setCodeRangesIndex(ClassEntry classEntry, int idx) {
+        assert idx >= 0;
+        DwarfClassProperties classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        assert classProperties.codeRangesIndex == -1 || classProperties.codeRangesIndex == idx;
+        classProperties.codeRangesIndex = idx;
+    }
+
+    public int getCodeRangesIndex(ClassEntry classEntry) {
+        DwarfClassProperties classProperties;
+        classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        assert classProperties.codeRangesIndex >= 0;
+        return classProperties.codeRangesIndex;
+    }
+
+    public void setLineIndex(ClassEntry classEntry, int idx) {
+        assert idx >= 0;
+        DwarfClassProperties classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        assert classProperties.lineIndex == -1 || classProperties.lineIndex == idx;
+        classProperties.lineIndex = idx;
+    }
+
+    public int getLineIndex(ClassEntry classEntry) {
+        DwarfClassProperties classProperties;
+        classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        assert classProperties.lineIndex >= 0;
+        return classProperties.lineIndex;
+    }
+
+    public void setLinePrologueSize(ClassEntry classEntry, int size) {
+        assert size >= 0;
+        DwarfClassProperties classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        assert classProperties.linePrologueSize == -1 || classProperties.linePrologueSize == size;
+        classProperties.linePrologueSize = size;
+    }
+
+    public int getLinePrologueSize(ClassEntry classEntry) {
+        DwarfClassProperties classProperties;
+        classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        assert classProperties.linePrologueSize >= 0;
+        return classProperties.linePrologueSize;
     }
 
     public void setFieldDeclarationIndex(StructureTypeEntry entry, String fieldName, int pos) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -110,17 +110,18 @@ public class DwarfDebugInfo extends DebugInfoBase {
     /* Level 2+K DIEs (where inline depth K >= 0) */
     public static final int DW_ABBREV_CODE_inlined_subroutine = 35;
     public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 36;
+    public static final int DW_ABBREV_CODE_abstract_inline_method = 37;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 37;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 38;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 39;
-    public static final int DW_ABBREV_CODE_method_local_declaration1 = 40;
-    public static final int DW_ABBREV_CODE_method_local_declaration2 = 41;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 38;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 39;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 40;
+    public static final int DW_ABBREV_CODE_method_local_declaration1 = 41;
+    public static final int DW_ABBREV_CODE_method_local_declaration2 = 42;
     /* Level 3 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_location1 = 42;
-    public static final int DW_ABBREV_CODE_method_parameter_location2 = 43;
-    public static final int DW_ABBREV_CODE_method_local_location1 = 44;
-    public static final int DW_ABBREV_CODE_method_local_location2 = 45;
+    public static final int DW_ABBREV_CODE_method_parameter_location1 = 43;
+    public static final int DW_ABBREV_CODE_method_parameter_location2 = 44;
+    public static final int DW_ABBREV_CODE_method_local_location1 = 45;
+    public static final int DW_ABBREV_CODE_method_local_location2 = 46;
 
     /*
      * Define all the Dwarf tags we need for our DIEs.
@@ -322,7 +323,6 @@ public class DwarfDebugInfo extends DebugInfoBase {
      * bits
      */
     public static final String HUB_TYPE_NAME = "java.lang.Class";
-
     private final DwarfStrSectionImpl dwarfStrSection;
     private final DwarfAbbrevSectionImpl dwarfAbbrevSection;
     private final DwarfInfoSectionImpl dwarfInfoSection;
@@ -530,13 +530,20 @@ public class DwarfDebugInfo extends DebugInfoBase {
         private int methodDeclarationIndex;
 
         /**
-         * Index of info locations for params/locals belonging to a method.
+         * Per class map that identifies the info declarations for a top level method declaration
+         * or an abstract inline method declaration.
          */
-        private DwarfLocalProperties localProperties;
+        private EconomicMap<ClassEntry, DwarfLocalProperties> localPropertiesMap;
+
+        /**
+         * Per class map that identifies the info declaration for an abstract inline method.
+         */
+        private EconomicMap<ClassEntry, Integer> abstractInlineMethodIndex;
 
         DwarfMethodProperties() {
             methodDeclarationIndex = -1;
-            localProperties = null;
+            localPropertiesMap = null;
+            abstractInlineMethodIndex = null;
         }
 
         public int getMethodDeclarationIndex() {
@@ -549,11 +556,30 @@ public class DwarfDebugInfo extends DebugInfoBase {
             methodDeclarationIndex = pos;
         }
 
-        public DwarfLocalProperties getLocalProperties() {
+        public DwarfLocalProperties getLocalProperties(ClassEntry classEntry) {
+            if (localPropertiesMap == null) {
+                localPropertiesMap = EconomicMap.create();
+            }
+            DwarfLocalProperties localProperties = localPropertiesMap.get(classEntry);
             if (localProperties == null) {
                 localProperties = new DwarfLocalProperties();
+                localPropertiesMap.put(classEntry, localProperties);
             }
             return localProperties;
+        }
+
+        public void setAbstractInlineMethodIndex(ClassEntry classEntry, int pos) {
+            if (abstractInlineMethodIndex == null) {
+                abstractInlineMethodIndex = EconomicMap.create();
+            }
+            // replace but check it did not change
+            Integer val = abstractInlineMethodIndex.put(classEntry, pos);
+            assert val == null || val == pos;
+        }
+
+        public int getAbstractInlineMethodIndex(ClassEntry classEntry) {
+            // should be set before we get here but an NPE will guard that
+            return abstractInlineMethodIndex.get(classEntry);
         }
     }
 
@@ -812,23 +838,31 @@ public class DwarfDebugInfo extends DebugInfoBase {
         }
     }
 
+    public void setAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry, int pos) {
+        lookupMethodProperties(methodEntry).setAbstractInlineMethodIndex(classEntry, pos);
+    }
+
+    public int getAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry) {
+        return lookupMethodProperties(methodEntry).getAbstractInlineMethodIndex(classEntry);
+    }
+
     private DwarfLocalProperties addRangeLocalProperties(Range range) {
         DwarfLocalProperties localProperties = new DwarfLocalProperties();
         rangeLocalPropertiesIndex.put(range, localProperties);
         return localProperties;
     }
 
-    public DwarfLocalProperties lookupLocalProperties(MethodEntry methodEntry) {
-        return lookupMethodProperties(methodEntry).getLocalProperties();
+    public DwarfLocalProperties lookupLocalProperties(ClassEntry classEntry, MethodEntry methodEntry) {
+        return lookupMethodProperties(methodEntry).getLocalProperties(classEntry);
     }
 
-    public void setMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {
-        DwarfLocalProperties localProperties = lookupLocalProperties(methodEntry);
+    public void setMethodLocalIndex(ClassEntry classEntry, MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {
+        DwarfLocalProperties localProperties = lookupLocalProperties(classEntry, methodEntry);
         localProperties.setIndex(localInfo, index);
     }
 
-    public int getMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo) {
-        DwarfLocalProperties localProperties = lookupLocalProperties(methodEntry);
+    public int getMethodLocalIndex(ClassEntry classEntry, MethodEntry methodEntry, DebugLocalInfo localInfo) {
+        DwarfLocalProperties localProperties = lookupLocalProperties(classEntry, methodEntry);
         assert localProperties != null : "get of non-existent local index";
         int index = localProperties.getIndex(localInfo);
         assert index >= 0 : "get of local index before it was set";

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -530,8 +530,8 @@ public class DwarfDebugInfo extends DebugInfoBase {
         private int methodDeclarationIndex;
 
         /**
-         * Per class map that identifies the info declarations for a top level method declaration
-         * or an abstract inline method declaration.
+         * Per class map that identifies the info declarations for a top level method declaration or
+         * an abstract inline method declaration.
          */
         private EconomicMap<ClassEntry, DwarfLocalProperties> localPropertiesMap;
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
@@ -57,7 +57,8 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
         int pos = 0;
 
         /*
-         * The frame section contains one CIE at offset 0 followed by an FIE for each method.
+         * The frame section contains one CIE at offset 0 followed by an FIE for each compiled
+         * method.
          */
         pos = writeCIE(null, pos);
         pos = writeMethodFrames(null, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -1774,6 +1774,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             }
         }
     }
+
     private int writeAbstractInlineMethod(DebugContext context, ClassEntry classEntry, MethodEntry method, byte[] buffer, int p) {
         int pos = p;
         log(context, "  [0x%08x] abstract inline method %s::%s", pos, classEntry.getTypeName(), method.methodName());
@@ -1791,8 +1792,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         log(context, "  [0x%08x]     specification  0x%x", pos, methodSpecOffset);
         pos = writeInfoSectionOffset(methodSpecOffset, buffer, pos);
         /*
-         * If the inline method exists in a different CU then write locals and params
-         * otherwise we can just reuse the locals and params in the declaration
+         * If the inline method exists in a different CU then write locals and params otherwise we
+         * can just reuse the locals and params in the declaration
          */
         if (classEntry != method.ownerType()) {
             FileEntry fileEntry = method.getFileEntry();
@@ -1812,6 +1813,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
          */
         return writeAttrNull(buffer, pos);
     }
+
     private int writeAttrRef4(int reference, byte[] buffer, int p) {
         // make sure we have actually started writing a CU
         assert cuStart >= 0;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLocSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLocSectionImpl.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.range.SubRange;
 import org.graalvm.compiler.debug.DebugContext;
 
@@ -125,24 +126,42 @@ public class DwarfLocSectionImpl extends DwarfSectionImpl {
 
     private int generateContent(DebugContext context, byte[] buffer) {
         Cursor cursor = new Cursor();
-        compiledMethodsStream().forEach(compiledMethod -> {
-            cursor.set(writeCompiledMethodLocations(context, compiledMethod, buffer, cursor.get()));
+        // n.b. We could do this by iterating over the compiled methods sequence. the
+        // reason for doing it in class entry order is to because it mirrors the
+        // order in which entries appear in the info section. That stops objdump
+        // posting spurious messages about overlaps and holes in the var ranges.
+        instanceClassStream().filter(ClassEntry::hasCompiledEntries).forEachOrdered(classEntry -> {
+            classEntry.compiledEntries().forEachOrdered(compiledMethodEntry -> {
+                cursor.set(writeCompiledMethodLocations(context, compiledMethodEntry, buffer, cursor.get()));
+            });
         });
         return cursor.get();
     }
 
     private int writeCompiledMethodLocations(DebugContext context, CompiledMethodEntry compiledEntry, byte[] buffer, int p) {
         int pos = p;
-        pos = writeTopLevelLocations(context, compiledEntry, buffer, pos);
-        pos = writeInlineLocations(context, compiledEntry, buffer, pos);
+        Range primary = compiledEntry.getPrimary();
+        /*
+         * Note that offsets are written relative to the primary range base. This requires writing a
+         * base address entry before each of the location list ranges. It is possible to default the
+         * base address to the low_pc value of the compile unit for the compiled method's owning
+         * class, saving two words per location list. However, that forces the debugger to do a lot
+         * more up-front cross-referencing of CUs when it needs to resolve code addresses e.g. to
+         * set a breakpoint, leading to a very slow response for the user.
+         */
+        int base = primary.getLo();
+        log(context, "  [0x%08x] top level locations [0x%x, 0x%x] method %s", pos, primary.getLo(), primary.getHi(), primary.getFullMethodNameWithParams());
+        pos = writeTopLevelLocations(context, compiledEntry, base, buffer, pos);
+        if (!primary.isLeaf()) {
+            log(context, "  [0x%08x] inline locations %s", pos, primary.getFullMethodNameWithParams());
+            pos = writeInlineLocations(context, compiledEntry, base, buffer, pos);
+        }
         return pos;
     }
 
-    private int writeTopLevelLocations(DebugContext context, CompiledMethodEntry compiledEntry, byte[] buffer, int p) {
+    private int writeTopLevelLocations(DebugContext context, CompiledMethodEntry compiledEntry, int base, byte[] buffer, int p) {
         int pos = p;
         Range primary = compiledEntry.getPrimary();
-        long base = primary.getLo();
-        log(context, "  [0x%08x] top level locations [0x%x,0x%x] %s", pos, primary.getLo(), primary.getHi(), primary.getFullMethodNameWithParams());
         HashMap<DebugLocalInfo, List<SubRange>> varRangeMap = primary.getVarRangeMap();
         for (DebugLocalInfo local : varRangeMap.keySet()) {
             List<SubRange> rangeList = varRangeMap.get(local);
@@ -154,14 +173,10 @@ public class DwarfLocSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
-    private int writeInlineLocations(DebugContext context, CompiledMethodEntry compiledEntry, byte[] buffer, int p) {
+    private int writeInlineLocations(DebugContext context, CompiledMethodEntry compiledEntry, int base, byte[] buffer, int p) {
         int pos = p;
         Range primary = compiledEntry.getPrimary();
-        if (primary.isLeaf()) {
-            return p;
-        }
-        long base = primary.getLo();
-        log(context, "  [0x%08x] inline locations [0x%x,0x%x] %s", pos, primary.getLo(), primary.getHi(), primary.getFullMethodNameWithParams());
+        assert !primary.isLeaf();
         Iterator<SubRange> iterator = compiledEntry.topDownRangeIterator();
         while (iterator.hasNext()) {
             SubRange subrange = iterator.next();
@@ -180,22 +195,17 @@ public class DwarfLocSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
-    private int writeVarLocations(DebugContext context, DebugLocalInfo local, long base, List<SubRange> rangeList, byte[] buffer, int p) {
+    private int writeVarLocations(DebugContext context, DebugLocalInfo local, int base, List<SubRange> rangeList, byte[] buffer, int p) {
         assert !rangeList.isEmpty();
         int pos = p;
         // collect ranges and values, merging adjacent ranges that have equal value
         List<LocalValueExtent> extents = LocalValueExtent.coalesce(local, rangeList);
 
-        // TODO - currently we use the start address of the range's compiled method as
-        // a base from which to write location offsets. This means we need to explicitly
-        // write a (relocatable) base address as a prefix to each location list. If instead
-        // we rebased relative to the start of the enclosing compilation unit then we
-        // could omit writing the base address prefix, saving two long words per location list.
-
-        // write the base address
+        // write start of primary range as base address - see comment above for reasons why
+        // we choose ot do this rather than use the relevant compile unit low_pc
         pos = writeAttrData8(-1L, buffer, pos);
         pos = writeAttrAddress(base, buffer, pos);
-        // now write ranges as offsets from base
+        // write ranges as offsets from base
         for (LocalValueExtent extent : extents) {
             DebugLocalValueInfo value = extent.value;
             assert (value != null);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfRangesSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfRangesSectionImpl.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.objectfile.elf.dwarf;
+
+import com.oracle.objectfile.LayoutDecision;
+import com.oracle.objectfile.LayoutDecisionMap;
+import com.oracle.objectfile.ObjectFile;
+import com.oracle.objectfile.debugentry.ClassEntry;
+import org.graalvm.compiler.debug.DebugContext;
+
+import java.util.Map;
+
+public class DwarfRangesSectionImpl extends DwarfSectionImpl {
+    public DwarfRangesSectionImpl(DwarfDebugInfo dwarfSections) {
+        super(dwarfSections);
+    }
+
+    @Override
+    public String getSectionName() {
+        return DwarfDebugInfo.DW_RANGES_SECTION_NAME;
+    }
+
+    @Override
+    public void createContent() {
+        assert !contentByteArrayCreated();
+        Cursor cursor = new Cursor();
+        instanceClassStream().filter(ClassEntry::hasCompiledEntries).forEachOrdered(classEntry -> {
+            setCodeRangesIndex(classEntry, cursor.get());
+            // base address
+            cursor.add(2 * 8);
+            // per method lo and hi offsets
+            cursor.add(2 * 8 * classEntry.compiledEntryCount());
+            // end marker
+            cursor.add(2 * 8);
+        });
+        byte[] buffer = new byte[cursor.get()];
+        super.setContent(buffer);
+    }
+
+    @Override
+    public byte[] getOrDecideContent(Map<ObjectFile.Element, LayoutDecisionMap> alreadyDecided, byte[] contentHint) {
+        ObjectFile.Element textElement = getElement().getOwner().elementForName(".text");
+        LayoutDecisionMap decisionMap = alreadyDecided.get(textElement);
+        if (decisionMap != null) {
+            Object valueObj = decisionMap.getDecidedValue(LayoutDecision.Kind.VADDR);
+            if (valueObj != null && valueObj instanceof Number) {
+                /*
+                 * This may not be the final vaddr for the text segment but it will be close enough
+                 * to make debug easier i.e. to within a 4k page or two.
+                 */
+                debugTextBase = ((Number) valueObj).longValue();
+            }
+        }
+        return super.getOrDecideContent(alreadyDecided, contentHint);
+    }
+
+    @Override
+    public void writeContent(DebugContext context) {
+        assert contentByteArrayCreated();
+        byte[] buffer = getContent();
+        int size = buffer.length;
+        Cursor cursor = new Cursor();
+
+        enableLog(context, cursor.get());
+        log(context, "  [0x%08x] DEBUG_RANGES", cursor.get());
+
+        instanceClassStream().filter(ClassEntry::hasCompiledEntries).forEachOrdered(classEntry -> {
+            int pos = cursor.get();
+            int start = pos;
+            setCodeRangesIndex(classEntry, pos);
+            log(context, "  [0x%08x] ranges start for class %s", pos, classEntry.getTypeName());
+            int base = classEntry.compiledEntriesBase();
+            log(context, "  [0x%08x] base 0x%x", pos, base);
+            pos = writeLong(-1L, buffer, pos);
+            pos = writeRelocatableCodeOffset(base, buffer, pos);
+            cursor.set(pos);
+            classEntry.compiledEntries().forEach(compiledMethodEntry -> {
+                int lo = compiledMethodEntry.getPrimary().getLo();
+                int hi = compiledMethodEntry.getPrimary().getHi();
+                log(context, "  [0x%08x] lo 0x%x (%s)", cursor.get(), lo - base, compiledMethodEntry.getPrimary().getFullMethodNameWithParams());
+                cursor.set(writeLong(lo - base, buffer, cursor.get()));
+                log(context, "  [0x%08x] hi 0x%x", cursor.get(), hi - base);
+                cursor.set(writeLong(hi - base, buffer, cursor.get()));
+            });
+            pos = cursor.get();
+            // write end marker
+            pos = writeLong(0, buffer, pos);
+            pos = writeLong(0, buffer, pos);
+            log(context, "  [0x%08x] ranges size 0x%x  for class %s", pos, pos - start, classEntry.getTypeName());
+            cursor.set(pos);
+        });
+
+        assert cursor.get() == size;
+    }
+
+    /*
+     * The debug_ranges section depends on debug_aranges section.
+     */
+    private static final String TARGET_SECTION_NAME = DwarfDebugInfo.DW_ARANGES_SECTION_NAME;
+
+    @Override
+    public String targetSectionName() {
+        return TARGET_SECTION_NAME;
+    }
+
+    private final LayoutDecision.Kind[] targetSectionKinds = {
+                    LayoutDecision.Kind.CONTENT,
+                    LayoutDecision.Kind.SIZE
+    };
+
+    @Override
+    public LayoutDecision.Kind[] targetSectionKinds() {
+        return targetSectionKinds;
+    }
+}

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -466,6 +466,10 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return writeDwarfSectionOffset(offset, buffer, DwarfDebugInfo.DW_LINE_SECTION_NAME, pos);
     }
 
+    protected int writeRangesSectionOffset(int offset, byte[] buffer, int pos) {
+        return writeDwarfSectionOffset(offset, buffer, DwarfDebugInfo.DW_RANGES_SECTION_NAME, pos);
+    }
+
     protected int writeAbbrevSectionOffset(int offset, byte[] buffer, int pos) {
         return writeDwarfSectionOffset(offset, buffer, DwarfDebugInfo.DW_ABBREV_SECTION_NAME, pos);
     }
@@ -812,6 +816,21 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         dwarfSections.setIndirectTypeIndex(typeEntry, pos);
     }
 
+    protected int getCUIndex(ClassEntry classEntry) {
+        if (!contentByteArrayCreated()) {
+            return 0;
+        }
+        return dwarfSections.getCUIndex(classEntry);
+    }
+
+    protected void setCUIndex(ClassEntry classEntry, int idx) {
+        dwarfSections.setCUIndex(classEntry, idx);
+    }
+
+    protected void setLayoutIndex(ClassEntry classEntry, int pos) {
+        dwarfSections.setLayoutIndex(classEntry, pos);
+    }
+
     protected int getLayoutIndex(ClassEntry classEntry) {
         if (!contentByteArrayCreated()) {
             return 0;
@@ -830,8 +849,37 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.getIndirectLayoutIndex(classEntry);
     }
 
-    protected void setLayoutIndex(ClassEntry classEntry, int pos) {
-        dwarfSections.setLayoutIndex(classEntry, pos);
+    protected void setCodeRangesIndex(ClassEntry classEntry, int pos) {
+        dwarfSections.setCodeRangesIndex(classEntry, pos);
+    }
+
+    protected int getCodeRangesIndex(ClassEntry classEntry) {
+        if (!contentByteArrayCreated()) {
+            return 0;
+        }
+        return dwarfSections.getCodeRangesIndex(classEntry);
+    }
+
+    protected void setLineIndex(ClassEntry classEntry, int pos) {
+        dwarfSections.setLineIndex(classEntry, pos);
+    }
+
+    protected int getLineIndex(ClassEntry classEntry) {
+        if (!contentByteArrayCreated()) {
+            return 0;
+        }
+        return dwarfSections.getLineIndex(classEntry);
+    }
+
+    protected void setLinePrologueSize(ClassEntry classEntry, int pos) {
+        dwarfSections.setLinePrologueSize(classEntry, pos);
+    }
+
+    protected int getLinePrologueSize(ClassEntry classEntry) {
+        if (!contentByteArrayCreated()) {
+            return 0;
+        }
+        return dwarfSections.getLinePrologueSize(classEntry);
     }
 
     protected void setFieldDeclarationIndex(StructureTypeEntry entry, String fieldName, int pos) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -904,31 +904,44 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.getMethodDeclarationIndex(methodEntry);
     }
 
+    protected void setAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry, int pos) {
+        dwarfSections.setAbstractInlineMethodIndex(classEntry, methodEntry, pos);
+    }
+
+    protected int getAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry) {
+        if (!contentByteArrayCreated()) {
+            return 0;
+        }
+        return dwarfSections.getAbstractInlineMethodIndex(classEntry, methodEntry);
+    }
+
     /**
      * Record the info section offset of a local (or parameter) declaration DIE appearing as a child
-     * of a standard method declaration.
-     * 
+     * of a standard method declaration or an abstract inline method declaration.
+     *
+     * @param classEntry the class of the top level method being declared or inlined into
      * @param methodEntry the method being declared or inlined.
      * @param localInfo the local or param whose index is to be recorded.
      * @param index the info section offset to be recorded.
      */
-    protected void setMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {
-        dwarfSections.setMethodLocalIndex(methodEntry, localInfo, index);
+    protected void setMethodLocalIndex(ClassEntry classEntry, MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {
+        dwarfSections.setMethodLocalIndex(classEntry, methodEntry, localInfo, index);
     }
 
     /**
      * Retrieve the info section offset of a local (or parameter) declaration DIE appearing as a
-     * child of a standard method declaration.
+     * child of a standard method declaration or an abstract inline method declaration.
      *
+     * @param classEntry the class of the top level method being declared or inlined into
      * @param methodEntry the method being declared or imported
      * @param localInfo the local or param whose index is to be retrieved.
      * @return the associated info section offset.
      */
-    protected int getMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo) {
+    protected int getMethodLocalIndex(ClassEntry classEntry, MethodEntry methodEntry, DebugLocalInfo localInfo) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getMethodLocalIndex(methodEntry, localInfo);
+        return dwarfSections.getMethodLocalIndex(classEntry, methodEntry, localInfo);
     }
 
     /**


### PR DESCRIPTION
Backports https://github.com/oracle/graal/pull/6984

The backport was clean with some auto resolutions from `git`
