### PR TITLE
[CI] Remove echo of triggering workflow run context

### DIFF
--- a/.github/workflows/github-issue-updater.yml
+++ b/.github/workflows/github-issue-updater.yml
@@ -22,10 +22,6 @@ jobs:
         shell: bash
         run: |
             echo "Triggering Workflow Run ID: ${{ github.event.workflow_run.id }}"
-      - name: Get Triggering Workflow Run context
-        shell: bash
-        run: |
-            echo "Triggering Workflow Run Context: ${{ toJson(github.event.workflow_run) }}"
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'


### PR DESCRIPTION
It causes failures with:

```
/home/runner/work/_temp/acc7eefc-4c97-4c1a-81bb-02b1c77b9e78.sh: line 42: syntax error near unexpected token `('
```

because `head_commit.message` might contain un-sanitized characters, see https://github.com/graalvm/mandrel/actions/runs/7149959024/job/19472732491#step:4:235.

This was only kept for verbosity, it's not strictly necessary.
