### PR TITLE
[CI] Increase max heap size now that GitHub runners got stronger

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -71,7 +71,7 @@ env:
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test
   COMMON_MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
-  NATIVE_TEST_MAVEN_OPTS: "-Dtest-containers -Dstart-containers -DfailIfNoTests=false -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests -DskipDocs"
+  NATIVE_TEST_MAVEN_OPTS: "-Dtest-containers -Dstart-containers -DfailIfNoTests=false -Dquarkus.native.native-image-xmx=13g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests -DskipDocs"
   MX_GIT_CACHE: refcache
   JAVA_HOME: ${{ github.workspace }}\openjdk
   GRAALVM_HOME: ${{ github.workspace }}\graalvm-home

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -70,7 +70,7 @@ env:
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test
-  NATIVE_TEST_MAVEN_OPTS: "--fail-at-end -Dtest-containers -Dstart-containers -DfailIfNoTests=false -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
+  NATIVE_TEST_MAVEN_OPTS: "--fail-at-end -Dtest-containers -Dstart-containers -DfailIfNoTests=false -Dquarkus.native.native-image-xmx=13g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
   MX_GIT_CACHE: refcache
   JAVA_HOME: ${{ github.workspace }}/openjdk
   GRAALVM_HOME: ${{ github.workspace }}/graalvm-home
@@ -590,7 +590,12 @@ jobs:
             fi
             unset IFS
           fi
-          ./mvnw -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml -f integration-tests -pl "$TEST_MODULES" -amd $BUILDER_IMAGE $NATIVE_TEST_MAVEN_OPTS
+          if [[ $TEST_MODULES == "main" ]]
+          then
+            # Build main module with constraint memory to ensure we can build apps on smaller machines too
+            export NEW_MAX_HEAP_SIZE=-Dquarkus.native.native-image-xmx=5g
+          fi
+          ./mvnw -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml -f integration-tests -pl "$TEST_MODULES" -amd $BUILDER_IMAGE $NATIVE_TEST_MAVEN_OPTS $NEW_MAX_HEAP_SIZE
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -724,11 +729,11 @@ jobs:
           if [[ ${{ inputs.builder-image }} == "null" ]]
           then
             ${GRAALVM_HOME}/bin/native-image --version
-            mvn clean verify -Dquarkus.native.native-image-xmx=5g \
+            mvn clean verify -Dquarkus.native.native-image-xmx=13g \
               -Dquarkus.version=$QUARKUS_VERSION \
               -Ptestsuite
           else
-            mvn clean verify -Dquarkus.native.native-image-xmx=5g \
+            mvn clean verify -Dquarkus.native.native-image-xmx=13g \
               -Dquarkus.version=$QUARKUS_VERSION \
               -Dquarkus.native.builder-image=${{ inputs.builder-image }} \
               -Ptestsuite-builder-image


### PR DESCRIPTION
The new github runners come with 16gb of RAM:

```
Build resources:
 - 4.44GB of memory (28.5% of 15.61GB system memory, set via '-Xmx5g')
 - 4 thread(s) (100.0% of 4 available processor(s), determined at start)
```

https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/
