### PR TITLE
The Windows Mandrel IT issue is 207, not 208 (which is Linux)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
       version: "graal/master"
       issue-number: "579"
       issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "208"
+      mandrel-it-issue-number: "207"
       jdk: "22/ea"
       build-stats-tag: "gha-win-mandrel-qmain-mlatest-jdk22ea"
     secrets:


### PR DESCRIPTION
The Linux Mandrel IT issue flip-flops from fixed to broken. See:

https://github.com/Karm/mandrel-integration-tests/issues/208

It's the Windows build that closes the issue. See:
https://github.com/graalvm/mandrel/actions/runs/7040800666/job/19163117878#step:4:179

The correct (Windows) issue should be 207:
https://github.com/Karm/mandrel-integration-tests/issues/207