### PR TITLE
[CI] Don't update file while reading it

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -468,7 +468,8 @@ jobs:
         if: startsWith(matrix.os-name, 'windows')
         shell: bash
         run: |
-          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json.new
+          mv ~/.docker/config.json.new ~/.docker/config.json
       - name: Change quarkus.version for Quarkus 2.2 to make mandrel-integration-test not apply quarkus_main.patch
         if: startsWith(matrix.os-name, 'windows')
         # See https://github.com/Karm/mandrel-integration-tests/pull/64
@@ -610,7 +611,8 @@ jobs:
       - name: Update Docker Client User Agent
         shell: bash
         run: |
-          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json.new
+          mv ~/.docker/config.json.new ~/.docker/config.json
       - name: Build with Maven
         run: |
           cmd.exe /c "call `"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars64.txt"

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -542,7 +542,8 @@ jobs:
         if: "!startsWith(matrix.os-name, 'windows')"
         shell: bash
         run: |
-          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json.new
+          mv ~/.docker/config.json.new ~/.docker/config.json
       - name: Change quarkus.version for Quarkus 2.2 to make mandrel-integration-test not apply quarkus_main.patch
         if: "!startsWith(matrix.os-name, 'windows')"
         # See https://github.com/Karm/mandrel-integration-tests/pull/64
@@ -696,7 +697,8 @@ jobs:
           tar -xzvf jdk.tgz -C ${GRAALVM_HOME} --strip-components=1
       - name: Update Docker Client User Agent
         run: |
-          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json
+          cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json.new
+          mv ~/.docker/config.json.new ~/.docker/config.json
       - name: Install gdb
         run: |
           sudo apt-get update -y


### PR DESCRIPTION
The pattern is `cat <<< $(echo < input-file.txt) > input-file.txt` which makes no guarantee that the input file, `input-file.txt`, isn't being clobbered while still being read by the subshell. Fix it by creating a temporary copy.