### PR TITLE
[23.0] Add JFR threshold checking before event emission

### DIFF
--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   q-main-ea:
     name: "Q main M 23.0 EA"
-    uses: graalvm/mandrel/.github/workflows/base.yml@default
+    uses: graalvm/mandrel/.github/workflows/base.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
     with:
       quarkus-version: "main"
       repo: ${{ github.repository }}
@@ -38,7 +38,7 @@ jobs:
       jdk: "17/ea"
   q-main-ea-win:
     name: "Q main M 23.0 windows EA"
-    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
+    uses: graalvm/mandrel/.github/workflows/base-windows.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
     with:
       quarkus-version: "main"
       repo: ${{ github.repository }}
@@ -47,7 +47,7 @@ jobs:
       jdk: "17/ea"
   q-main-ea-20:
     name: "Q main M 23.0 EA Java 20"
-    uses: graalvm/mandrel/.github/workflows/base.yml@default
+    uses: graalvm/mandrel/.github/workflows/base.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
     with:
       quarkus-version: "main"
       repo: ${{ github.repository }}
@@ -56,7 +56,7 @@ jobs:
       jdk: "20/ea"
   q-main-ea-win-20:
     name: "Q main M 23.0 windows EA Java 20"
-    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
+    uses: graalvm/mandrel/.github/workflows/base-windows.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
     with:
       quarkus-version: "main"
       repo: ${{ github.repository }}

--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -29,8 +29,9 @@ concurrency:
 jobs:
   q-main-ea:
     name: "Q main M 23.0 EA"
-    uses: graalvm/mandrel/.github/workflows/base.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
+    uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
@@ -38,8 +39,9 @@ jobs:
       jdk: "17/ea"
   q-main-ea-win:
     name: "Q main M 23.0 windows EA"
-    uses: graalvm/mandrel/.github/workflows/base-windows.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
+    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
@@ -47,8 +49,9 @@ jobs:
       jdk: "17/ea"
   q-main-ea-20:
     name: "Q main M 23.0 EA Java 20"
-    uses: graalvm/mandrel/.github/workflows/base.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
+    uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
@@ -56,8 +59,9 @@ jobs:
       jdk: "20/ea"
   q-main-ea-win-20:
     name: "Q main M 23.0 windows EA Java 20"
-    uses: graalvm/mandrel/.github/workflows/base-windows.yml@5c44969947cbeff84ca9ccedc127cb6730b82415
+    uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
     with:
