### PR TITLE
[CI] Don't try to upload stats when native-tests are not ran

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -675,7 +675,7 @@ jobs:
 
   native-tests-stats-upload:
     name: Upload build stats to collector
-    if: ${{ always() && inputs.build-stats-tag != 'null' && github.event_name != 'pull_request' }}
+    if: ${{ always() && inputs.build-stats-tag != 'null' && github.event_name != 'pull_request' && needs.native-tests.result != 'skipped' && needs.native-tests.result != 'cancelled' }}
     needs:
       - native-tests
       - get-test-matrix


### PR DESCRIPTION
Prevents the upload step from failing and creating extra noise.
