### PR TITLE
[CI] Add JDK 22 for windows and "latest" for labsjdk

### DIFF
--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -54,6 +54,9 @@ on:
           - "20/ga"
           - "21/ga"
           - "21/ea"
+          - "22/ga"
+          - "22/ea"
+          - "latest/labsjdk"
       builder-image:
         type: string
         description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -58,6 +58,7 @@ on:
           - "21/ea"
           - "22/ga"
           - "22/ea"
+          - "latest/labsjdk"
       builder-image:
         type: string
         description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'


### PR DESCRIPTION
Enables building GraalVM with latest labsJDK (currently 22)
