### PR TITLE
Revert "[CI] Enable non time sensitive performance regression checks"

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -632,7 +632,7 @@ jobs:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g
       # Don't perform performance checks since GH runners are not that stable
-      FAIL_ON_PERF_REGRESSION: non_time_sensitive
+      FAIL_ON_PERF_REGRESSION: false
       # USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
     timeout-minutes: 40
     strategy:

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -717,7 +717,7 @@ jobs:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g
       # Don't perform performance checks since GH runners are not that stable
-      FAIL_ON_PERF_REGRESSION: non_time_sensitive
+      FAIL_ON_PERF_REGRESSION: false
       # USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
     timeout-minutes: 80
     strategy:


### PR DESCRIPTION
This reverts commit ca15aab163097533d972346eba127bd79dce3e33 since it's
causing CI failures. We need to investigate more and re-enable once the
tests are more reliable.

Relates to https://github.com/Karm/mandrel-integration-tests/issues/226
