### PR TITLE
[22.3] Fix `javax.crypto.JceSecurity` substitutions in JDK >= 17.0.10

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JceSecurityHasInnerClassIdentityWrapper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JceSecurityHasInnerClassIdentityWrapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+public class JceSecurityHasInnerClassIdentityWrapper implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName("javax.crypto.JceSecurity$IdentityWrapper");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JceSecurityHasInnerClassWeakIdentityWrapper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JceSecurityHasInnerClassWeakIdentityWrapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+public class JceSecurityHasInnerClassWeakIdentityWrapper implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName("javax.crypto.JceSecurity$WeakIdentityWrapper");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SecuritySubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SecuritySubstitutions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package com.oracle.svm.core.jdk;
 
 import static com.oracle.svm.core.snippets.KnownIntrinsics.readCallerStackPointer;
 
+import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
@@ -43,6 +44,7 @@ import java.security.Provider;
 import java.security.SecureRandom;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
@@ -313,9 +315,25 @@ final class Target_javax_crypto_ProviderVerifier {
     }
 }
 
+final class QueueFieldPresent implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class<?> jceSecurity = Class.forName("javax.crypto.JceSecurity");
+            jceSecurity.getDeclaredField("queue");
+            return true;
+        } catch (ClassNotFoundException | NoSuchFieldException e) {
+            return false;
+        }
+    }
+}
+
 @TargetClass(className = "javax.crypto.JceSecurity")
 @SuppressWarnings({"unused"})
 final class Target_javax_crypto_JceSecurity {
+
+    @Alias @TargetElement(onlyWith = QueueFieldPresent.class)//
+    public static ReferenceQueue<Object> queue;
 
     /*
      * Lazily recompute the RANDOM field at runtime. We cannot push the entire static initialization
@@ -389,8 +407,7 @@ final class Target_javax_crypto_JceSecurity {
     }
 }
 
-@TargetClass(className = "javax.crypto.JceSecurity", innerClass = "IdentityWrapper", onlyWith = JDK17OrLater.class)
-@SuppressWarnings({"unused"})
+@TargetClass(className = "javax.crypto.JceSecurity", innerClass = "IdentityWrapper", onlyWith = JceSecurityHasInnerClassIdentityWrapper.class)
 final class Target_javax_crypto_JceSecurity_IdentityWrapper {
     @Alias //
     Provider obj;
@@ -398,6 +415,14 @@ final class Target_javax_crypto_JceSecurity_IdentityWrapper {
     @Alias //
     Target_javax_crypto_JceSecurity_IdentityWrapper(Provider obj) {
         this.obj = obj;
+    }
+}
+
+@TargetClass(className = "javax.crypto.JceSecurity", innerClass = "WeakIdentityWrapper", onlyWith = JceSecurityHasInnerClassWeakIdentityWrapper.class)
+final class Target_javax_crypto_JceSecurity_WeakIdentityWrapper {
+    @Alias //
+    Target_javax_crypto_JceSecurity_WeakIdentityWrapper(Provider obj, ReferenceQueue<Object> queue) {
+        // Do nothing this is just an alias
     }
 }
 
@@ -432,7 +457,12 @@ final class JceSecurityUtil {
         if (JavaVersionUtil.JAVA_SPEC <= 11) {
             return p;
         }
+
         /* Starting with JDK 17 the verification results map key is an identity wrapper object. */
+        if (new JceSecurityHasInnerClassWeakIdentityWrapper().getAsBoolean()) {
+            return new Target_javax_crypto_JceSecurity_WeakIdentityWrapper(p, Target_javax_crypto_JceSecurity.queue);
+        }
+
         return new Target_javax_crypto_JceSecurity_IdentityWrapper(p);
     }
 


### PR DESCRIPTION
Closes https://github.com/graalvm/mandrel/issues/608
