### PR TITLE
Bump mandrel integration test timeout to 80 minutes

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -639,7 +639,7 @@ jobs:
       # Don't perform performance checks since GH runners are not that stable
       FAIL_ON_PERF_REGRESSION: false
       # USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
-    timeout-minutes: 50
+    timeout-minutes: 80
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
We see frequently cancelled CI jobs on `mandrel-integration-tests` after 50 minutes. Example here: https://github.com/graalvm/mandrel/actions/runs/6159630722/job/16716434614#step:11:17012

It takes longer to run the full suite these days, bump the timeout. Yes, the new number of 80 minutes is arbitrary. It would be good to have some non-cancelled builds though.