### PR TITLE
[23.0] Allow built-in periodic JFR events when using JFR API to make recordings

### DIFF
--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   q-main-ea:
     name: "Q main M 23.0 EA"
-    uses: graalvm/mandrel/.github/workflows/base.yml@default
+    uses: graalvm/mandrel/.github/workflows/base.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
     with:
       quarkus-version: "main"
       repo: ${{ github.repository }}
@@ -38,7 +38,7 @@ jobs:
       jdk: "17/ea"
   q-main-ea-win:
     name: "Q main M 23.0 windows EA"
-    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
+    uses: graalvm/mandrel/.github/workflows/base-windows.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
     with:
       quarkus-version: "main"
       repo: ${{ github.repository }}
@@ -47,7 +47,7 @@ jobs:
       jdk: "17/ea"
   q-main-ea-20:
     name: "Q main M 23.0 EA Java 20"
-    uses: graalvm/mandrel/.github/workflows/base.yml@default
+    uses: graalvm/mandrel/.github/workflows/base.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
     with:
       quarkus-version: "main"
       repo: ${{ github.repository }}
@@ -56,7 +56,7 @@ jobs:
       jdk: "20/ea"
   q-main-ea-win-20:
     name: "Q main M 23.0 windows EA Java 20"
-    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
+    uses: graalvm/mandrel/.github/workflows/base-windows.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
     with:
       quarkus-version: "main"
       repo: ${{ github.repository }}

--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -29,8 +29,9 @@ concurrency:
 jobs:
   q-main-ea:
     name: "Q main M 23.0 EA"
-    uses: graalvm/mandrel/.github/workflows/base.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
+    uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
@@ -38,8 +39,9 @@ jobs:
       jdk: "17/ea"
   q-main-ea-win:
     name: "Q main M 23.0 windows EA"
-    uses: graalvm/mandrel/.github/workflows/base-windows.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
+    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
@@ -47,8 +49,9 @@ jobs:
       jdk: "17/ea"
   q-main-ea-20:
     name: "Q main M 23.0 EA Java 20"
-    uses: graalvm/mandrel/.github/workflows/base.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
+    uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
@@ -56,8 +59,9 @@ jobs:
       jdk: "20/ea"
   q-main-ea-win-20:
     name: "Q main M 23.0 windows EA Java 20"
-    uses: graalvm/mandrel/.github/workflows/base-windows.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
+    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
@@ -86,8 +86,8 @@ public class JfrManager {
     public RuntimeSupport.Hook startupHook() {
         return isFirstIsolate -> {
             parseFlightRecorderLogging(SubstrateOptions.FlightRecorderLogging.getValue());
+            periodicEventSetup();
             if (isJFREnabled()) {
-                periodicEventSetup();
                 initRecording();
             }
         };


### PR DESCRIPTION
### Summary

Built-in periodic JFR events were previously erroneously disabled unless JFR is started from the command line when executing your app. This means that users using the JFR API would not have access to those periodic events. The fix is to always register the built-in periodic events if JFR is in the image, regardless of whether a recording is started upon application execution. 

Original fix: https://github.com/oracle/graal/pull/7252