+      build-type: "mandrel-source-nolocalmvn"
       quarkus-version: "main"
       repo: ${{ github.repository }}
       version: ${{ github.ref }}

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCEventSupport.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCEventSupport.java
@@ -64,21 +64,20 @@ class JfrGCEventSupport {
     }
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
-    public void emitGarbageCollectionEvent(UnsignedWord gcEpoch, GCCause cause, long start) {
-        if (JfrEvent.GarbageCollection.shouldEmit(start)) {
-            long pauseTime = JfrTicks.elapsedTicks() - start;
-
+    public void emitGarbageCollectionEvent(UnsignedWord gcEpoch, GCCause cause, long startTicks) {
+        long duration = JfrTicks.duration(startTicks);
+        if (JfrEvent.GarbageCollection.shouldEmit(duration)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.GarbageCollection);
-            JfrNativeEventWriter.putLong(data, start);
-            JfrNativeEventWriter.putLong(data, pauseTime);
+            JfrNativeEventWriter.putLong(data, startTicks);
+            JfrNativeEventWriter.putLong(data, duration);
             JfrNativeEventWriter.putLong(data, gcEpoch.rawValue());
             JfrNativeEventWriter.putLong(data, gcName.getId());
             JfrNativeEventWriter.putLong(data, cause.getId());
-            JfrNativeEventWriter.putLong(data, pauseTime);  // sum of pause
-            JfrNativeEventWriter.putLong(data, pauseTime);  // longest pause
+            JfrNativeEventWriter.putLong(data, duration); // sum of pause
+            JfrNativeEventWriter.putLong(data, duration); // longest pause
             JfrNativeEventWriter.endSmallEvent(data);
         }
     }
@@ -86,14 +85,14 @@ class JfrGCEventSupport {
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public void emitGCPhasePauseEvent(UnsignedWord gcEpoch, int level, String name, long startTicks) {
         JfrEvent event = getGCPhasePauseEvent(level);
-        if (event.shouldEmit(startTicks)) {
-            long end = JfrTicks.elapsedTicks();
+        long duration = JfrTicks.duration(startTicks);
+        if (event.shouldEmit(duration)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 
             JfrNativeEventWriter.beginSmallEvent(data, event);
             JfrNativeEventWriter.putLong(data, startTicks);
-            JfrNativeEventWriter.putLong(data, end - startTicks);
+            JfrNativeEventWriter.putLong(data, duration);
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, gcEpoch.rawValue());
             JfrNativeEventWriter.putString(data, name);
@@ -110,15 +109,15 @@ class JfrGCEventSupport {
     private static JfrEvent getGCPhasePauseEvent(int level) {
         switch (level) {
             case 0:
-                return JfrEvent.GCPhasePauseEvent;
+                return JfrEvent.GCPhasePause;
             case 1:
-                return JfrEvent.GCPhasePauseLevel1Event;
+                return JfrEvent.GCPhasePauseLevel1;
             case 2:
-                return JfrEvent.GCPhasePauseLevel2Event;
+                return JfrEvent.GCPhasePauseLevel2;
             case 3:
-                return JfrEvent.GCPhasePauseLevel3Event;
+                return JfrEvent.GCPhasePauseLevel3;
             case 4:
-                return JfrEvent.GCPhasePauseLevel4Event;
+                return JfrEvent.GCPhasePauseLevel4;
             default:
                 throw VMError.shouldNotReachHere("GC phase pause level must be between 0 and 4.");
         }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCEventSupport.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCEventSupport.java
@@ -65,7 +65,7 @@ class JfrGCEventSupport {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public void emitGarbageCollectionEvent(UnsignedWord gcEpoch, GCCause cause, long start) {
-        if (JfrEvent.GarbageCollection.shouldEmit()) {
+        if (JfrEvent.GarbageCollection.shouldEmit(start)) {
             long pauseTime = JfrTicks.elapsedTicks() - start;
 
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
@@ -86,7 +86,7 @@ class JfrGCEventSupport {
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public void emitGCPhasePauseEvent(UnsignedWord gcEpoch, int level, String name, long startTicks) {
         JfrEvent event = getGCPhasePauseEvent(level);
-        if (event.shouldEmit()) {
+        if (event.shouldEmit(startTicks)) {
             long end = JfrTicks.elapsedTicks();
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -89,4 +89,9 @@ public final class JfrEvent {
     public boolean shouldEmit() {
         return SubstrateJVM.get().isRecording() && SubstrateJVM.get().isEnabled(this) && !SubstrateJVM.get().isCurrentThreadExcluded();
     }
+
+    @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
+    public boolean shouldEmit(long startTicks) {
+        return shouldEmit() && JfrTicks.elapsedTicks() - startTicks > SubstrateJVM.get().getThreshold(this);
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -34,45 +34,47 @@ import com.oracle.svm.core.Uninterruptible;
  * IDs depend on the JDK version (see metadata.xml file) and are computed at image build time.
  */
 public final class JfrEvent {
-    public static final JfrEvent ThreadStart = create("jdk.ThreadStart");
-    public static final JfrEvent ThreadEnd = create("jdk.ThreadEnd");
-    public static final JfrEvent DataLoss = create("jdk.DataLoss");
-    public static final JfrEvent ClassLoadingStatistics = create("jdk.ClassLoadingStatistics");
-    public static final JfrEvent InitialEnvironmentVariable = create("jdk.InitialEnvironmentVariable");
-    public static final JfrEvent InitialSystemProperty = create("jdk.InitialSystemProperty");
-    public static final JfrEvent JavaThreadStatistics = create("jdk.JavaThreadStatistics");
-    public static final JfrEvent JVMInformation = create("jdk.JVMInformation");
-    public static final JfrEvent OSInformation = create("jdk.OSInformation");
-    public static final JfrEvent PhysicalMemory = create("jdk.PhysicalMemory");
-    public static final JfrEvent ExecutionSample = create("jdk.ExecutionSample");
-    public static final JfrEvent NativeMethodSample = create("jdk.NativeMethodSample");
-    public static final JfrEvent GarbageCollection = create("jdk.GarbageCollection");
-    public static final JfrEvent GCPhasePauseEvent = create("jdk.GCPhasePause");
-    public static final JfrEvent GCPhasePauseLevel1Event = create("jdk.GCPhasePauseLevel1");
-    public static final JfrEvent GCPhasePauseLevel2Event = create("jdk.GCPhasePauseLevel2");
-    public static final JfrEvent GCPhasePauseLevel3Event = create("jdk.GCPhasePauseLevel3");
-    public static final JfrEvent GCPhasePauseLevel4Event = create("jdk.GCPhasePauseLevel4");
-    public static final JfrEvent SafepointBegin = create("jdk.SafepointBegin");
-    public static final JfrEvent SafepointEnd = create("jdk.SafepointEnd");
-    public static final JfrEvent ExecuteVMOperation = create("jdk.ExecuteVMOperation");
-    public static final JfrEvent JavaMonitorEnter = create("jdk.JavaMonitorEnter");
-    public static final JfrEvent ThreadPark = create("jdk.ThreadPark");
-    public static final JfrEvent JavaMonitorWait = create("jdk.JavaMonitorWait");
-    public static final JfrEvent JavaMonitorInflate = create("jdk.JavaMonitorInflate");
-    public static final JfrEvent ObjectAllocationInNewTLAB = create("jdk.ObjectAllocationInNewTLAB");
+    public static final JfrEvent ThreadStart = create("jdk.ThreadStart", false);
+    public static final JfrEvent ThreadEnd = create("jdk.ThreadEnd", false);
+    public static final JfrEvent DataLoss = create("jdk.DataLoss", false);
+    public static final JfrEvent ClassLoadingStatistics = create("jdk.ClassLoadingStatistics", false);
+    public static final JfrEvent InitialEnvironmentVariable = create("jdk.InitialEnvironmentVariable", false);
+    public static final JfrEvent InitialSystemProperty = create("jdk.InitialSystemProperty", false);
+    public static final JfrEvent JavaThreadStatistics = create("jdk.JavaThreadStatistics", false);
+    public static final JfrEvent JVMInformation = create("jdk.JVMInformation", false);
+    public static final JfrEvent OSInformation = create("jdk.OSInformation", false);
+    public static final JfrEvent PhysicalMemory = create("jdk.PhysicalMemory", false);
+    public static final JfrEvent ExecutionSample = create("jdk.ExecutionSample", false);
+    public static final JfrEvent NativeMethodSample = create("jdk.NativeMethodSample", false);
+    public static final JfrEvent GarbageCollection = create("jdk.GarbageCollection", true);
+    public static final JfrEvent GCPhasePause = create("jdk.GCPhasePause", true);
+    public static final JfrEvent GCPhasePauseLevel1 = create("jdk.GCPhasePauseLevel1", true);
+    public static final JfrEvent GCPhasePauseLevel2 = create("jdk.GCPhasePauseLevel2", true);
+    public static final JfrEvent GCPhasePauseLevel3 = create("jdk.GCPhasePauseLevel3", true);
+    public static final JfrEvent GCPhasePauseLevel4 = create("jdk.GCPhasePauseLevel4", true);
+    public static final JfrEvent SafepointBegin = create("jdk.SafepointBegin", true);
+    public static final JfrEvent SafepointEnd = create("jdk.SafepointEnd", true);
+    public static final JfrEvent ExecuteVMOperation = create("jdk.ExecuteVMOperation", true);
+    public static final JfrEvent JavaMonitorEnter = create("jdk.JavaMonitorEnter", true);
+    public static final JfrEvent ThreadPark = create("jdk.ThreadPark", true);
+    public static final JfrEvent JavaMonitorWait = create("jdk.JavaMonitorWait", true);
+    public static final JfrEvent JavaMonitorInflate = create("jdk.JavaMonitorInflate", true);
+    public static final JfrEvent ObjectAllocationInNewTLAB = create("jdk.ObjectAllocationInNewTLAB", false);
 
     private final long id;
     private final String name;
+    private final boolean hasDuration;
 
     @Platforms(Platform.HOSTED_ONLY.class)
-    public static JfrEvent create(String name) {
-        return new JfrEvent(name);
+    public static JfrEvent create(String name, boolean hasDuration) {
+        return new JfrEvent(name, hasDuration);
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
-    private JfrEvent(String name) {
+    private JfrEvent(String name, boolean hasDuration) {
         this.id = JfrMetadataTypeLibrary.lookupPlatformEvent(name);
         this.name = name;
+        this.hasDuration = hasDuration;
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
@@ -87,11 +89,18 @@ public final class JfrEvent {
 
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
     public boolean shouldEmit() {
-        return SubstrateJVM.get().isRecording() && SubstrateJVM.get().isEnabled(this) && !SubstrateJVM.get().isCurrentThreadExcluded();
+        assert !hasDuration;
+        return shouldEmit0();
     }
 
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
-    public boolean shouldEmit(long startTicks) {
-        return shouldEmit() && JfrTicks.elapsedTicks() - startTicks > SubstrateJVM.get().getThreshold(this);
+    public boolean shouldEmit(long durationTicks) {
+        assert hasDuration;
+        return shouldEmit0() && durationTicks >= SubstrateJVM.get().getThresholdTicks(this);
+    }
+
+    @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
+    private boolean shouldEmit0() {
+        return SubstrateJVM.get().isRecording() && SubstrateJVM.get().isEnabled(this) && !SubstrateJVM.get().isCurrentThreadExcluded();
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNativeEventSetting.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNativeEventSetting.java
@@ -44,6 +44,7 @@ public class JfrNativeEventSetting {
     public JfrNativeEventSetting() {
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public long getThresholdTicks() {
         return thresholdTicks;
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
@@ -33,6 +33,7 @@ import org.graalvm.nativeimage.StackValue;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.WordFactory;
 
+import com.oracle.svm.core.JavaMainWrapper;
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.UnmanagedMemoryUtil;
@@ -41,6 +42,7 @@ import com.oracle.svm.core.jfr.events.ThreadStartEvent;
 import com.oracle.svm.core.sampler.SamplerBuffer;
 import com.oracle.svm.core.sampler.SamplerSampleWriterData;
 import com.oracle.svm.core.thread.JavaThreads;
+import com.oracle.svm.core.thread.PlatformThreads;
 import com.oracle.svm.core.thread.Target_java_lang_Thread;
 import com.oracle.svm.core.thread.ThreadListener;
 import com.oracle.svm.core.thread.VMOperation;
@@ -48,8 +50,6 @@ import com.oracle.svm.core.threadlocal.FastThreadLocalFactory;
 import com.oracle.svm.core.threadlocal.FastThreadLocalLong;
 import com.oracle.svm.core.threadlocal.FastThreadLocalObject;
 import com.oracle.svm.core.threadlocal.FastThreadLocalWord;
-import com.oracle.svm.core.JavaMainWrapper;
-import com.oracle.svm.core.thread.PlatformThreads;
 
 /**
  * This class holds various JFR-specific thread local values.

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTicks.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTicks.java
@@ -24,9 +24,9 @@
  */
 package com.oracle.svm.core.jfr;
 
-import com.oracle.svm.core.Uninterruptible;
-
 import java.util.concurrent.TimeUnit;
+
+import com.oracle.svm.core.Uninterruptible;
 
 /**
  * Utility class to manage ticks for event timestamps based on an initial start point when the
@@ -51,6 +51,11 @@ public final class JfrTicks {
             return System.nanoTime() - initialTicks;
         }
         return 0;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public static long duration(long startTicks) {
+        return elapsedTicks() - startTicks;
     }
 
     public static long getTicksFrequency() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -659,7 +659,7 @@ public class SubstrateJVM {
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    long getThreshold(JfrEvent event) {
+    long getThresholdTicks(JfrEvent event) {
         return eventSettings[(int) event.getId()].getThresholdTicks();
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -658,6 +658,11 @@ public class SubstrateJVM {
         return true;
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    long getThreshold(JfrEvent event) {
+        return eventSettings[(int) event.getId()].getThresholdTicks();
+    }
+
     /**
      * See {@link JVM#setCutoff}.
      */

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ExecuteVMOperationEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ExecuteVMOperationEvent.java
@@ -49,13 +49,14 @@ public class ExecuteVMOperationEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(VMOperation vmOperation, long requestingThreadId, long startTicks) {
-        if (JfrEvent.ExecuteVMOperation.shouldEmit()) {
+        long duration = JfrTicks.duration(startTicks);
+        if (JfrEvent.ExecuteVMOperation.shouldEmit(duration)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ExecuteVMOperation);
             JfrNativeEventWriter.putLong(data, startTicks);
-            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTicks);
+            JfrNativeEventWriter.putLong(data, duration);
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, vmOperation.getId() + 1); // id starts with 1
             JfrNativeEventWriter.putBoolean(data, vmOperation.getCausesSafepoint());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
@@ -47,13 +47,14 @@ public class JavaMonitorEnterEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static void emit0(Object obj, long previousOwnerTid, long startTicks) {
-        if (JfrEvent.JavaMonitorEnter.shouldEmit(startTicks)) {
+        long duration = JfrTicks.duration(startTicks);
+        if (JfrEvent.JavaMonitorEnter.shouldEmit(duration)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.JavaMonitorEnter);
             JfrNativeEventWriter.putLong(data, startTicks);
-            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTicks);
+            JfrNativeEventWriter.putLong(data, duration);
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.JavaMonitorEnter, 0));
             JfrNativeEventWriter.putClass(data, obj.getClass());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
@@ -47,7 +47,7 @@ public class JavaMonitorEnterEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static void emit0(Object obj, long previousOwnerTid, long startTicks) {
-        if (JfrEvent.JavaMonitorEnter.shouldEmit()) {
+        if (JfrEvent.JavaMonitorEnter.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorInflateEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorInflateEvent.java
@@ -48,7 +48,7 @@ public class JavaMonitorInflateEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static void emit0(Object obj, long startTicks, MonitorInflationCause cause) {
-        if (JfrEvent.JavaMonitorInflate.shouldEmit()) {
+        if (JfrEvent.JavaMonitorInflate.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorInflateEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorInflateEvent.java
@@ -48,13 +48,14 @@ public class JavaMonitorInflateEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static void emit0(Object obj, long startTicks, MonitorInflationCause cause) {
-        if (JfrEvent.JavaMonitorInflate.shouldEmit(startTicks)) {
+        long duration = JfrTicks.duration(startTicks);
+        if (JfrEvent.JavaMonitorInflate.shouldEmit(duration)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.JavaMonitorInflate);
             JfrNativeEventWriter.putLong(data, startTicks);
-            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTicks);
+            JfrNativeEventWriter.putLong(data, duration);
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.JavaMonitorInflate, 0));
             JfrNativeEventWriter.putClass(data, obj.getClass());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -46,12 +46,13 @@ public class JavaMonitorWaitEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
-        if (JfrEvent.JavaMonitorWait.shouldEmit(startTicks)) {
+        long duration = JfrTicks.duration(startTicks);
+        if (JfrEvent.JavaMonitorWait.shouldEmit(duration)) {
             JfrNativeEventWriterData data = org.graalvm.nativeimage.StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.JavaMonitorWait);
             JfrNativeEventWriter.putLong(data, startTicks);
-            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTicks);
+            JfrNativeEventWriter.putLong(data, duration);
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.JavaMonitorWait, 0));
             JfrNativeEventWriter.putClass(data, obj.getClass());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -46,7 +46,7 @@ public class JavaMonitorWaitEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
-        if (JfrEvent.JavaMonitorWait.shouldEmit()) {
+        if (JfrEvent.JavaMonitorWait.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = org.graalvm.nativeimage.StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.JavaMonitorWait);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointBeginEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointBeginEvent.java
@@ -52,13 +52,14 @@ public class SafepointBeginEvent {
      */
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(UnsignedWord safepointId, int numJavaThreads, long startTicks) {
-        if (JfrEvent.SafepointBegin.shouldEmit(startTicks)) {
+        long duration = JfrTicks.duration(startTicks);
+        if (JfrEvent.SafepointBegin.shouldEmit(duration)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.SafepointBegin);
             JfrNativeEventWriter.putLong(data, startTicks);
-            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTicks);
+            JfrNativeEventWriter.putLong(data, duration);
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, safepointId.rawValue());
             JfrNativeEventWriter.putInt(data, numJavaThreads);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointBeginEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointBeginEvent.java
@@ -52,7 +52,7 @@ public class SafepointBeginEvent {
      */
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(UnsignedWord safepointId, int numJavaThreads, long startTicks) {
-        if (JfrEvent.SafepointBegin.shouldEmit()) {
+        if (JfrEvent.SafepointBegin.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointEndEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointEndEvent.java
@@ -47,7 +47,7 @@ public class SafepointEndEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(UnsignedWord safepointId, long startTick) {
-        if (JfrEvent.SafepointEnd.shouldEmit()) {
+        if (JfrEvent.SafepointEnd.shouldEmit(startTick)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointEndEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointEndEvent.java
@@ -46,14 +46,15 @@ public class SafepointEndEvent {
     }
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
-    private static void emit0(UnsignedWord safepointId, long startTick) {
-        if (JfrEvent.SafepointEnd.shouldEmit(startTick)) {
+    private static void emit0(UnsignedWord safepointId, long startTicks) {
+        long duration = JfrTicks.duration(startTicks);
+        if (JfrEvent.SafepointEnd.shouldEmit(duration)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.SafepointEnd);
-            JfrNativeEventWriter.putLong(data, startTick);
-            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTick);
+            JfrNativeEventWriter.putLong(data, startTicks);
+            JfrNativeEventWriter.putLong(data, duration);
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, safepointId.rawValue());
             JfrNativeEventWriter.endSmallEvent(data);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadParkEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadParkEvent.java
@@ -47,7 +47,7 @@ public class ThreadParkEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(long startTicks, Object obj, boolean isAbsolute, long time) {
-        if (JfrEvent.ThreadPark.shouldEmit()) {
+        if (JfrEvent.ThreadPark.shouldEmit(startTicks)) {
             Class<?> parkedClass = null;
             if (obj != null) {
                 parkedClass = obj.getClass();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadParkEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadParkEvent.java
@@ -47,7 +47,8 @@ public class ThreadParkEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(long startTicks, Object obj, boolean isAbsolute, long time) {
-        if (JfrEvent.ThreadPark.shouldEmit(startTicks)) {
+        long duration = JfrTicks.duration(startTicks);
+        if (JfrEvent.ThreadPark.shouldEmit(duration)) {
             Class<?> parkedClass = null;
             if (obj != null) {
                 parkedClass = obj.getClass();
@@ -65,7 +66,7 @@ public class ThreadParkEvent {
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ThreadPark);
             JfrNativeEventWriter.putLong(data, startTicks);
-            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTicks);
+            JfrNativeEventWriter.putLong(data, duration);
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.ThreadPark, 0));
             JfrNativeEventWriter.putClass(data, parkedClass);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadSleepEventJDK17.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadSleepEventJDK17.java
@@ -48,7 +48,7 @@ public class ThreadSleepEventJDK17 {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(long time, long startTicks) {
-        if (ThreadSleep.shouldEmit()) {
+        if (ThreadSleep.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadStartEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadStartEvent.java
@@ -36,7 +36,6 @@ import com.oracle.svm.core.jfr.SubstrateJVM;
 import com.oracle.svm.core.thread.JavaThreads;
 
 public class ThreadStartEvent {
-
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static void emit(Thread thread) {
         if (JfrEvent.ThreadStart.shouldEmit()) {

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/JfrRecordingTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/JfrRecordingTest.java
@@ -26,7 +26,9 @@
 
 package com.oracle.svm.test.jfr;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -60,6 +62,12 @@ public abstract class JfrRecordingTest extends AbstractJfrTest {
     }
 
     protected Recording startRecording(String[] events, Configuration config, Map<String, String> settings, Path path) throws Throwable {
+        Recording recording = prepareRecording(events, config, settings, path);
+        recording.start();
+        return recording;
+    }
+
+    protected Recording prepareRecording(String[] events, Configuration config, Map<String, String> settings, Path path) throws IOException {
         Recording recording = createRecording(config);
         recordingStates.put(recording, new JfrRecordingState(events));
 
@@ -67,9 +75,7 @@ public abstract class JfrRecordingTest extends AbstractJfrTest {
         if (settings != null) {
             recording.setSettings(settings);
         }
-
         enableEvents(recording, events);
-        recording.start();
         return recording;
     }
 
@@ -84,7 +90,7 @@ public abstract class JfrRecordingTest extends AbstractJfrTest {
     private static void enableEvents(Recording recording, String[] events) {
         /* Additionally, enable all events that the test case wants to test explicitly. */
         for (String event : events) {
-            recording.enable(event);
+            recording.enable(event).withThreshold(Duration.ZERO);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/JfrStreamingTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/JfrStreamingTest.java
@@ -111,7 +111,7 @@ public abstract class JfrStreamingTest extends AbstractJfrTest {
     private static void enableEvents(RecordingStream stream, String[] events) {
         /* Additionally, enable all events that the test case wants to test explicitly. */
         for (String event : events) {
-            stream.enable(event);
+            stream.enable(event).withThreshold(Duration.ZERO);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCEvents.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCEvents.java
@@ -40,8 +40,8 @@ import jdk.jfr.consumer.RecordedEvent;
 public class TestGCEvents extends JfrRecordingTest {
     @Test
     public void test() throws Throwable {
-        String[] events = new String[]{JfrEvent.GarbageCollection.getName(), JfrEvent.GCPhasePauseEvent.getName(), JfrEvent.GCPhasePauseLevel1Event.getName(),
-                        JfrEvent.GCPhasePauseLevel2Event.getName(), JfrEvent.ExecuteVMOperation.getName()};
+        String[] events = new String[]{JfrEvent.GarbageCollection.getName(), JfrEvent.GCPhasePause.getName(), JfrEvent.GCPhasePauseLevel1.getName(),
+                        JfrEvent.GCPhasePauseLevel2.getName(), JfrEvent.ExecuteVMOperation.getName()};
         Recording recording = startRecording(events);
 
         System.gc();

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreshold.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreshold.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import static com.oracle.svm.test.jfr.AbstractJfrTest.getDefaultConfiguration;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.locks.LockSupport;
+
+import com.oracle.svm.test.jfr.events.StringEvent;
+import org.junit.Test;
+
+import com.oracle.svm.core.jfr.JfrEvent;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
+
+public class TestThreshold extends JfrRecordingTest {
+
+    private static final long SHORT_MILLIS = 10;
+    private static final long THRESHOLD = 20;
+    private static final long LONG_MILLIS = 30;
+
+    private final Helper helper = new Helper();
+
+    @Test
+    public void test() throws Throwable {
+        String[] events = new String[]{JfrEvent.JavaMonitorWait.getName(), JfrEvent.ThreadPark.getName(), "com.jfr.String", "jdk.ThreadSleep"};
+        // Cannot start recording until thresholds are set
+        Recording recording = prepareRecording(events, getDefaultConfiguration(), null, createTempJfrFile());
+        recording.enable(JfrEvent.JavaMonitorWait.getName()).withThreshold(Duration.ofMillis(THRESHOLD));
+        recording.enable(JfrEvent.ThreadPark.getName()).withThreshold(Duration.ofMillis(THRESHOLD));
+        recording.enable("jdk.ThreadSleep").withThreshold(Duration.ofMillis(THRESHOLD));
+        recording.enable("com.jfr.String").withThreshold(Duration.ofMillis(THRESHOLD));
+        recording.start();
+
+        StringEvent shortStringEvent = new StringEvent();
+        shortStringEvent.begin();
+        shortStringEvent.commit();
+        StringEvent longStringEvent = new StringEvent();
+        longStringEvent.begin();
+        Thread.sleep(SHORT_MILLIS);
+        Thread.sleep(LONG_MILLIS);
+        longStringEvent.commit();
+
+        LockSupport.parkNanos(helper, SHORT_MILLIS * 1000000);
+        LockSupport.parkNanos(helper, LONG_MILLIS * 1000000);
+
+        helper.simpleWait(SHORT_MILLIS);
+        helper.simpleWait(LONG_MILLIS);
+
+        stopRecording(recording, this::validateEvents);
+    }
+
+    private void validateEvents(List<RecordedEvent> events) {
+        boolean foundWaitEvent = false;
+        boolean foundJavaEvent = false;
+        boolean foundParkEvent = false;
+        boolean foundSleepEvent = false;
+        for (RecordedEvent event : events) {
+            String eventThread = event.<RecordedThread> getValue("eventThread").getJavaName();
+            assertNotNull("No event thread", eventThread);
+
+            // Even unintentional events emitted by SVM should not have durations over the
+            // threshold.
+            assertTrue(event.getDuration().toMillis() >= LONG_MILLIS);
+
+            if (event.getEventType().getName().equals("com.jfr.String")) {
+                foundJavaEvent = true;
+            } else if (event.getEventType().getName().equals(JfrEvent.JavaMonitorWait.getName()) && event.<RecordedClass> getValue("monitorClass").getName().equals(Helper.class.getName())) {
+                foundWaitEvent = true;
+            } else if (event.getEventType().getName().equals(JfrEvent.ThreadPark.getName()) && event.<RecordedClass> getValue("parkedClass").getName().equals(Helper.class.getName())) {
+                foundParkEvent = true;
+            } else if (event.getEventType().getName().equals("jdk.ThreadSleep")) {
+                foundSleepEvent = true;
+            }
+        }
+        assertTrue(foundJavaEvent && foundWaitEvent && foundParkEvent && foundSleepEvent);
+    }
+
+    private static class Helper {
+        public synchronized void simpleWait(long millis) throws InterruptedException {
+            wait(millis);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreshold.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreshold.java
@@ -26,7 +26,6 @@
 
 package com.oracle.svm.test.jfr;
 
-import static com.oracle.svm.test.jfr.AbstractJfrTest.getDefaultConfiguration;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
### Summary
This PR backports threshold checking from 23.1 to 23.0. Specified duration thresholds will be checked before emitting events wherever thresholds are supported.   

Original PR: https://github.com/oracle/graal/pull/6964
Oracle internal PR: https://github.com/oracle/graal/pull/7066