### PR TITLE
Use maven local repository for GraalVM dependencies in gradle tests

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -524,6 +524,11 @@ jobs:
           else
             export BUILDER_IMAGE="-Dquarkus.native.container-build=true -Dquarkus.native.builder-image=${{ inputs.builder-image }}"
           fi
+          # Patch Gradle config to look for GraalVM dependencies in maven local repository
+          for i in `grep -rl includeGroupByRegex .`
+          do
+            sed -i "s/\(^ *includeGroupByRegex\)\( 'io.quarkus.*'\)/\1\2\n\1 'org.graalvm.*'/g" $i
+          done
           # Backwards compatibility with Quarkus < 2.x native-tests.json
           if ! echo $TEST_MODULES | grep ',' > /dev/null
           then


### PR DESCRIPTION
Quarkus already instructs gradle to use the local maven repositories for io.quarkus.* artifacts. This sed command adds org.graal.* artifacts to the include pattern so that we can test locally built and installed GraalVM/Mandrel artifacts.

Testing in progress in https://github.com/zakkak/mandrel/actions/runs/6171689706