### PR TITLE
Fix weekly qmain mandrel build (no mvn local)

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -116,6 +116,7 @@ jobs:
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
       quarkus-version: "main"
+      build-type: "mandrel-source-nolocalmvn"
       version: "mandrel/23.0"
       jdk: "17/ea"
       mandrel-packaging-version: "23.0"


### PR DESCRIPTION
The 23.0 mandrel packaging branch has no support for it and it's not needed since we do testing of the new maven artefacts in later branches 23.1+

Fixes build issues like these:
```
[...]
 Inputs
    quarkus-version: main
    quarkus-repo: quarkusio/quarkus
    repo: graalvm/mandrel
    version: mandrel/23.0
    mandrel-packaging-version: 23.0
    mandrel-packaging-repo: graalvm/mandrel-packaging
    build-type: mandrel-source
[...]
 INFO [build] Creating Archive mandrel-java17-linux-amd64-23.0.2.2-devadfcdc70.tar.gz
native-image 17.0.10-beta 2024-01-16
OpenJDK Runtime Environment Mandrel-23.0.2.2-devadfcdc70 (build 17.0.10-beta+4-202311232331)
OpenJDK 64-Bit Server VM Mandrel-23.0.2.2-devadfcdc70 (build 17.0.10-beta+4-202311232331, mixed mode)
tar: .m2/repository/org/graalvm: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
Error: Process completed with exit code 2.
```

See: https://github.com/graalvm/mandrel/actions/runs/6986193979/job/19011389463#step:8:656