### PR TITLE
[23.0] Fix `javax.crypto.JceSecurity` substitutions in JDK >= 17.0.10

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JceSecurityHasInnerClassIdentityWrapper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JceSecurityHasInnerClassIdentityWrapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+public class JceSecurityHasInnerClassIdentityWrapper implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName("javax.crypto.JceSecurity$IdentityWrapper");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JceSecurityHasInnerClassWeakIdentityWrapper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JceSecurityHasInnerClassWeakIdentityWrapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+public class JceSecurityHasInnerClassWeakIdentityWrapper implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName("javax.crypto.JceSecurity$WeakIdentityWrapper");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.ref.Reference;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -87,6 +88,7 @@ import javax.xml.crypto.dsig.TransformService;
 import javax.xml.crypto.dsig.XMLSignatureFactory;
 import javax.xml.crypto.dsig.keyinfo.KeyInfoFactory;
 
+import com.oracle.svm.core.jdk.JceSecurityHasInnerClassWeakIdentityWrapper;
 import org.graalvm.compiler.options.Option;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.nativeimage.ImageSingletons;
@@ -885,7 +887,33 @@ public class SecurityServicesFeature extends JNIRegistrationUtil implements Inte
             };
         }
         /*
-         * For JDK 17 and later, the verification cache is an IdentityWrapper -> Verification result
+         * For JDK 17.0.10 and later, the verification cache is a WeakIdentityWrapper ->
+         * Verification result ConcurrentHashMap. The WeakIdentityWrapper contains the actual
+         * provider in the 'obj' field.
+         */
+        if (new JceSecurityHasInnerClassWeakIdentityWrapper().getAsBoolean()) {
+            Method getReferent = ReflectionUtil.lookupMethod(Reference.class, "get");
+            Predicate<Object> listRemovalPredicate = wrapper -> {
+                try {
+                    return shouldRemoveProvider((Provider) getReferent.invoke(wrapper));
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw VMError.shouldNotReachHere(e);
+                }
+            };
+
+            return obj -> {
+                Map<Object, Object> original = (Map<Object, Object>) obj;
+                Map<Object, Object> verificationResults = new ConcurrentHashMap<>(original);
+
+                verificationResults.keySet().removeIf(listRemovalPredicate);
+
+                return verificationResults;
+            };
+
+        }
+
+        /*
+         * For JDK 17 up to 17.0.10, the verification cache is an IdentityWrapper -> Verification result
          * ConcurrentHashMap. The IdentityWrapper contains the actual provider in the 'obj' field.
          */
         Class<?> identityWrapper = loader.findClassOrFail("javax.crypto.JceSecurity$IdentityWrapper");


### PR DESCRIPTION
Closes https://github.com/graalvm/mandrel/issues/607
