### PR TITLE
[CI] Use correct SNAPSHOT version for Quarkus release branches

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -636,6 +636,8 @@ jobs:
           # Don't use SNAPSHOT version for 2.2 and release tags
           if ("${{ inputs.quarkus-version }}" -eq "2.2") {
             $QUARKUS_VERSION="2.2.999"
+          } elseif (${{ inputs.quarkus-version }} -match "^[0-9]+\.[0-9]+$") {
+            $QUARKUS_VERSION="${{ inputs.quarkus-version }}.999-SNAPSHOT"
           } elseif (! ($QUARKUS_VERSION -match "^.*\.(Final|CR|Alpha|Beta)[0-9]?$")) {
             $QUARKUS_VERSION="999-SNAPSHOT"
           }

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -721,6 +721,10 @@ jobs:
           if [ "${{ inputs.quarkus-version }}" == "2.2" ]
           then
             export QUARKUS_VERSION=2.2.999
+          elif $(expr match "${{ inputs.quarkus-version }}" "^[0-9]\+\.[0-9]\+$" > /dev/null)
+          then
+            # release branches use the branch name followed by .999-SNAPSHOT as the version
+            export QUARKUS_VERSION="${{ inputs.quarkus-version }}.999-SNAPSHOT"
           elif ! $(expr match "$QUARKUS_VERSION" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
           then
             export QUARKUS_VERSION="999-SNAPSHOT"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -138,8 +138,7 @@ jobs:
     name: "Q 2.13 M 22.3 image"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
-      # Use a tag for 2.13 due to https://github.com/graalvm/mandrel/issues/501
-      quarkus-version: "2.13.8.Final"
+      quarkus-version: "2.13"
       build-type: "mandrel-source-nolocalmvn"
       version: "mandrel/22.3"
       jdk: "17/ea"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -113,7 +113,7 @@ jobs:
   ####
   q-main-mandrel-23_0:
     name: "Q main M 23.0 JDK 17"
-    uses: graalvm/mandrel/.github/workflows/base.yml@default
+    uses: zakkak/mandrel/.github/workflows/base.yml@2024-01-24-fix-quarkus-snapshots
     with:
       quarkus-version: "main"
       build-type: "mandrel-source-nolocalmvn"
@@ -125,7 +125,7 @@ jobs:
   ####
   q-3_2-mandrel-23_0:
     name: "Q 3.2 M 23.0 JDK 17"
-    uses: graalvm/mandrel/.github/workflows/base.yml@default
+    uses: zakkak/mandrel/.github/workflows/base.yml@2024-01-24-fix-quarkus-snapshots
     with:
       quarkus-version: "3.2"
       build-type: "mandrel-source-nolocalmvn"
@@ -136,7 +136,7 @@ jobs:
   # Test Quarkus 2.13 with Mandrel 22.3 JDK 17 ####
   q-2_13-mandrel-22_3:
     name: "Q 2.13 M 22.3 image"
-    uses: graalvm/mandrel/.github/workflows/base.yml@default
+    uses: zakkak/mandrel/.github/workflows/base.yml@2024-01-24-fix-quarkus-snapshots
     with:
       quarkus-version: "2.13"
       build-type: "mandrel-source-nolocalmvn"


### PR DESCRIPTION
Release branches are now using <version>.999-SNAPSHOT versions

See
https://github.com/quarkusio/quarkus/blob/3c8c772dda9ed99674c9d8a6cd9cb4635d1ce5a2/build-parent/pom.xml#L8
and
https://github.com/quarkusio/quarkus/blob/bc0ca288d32ba2df212d8c4a2783c0bb21ca99a1/build-parent/pom.xml#L8

Related to https://github.com/graalvm/mandrel/issues/501
