### PR TITLE
[CI] Enhance comments in "managed" github issues

### DIFF
--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -16,19 +16,24 @@
 
 //usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS org.kohsuke:github-api:1.101
+//DEPS org.kohsuke:github-api:1.318
 //DEPS info.picocli:picocli:4.2.0
 
 import org.kohsuke.github.*;
+import org.kohsuke.github.GHWorkflowRun.Conclusion;
+import org.kohsuke.github.function.InputStreamFunction;
+
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 
 @Command(name = "report", mixinStandardHelpOptions = true,
 		description = "Takes care of updating an issue depending on the status of the build")
@@ -37,6 +42,7 @@ class Report implements Runnable {
 	@Option(names = "token", description = "Github token to use when calling the Github API")
 	private String token;
 
+	@Deprecated
 	@Option(names = "status", description = "The status of the CI run")
 	private String status;
 
@@ -52,21 +58,29 @@ class Report implements Runnable {
 	@Option(names = "runId", description = "The ID of the Github Action run for  which we are reporting the CI status")
 	private String runId;
 
+	
+	@Option(names = "--dry-run", description = "Whether to actually update the issue or not")
+	private boolean dryRun;
+
 	@Override
 	public void run() {
 		try {
-			final boolean succeed = "success".equalsIgnoreCase(status);
-			if ("cancelled".equalsIgnoreCase(status) || "skipped".equalsIgnoreCase(status)) {
+			final GitHub github = new GitHubBuilder().withOAuthToken(token).build();
+			final GHRepository issueRepository = github.getRepository(issueRepo);
+			final GHRepository workflowRepository = github.getRepository(thisRepo);
+			GHWorkflowRun workflowRun = workflowRepository.getWorkflowRun(Long.parseLong(runId));
+			Conclusion status = workflowRun.getConclusion();
+
+			System.out.println(String.format("The CI build had status %s.", status));
+
+				
+			if (status.equals(Conclusion.CANCELLED) || status.equals(Conclusion.SKIPPED)) {
 				System.out.println("Job status is `cancelled` or `skipped` - exiting");
 				System.exit(0);
 			}
 
-			System.out.println(String.format("The CI build had status %s.", status));
 
-			final GitHub github = new GitHubBuilder().withOAuthToken(token).build();
-			final GHRepository repository = github.getRepository(issueRepo);
-
-			final GHIssue issue = repository.getIssue(issueNumber);
+			final GHIssue issue = issueRepository.getIssue(issueNumber);
 			if (issue == null) {
 				System.out.println(String.format("Unable to find the issue %s in project %s", issueNumber, issueRepo));
 				System.exit(-1);
@@ -75,23 +89,84 @@ class Report implements Runnable {
 				System.out.println(String.format("The issue is currently %s", issue.getState().toString()));
 			}
 
-			if (succeed) {
+			if (status.equals(Conclusion.SUCCESS)) {
 				if (issue != null  && isOpen(issue)) {
-					// close issue with a comment
-					final GHIssueComment comment = issue.comment(String.format("Build fixed:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId));
-					issue.close();
-					System.out.println(String.format("Comment added on issue %s - %s, the issue has also been closed", issue.getHtmlUrl().toString(), comment.getHtmlUrl().toString()));
+					String comment = String.format("Build fixed:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId);
+					if (!dryRun) {
+						// close issue with a comment
+						issue.comment(comment);
+						issue.close();
+					}
+					System.out.println(String.format("Comment added on issue %s\n%s\n, the issue has also been closed", issue.getHtmlUrl().toString(), comment));
 				} else {
 					System.out.println("Nothing to do - the build passed and the issue is already closed");
 				}
 			} else  {
-				if (isOpen(issue)) {
-					final GHIssueComment comment = issue.comment(String.format("The build is still failing:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId));
-					System.out.println(String.format("Comment added on issue %s - %s", issue.getHtmlUrl().toString(), comment.getHtmlUrl().toString()));
+
+				/*
+				 * If the issue contains a line like:
+				 * 
+				 * Filter: Q main G 22 latest
+				 * 
+				 * then we will only report on the jobs that contain "Q main G 22" in their name, e.g. "Q main G 22 latest / Q IT Misc2".
+				 * This is useful when the github action contains multiple reusable jobs and we want to use a different issue for each of them.
+				 */
+				final String filter;
+				String body = issue.getBody();
+				if (body != null) {
+					String regex = "^Job Filter: (.*)$";
+					Pattern pattern = Pattern.compile(regex);
+					Matcher matcher = pattern.matcher(body);
+					if (matcher.find()) {
+						filter = matcher.group(1);
+					} else {
+						filter = "";
+					}
 				} else {
-					issue.reopen();
-					final GHIssueComment comment = issue.comment(String.format("Unfortunately, the build failed:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId));
-					System.out.println(String.format("Comment added on issue %s - %s, the issue has been re-opened", issue.getHtmlUrl().toString(), comment.getHtmlUrl().toString()));
+					filter = "";
+				}
+
+				Predicate<? super GHWorkflowJob> predicate;
+				if (filter != "") {
+					System.out.println(String.format("Getting logs from failed jobs with names containing: %s", filter));
+					predicate = job -> job.getConclusion().equals(Conclusion.FAILURE) && job.getName().contains(filter);
+				} else {
+					System.out.println("Getting logs from all failed jobs");
+					predicate = job -> job.getConclusion().equals(Conclusion.FAILURE);
+				}
+
+				StringBuilder sb = new StringBuilder("Failed jobs:\n");
+				workflowRun.listJobs().toList().stream().filter(predicate).forEach(job -> {
+					sb.append(String.format("* [%s](%s)\n", job.getName(), job.getHtmlUrl()));
+					job.getSteps().stream().filter(step -> step.getConclusion().equals(Conclusion.FAILURE)).forEach(step -> {
+						sb.append(String.format("  * Step: %s\n", step.getName()));
+					});
+					String fullContent = "";
+					try {
+						fullContent = job.downloadLogs(getLogArchiveInputStreamFunction());
+					} catch (IOException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
+					if (!fullContent.isEmpty()) {
+						sb.append("    Filtered logs:\n");
+						sb.append(String.format("```\n%s```\n", fullContent));
+					}
+				});
+
+				if (isOpen(issue)) {
+					String comment = String.format("The build is still failing!\n\n%s\nLink to latest CI run: https://github.com/%s/actions/runs/%s", sb.toString(), thisRepo, runId);
+					if (!dryRun) {
+						issue.comment(comment);
+					}
+					System.out.println(String.format("Comment added on issue %s\n%s", issue.getHtmlUrl().toString(), comment));
+				} else {
+					String comment = String.format("Unfortunately, the build failed!\n\n%s\nLink to latest CI run: https://github.com/%s/actions/runs/%s", sb.toString(), thisRepo, runId);
+					if (!dryRun) {
+						issue.reopen();
+						issue.comment(comment);
+					}
+					System.out.println(String.format("Comment added on issue %s\n%s, the issue has been re-opened", issue.getHtmlUrl().toString(), comment));
 				}
 			}
 		}
@@ -99,6 +174,22 @@ class Report implements Runnable {
 			throw new UncheckedIOException(e);
 		}
 	}
+
+    private static InputStreamFunction<String> getLogArchiveInputStreamFunction() {
+        return (is) -> {
+			StringBuilder stringBuilder = new StringBuilder();
+			try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is))) {
+				String line;
+				while ((line = bufferedReader.readLine()) != null) {
+					if (line.contains("FAILURE [") || line.contains("Error:")) {
+						stringBuilder.append(line);
+						stringBuilder.append(System.lineSeparator());
+					}
+				}
+			}
+			return stringBuilder.toString();
+        };
+    }
 
 	private static boolean isOpen(GHIssue issue) {
 		return (issue.getState() == GHIssueState.OPEN);

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -265,7 +265,6 @@ jobs:
           echo "Attempting to report results"
           ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
             token="${BOT_TOKEN}" \
-            status="${{ needs.build-mandrel.result }}" \
             issueRepo="${{ inputs.issue-repo }}" \
             issueNumber="${{ inputs.issue-number }}" \
             thisRepo="${GITHUB_REPOSITORY}" \

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -667,7 +667,6 @@ jobs:
           echo "Attempting to report results"
           ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \
             token="${BOT_TOKEN}" \
-            status="${{ needs.native-tests.result }}" \
             issueRepo="${{ inputs.issue-repo }}" \
             issueNumber="${{ inputs.issue-number }}" \
             thisRepo="${GITHUB_REPOSITORY}" \


### PR DESCRIPTION
Till now the CI would automatically open and close issues based on the
CI results, providing just a link to the failing or successful run.

This PR aims to add a bit more context by showing what jobs failed, in
which step, and some filtered output from the logs. To filter the logs
for only related to the corresponding GitHub issue workflow jobs one can
define a "Job Filter" in the GitHub issue's description. E.g.:

> Job Filter: Q main G 22 latest

will only filter and report logs from jobs containing
"Q main G 22 latest" in their name, e.g.,
"Q main G 22 latest / Q IT Misc2"

The resulting comment in the GitHub issue will look like this:

> The build is still failing!
> 
> Failed jobs:
> * [Q main G 22 latest / Q IT Data5](https://github.com/graalvm/mandrel/actions/runs/7108970473/job/19353780171)
>   * Step: Build with Maven
>     Filtered logs:
> ```
> 2023-12-06T02:34:24.6847074Z org.opentest4j.AssertionFailedError: Type 'com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl' was found in the report in target/quarkus-integration-test-jpa-postgresql-999-SNAPSHOT-native-image-source-jar/reports/used_classes_quarkus-integration-test-jpa-postgresql-999-SNAPSHOT-runner_20231206_023237.txt
> 2023-12-06T02:38:57.0457755Z Error: Class initialization of io.vertx.pgclient.impl.codec.DataTypeCodec failed. Use the option
> 2023-12-06T02:43:25.9882325Z Error: Class initialization of io.vertx.pgclient.impl.codec.DataTypeCodec failed. Use the option
> 2023-12-06T02:46:22.4042108Z [INFO] Quarkus - Integration Tests - JPA - PostgreSQL ..... FAILURE [03:57 min]
> 2023-12-06T02:46:22.4044859Z [INFO] Quarkus - Integration Tests - Hibernate Reactive - PostgreSQL FAILURE [01:03 min]
> 2023-12-06T02:46:22.4047360Z [INFO] Quarkus - Integration Tests - Reactive Pg Client ... FAILURE [ 52.547 s]
> ```
> * [Q main G 22 latest / Q IT Data7](https://github.com/graalvm/mandrel/actions/runs/7108970473/job/19353780524)
>   * Step: Build with Maven
>     Filtered logs:
> ```
> 2023-12-06T02:35:15.1577013Z 2023-12-06 02:35:15,119 WARN  [org.hib.eng.jdb.spi.SqlExceptionHelper] (vert.x-eventloop-thread-0) SQL Error: -204, SQLState: 42704
> 2023-12-06T02:35:15.1586877Z 2023-12-06 02:35:15,123 WARN  [org.hib.eng.jdb.spi.SqlExceptionHelper] (vert.x-eventloop-thread-0) SQL Error: -204, SQLState: 42704
> 2023-12-06T02:48:07.0671437Z Error: Class initialization of io.vertx.pgclient.impl.codec.DataTypeCodec failed. Use the option
> 2023-12-06T02:49:46.2298413Z Error: Class initialization of io.vertx.pgclient.impl.codec.DataTypeCodec failed. Use the option
> 2023-12-06T02:49:46.2423648Z Error: Class initialization of io.vertx.pgclient.impl.codec.DataTypeCodec failed. This error is reported at image build time because class io.vertx.pgclient.impl.codec.DataTypeCodec is registered for linking at image build time by command line and command line. Use the option
> 2023-12-06T02:49:46.2512671Z Caused by: java.lang.NoClassDefFoundError: Could not initialize class io.vertx.pgclient.impl.codec.DataTypeCodec
> 2023-12-06T02:49:46.2517627Z Caused by: java.lang.ExceptionInInitializerError: Exception java.time.format.DateTimeParseException: Text '4714-11-24 00:00:00 BC' could not be parsed at index 20 [in thread "ForkJoinPool.commonPool-worker-2"]
> 2023-12-06T03:00:59.9015846Z [INFO] Quarkus - Integration Tests - Hibernate Reactive with Panache FAILURE [01:27 min]
> 2023-12-06T03:00:59.9016990Z [INFO] Quarkus - Integration Tests - Hibernate Reactive with Panache and Kotlin FAILURE [01:39 min]
> ```
> * [Q main G 22 latest / Q IT Security3](https://github.com/graalvm/mandrel/actions/runs/7108970473/job/19353781553)
>   * Step: Build with Maven
>     Filtered logs:
> ```
> 2023-12-06T02:48:26.4464579Z Error: Class initialization of io.vertx.pgclient.impl.codec.DataTypeCodec failed. Use the option
> 2023-12-06T02:55:45.1948764Z [INFO] Quarkus - Integration Tests - Security WebAuthn .... FAILURE [01:27 min]
> ```
> * [Q main G 22 latest / Q IT Misc4](https://github.com/graalvm/mandrel/actions/runs/7108970473/job/19353782619)
>   * Step: Build with Maven
>     Filtered logs:
> ```
> 2023-12-06T03:23:28.2319284Z Error: Class initialization of com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl failed. Use the option
> 2023-12-06T03:23:28.3140196Z [INFO] Quarkus - Integration Tests - JAXP ................. FAILURE [ 18.185 s]
> ```
> * [Q main G 22 latest / Q IT AWT, ImageIO and Java2D](https://github.com/graalvm/mandrel/actions/runs/7108970473/job/19353783389)
>   * Step: Build with Maven
>     Filtered logs:
> ```
> 2023-12-06T02:25:34.9321321Z Error: Error loading a referenced type: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported method jdk.internal.loader.NativeLibrary.findEntry0(long, String) is reachable
> 2023-12-06T02:28:01.6411073Z [INFO] Quarkus - Integration Tests - AWT .................. FAILURE [01:27 min]
> ```
> 
> Link to latest CI run: https://github.com/graalvm/mandrel/actions/runs/7108970473
> 