### PR TITLE
Add jobs to report Mandrel build failures in Github issues

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -239,6 +239,38 @@ jobs:
         name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
 
+  build-mandrel-report:
+    name: Report Mandrel build failures on GitHub
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' && contains(needs.*.result, 'failure') }}
+    needs:
+      - build-mandrel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: graalvm/mandrel
+          fetch-depth: 1
+          path: workflow-mandrel
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Setup jbang and report results
+        env:
+          BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
+        run: |
+          echo "Installing JBang"
+          wget https://github.com/jbangdev/jbang/releases/download/v0.87.0/jbang.zip
+          unzip jbang.zip
+          echo "Attempting to report results"
+          ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
+            token="${BOT_TOKEN}" \
+            status="${{ needs.build-mandrel.result }}" \
+            issueRepo="${{ inputs.issue-repo }}" \
+            issueNumber="${{ inputs.issue-number }}" \
+            thisRepo="${GITHUB_REPOSITORY}" \
+            runId="${GITHUB_RUN_ID}"
+
   build-graal:
     name: GraalVM CE build
     runs-on: windows-2022

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -263,6 +263,38 @@ jobs:
         name: mandrel-maven-version-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: graalvm-version.tgz
 
+  build-mandrel-report:
+    name: Report Mandrel build failures on GitHub
+    if: ${{ always() && inputs.issue-number != 'null' && github.repository == 'graalvm/mandrel' && github.event_name != 'pull_request' && contains(needs.*.result, 'failure') }}
+    needs:
+      - build-mandrel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: graalvm/mandrel
+          fetch-depth: 1
+          path: workflow-mandrel
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Setup jbang and report results
+        env:
+          BOT_TOKEN: ${{ secrets.ISSUE_BOT_TOKEN }}
+        run: |
+          echo "Installing JBang"
+          wget https://github.com/jbangdev/jbang/releases/download/v0.87.0/jbang.zip
+          unzip jbang.zip
+          echo "Attempting to report results"
+          ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
+            token="${BOT_TOKEN}" \
+            status="${{ needs.build-mandrel.result }}" \
+            issueRepo="${{ inputs.issue-repo }}" \
+            issueNumber="${{ inputs.issue-number }}" \
+            thisRepo="${GITHUB_REPOSITORY}" \
+            runId="${GITHUB_RUN_ID}"
+
   build-graal:
     name: GraalVM CE build
     runs-on: ubuntu-latest


### PR DESCRIPTION
The jobs run only on failures as we don't want the github issues to
close when the build succeeds but only if the native tests pass as well.
