### PR TITLE
Don't catch exceptions in GH issue updater script

### DIFF
--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -174,10 +174,8 @@ class Report implements Runnable {
 									}
 								}
 							} catch (IOException e) {
-								// TODO Auto-generated catch block
-								e.printStackTrace();
+								throw new UncheckedIOException(e);
 							}
-							
 						}
 					}
 				} else if (job.getName().startsWith("Keep graal/master in sync")) {
@@ -247,8 +245,7 @@ class Report implements Runnable {
 				GHIssue issue = issueRepository.getIssue(issueNumber);
 				process.accept(issue, job);
 			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				throw new UncheckedIOException(e);
 			}
 		}
 	}
@@ -307,8 +304,7 @@ class Report implements Runnable {
 				}
 			}
 		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			throw new UncheckedIOException(e);
 		}
 	}
 
@@ -329,7 +325,7 @@ class Report implements Runnable {
 			fullContent = job.downloadLogs(getLogArchiveInputStreamFunction(filters));
 		} catch (IOException e) {
 			System.out.println(String.format("Unable to get logs for job %s", job.getName()));
-			e.printStackTrace();
+			throw new UncheckedIOException(e);
 		}
 		return fullContent;
 	}

--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -330,8 +330,8 @@ class Report implements Runnable {
 		return fullContent;
 	}
 
-    private static InputStreamFunction<String> getLogArchiveInputStreamFunction(String... filters) {
-        return (is) -> {
+	private static InputStreamFunction<String> getLogArchiveInputStreamFunction(String... filters) {
+		return (is) -> {
 			StringBuilder stringBuilder = new StringBuilder();
 			try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is))) {
 				String line;
@@ -351,8 +351,8 @@ class Report implements Runnable {
 				}
 			}
 			return stringBuilder.toString();
-        };
-    }
+		};
+	}
 
 	private static boolean isOpen(GHIssue issue) {
 		return (issue.getState() == GHIssueState.OPEN);

--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -16,7 +16,7 @@
 
 //usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS org.kohsuke:github-api:1.318
+//DEPS org.kohsuke:github-api:1.319
 //DEPS info.picocli:picocli:4.2.0
 
 import org.kohsuke.github.*;


### PR DESCRIPTION
- [CI] Update github-api version of GH issue updater script
- [CI] Don't catch exceptions in GH issue updater script

  This will result in the corresponding GH job to fail when an exception is thrown making it easier to detect issues like https://github.com/graalvm/mandrel/issues/687
    
- [CI] Refactoring for consistency in code style
