### PR TITLE
[22.3] Allow built-in periodic JFR events when using JFR API to make recordings

### DIFF
--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -31,6 +31,7 @@ jobs:
     name: "Q main M 22.3 EA"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
@@ -40,6 +41,7 @@ jobs:
     name: "Q main M 22.3 windows EA"
     uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
@@ -49,6 +51,7 @@ jobs:
     name: "Q latest M 22.3 EA"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "latest"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
@@ -58,6 +61,7 @@ jobs:
     name: "Q latest M 22.3 windows EA"
     uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "latest"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
@@ -82,8 +82,8 @@ public class JfrManager {
     public RuntimeSupport.Hook startupHook() {
         return isFirstIsolate -> {
             parseFlightRecorderLogging(SubstrateOptions.FlightRecorderLogging.getValue());
+            periodicEventSetup();
             if (SubstrateOptions.FlightRecorder.getValue()) {
-                periodicEventSetup();
                 initRecording();
             }
         };


### PR DESCRIPTION
Summary
Built-in periodic JFR events were previously erroneously disabled unless JFR is started from the command line when executing your app. This means that users using the JFR API would not have access to those periodic events. The fix is to always register the built-in periodic events if JFR is in the image, regardless of whether a recording is started upon application execution.

Original fix: https://github.com/oracle/graal/pull/7252