### PR TITLE
[CI] Include maven ERROR messages in mandrel-integration-tests logs

### DIFF
--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -145,7 +145,13 @@ class Report implements Runnable {
 						}
 					}
 				} else if (job.getName().contains("Q Mandrel IT")) {
-					String fullContent = getJobsLogs(job, "mandrel-it-issue-number", "FAILURE [", "Z Error:");
+					String fullContent = getJobsLogs(job, "mandrel-it-issue-number",
+							"FAILURE [",
+							"Z Error:",
+							"  Time elapsed: ",
+							"Z [ERROR]   ",
+							"Z [ERROR] Failures",
+							"Z [ERROR] Tests run:");
 					if (!fullContent.isEmpty()) {
 						// Get the issue number for mandrel-integration-tests issues
 						Matcher mandrelIssueNumberMatcher = Pattern.compile(" mandrel-it-issue-number: (\\d+)").matcher(fullContent);


### PR DESCRIPTION
Make github comments a bit more verbose by including the maven ERROR
lines in the filtered logs.

## Before this change:

```
2023-12-11T02:28:20.8667068Z Error: Error loading a referenced type: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported method jdk.internal.loader.NativeLibrary.findEntry0(long, String) is reachable
2023-12-11T02:36:03.7296398Z [INFO] testsuite .......................................... FAILURE [26:09 min]
```

## After this change:

```
2023-12-11T02:28:20.8667068Z Error: Error loading a referenced type: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported method jdk.internal.loader.NativeLibrary.findEntry0(long, String) is reachable
2023-12-11T02:28:22.0027728Z [ERROR] Tests run: 12, Failures: 1, Errors: 0, Skipped: 5, Time elapsed: 381.094 s <<< FAILURE! - in org.graalvm.tests.integration.AppReproducersTest
2023-12-11T02:28:22.0029653Z [ERROR] imageioAWTTest{TestInfo}  Time elapsed: 45.949 s  <<< FAILURE!
2023-12-11T02:36:03.3939460Z [ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 461.386 s <<< FAILURE! - in org.graalvm.tests.integration.JFRTest
2023-12-11T02:36:03.3944535Z [ERROR] jfrPerfTest{TestInfo}  Time elapsed: 281.976 s  <<< FAILURE!
2023-12-11T02:36:03.7241289Z [ERROR] Failures: 
2023-12-11T02:36:03.7244933Z [ERROR]   AppReproducersTest.imageioAWTTest:501->imageioAWT:569 The test application failed to run. Check /home/runner/work/mandrel/mandrel/mandrel-integration-tests/testsuite/target/archived-logs/org.graalvm.tests.integration.AppReproducersTest/imageioAWTTest/build-and-run.log ==> expected: not <null>
2023-12-11T02:36:03.7248780Z [ERROR]   JFRTest.jfrPerfTest:176->jfrPerfTestRun:214->startComparisonForBenchmark:254->runBenchmarkForApp:355 Timeout 10s was reached. Empty webpage does not contain string: `hello' ==> expected: <true> but was: <false>
2023-12-11T02:36:03.7250949Z [ERROR] Tests run: 19, Failures: 2, Errors: 0, Skipped: 5
2023-12-11T02:36:03.7296398Z [INFO] testsuite .......................................... FAILURE [26:09 min]
2023-12-11T02:36:03.7324637Z [ERROR]   mvn <args> -rf :testsuite
```
