### PR TITLE
[CI] Update GHA actions to fix node warnings

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -169,7 +169,7 @@ jobs:
       - get-test-matrix
       - build-vars
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       with:
         repository: ${{ inputs.repo }}
@@ -177,7 +177,7 @@ jobs:
         ref: ${{ inputs.version }}
         path: ${{ env.MANDREL_REPO }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
     - name: Checkout MX
@@ -187,13 +187,13 @@ jobs:
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
         ./mx/mx --version
       shell: bash
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       with:
         repository: ${{ inputs.mandrel-packaging-repo }}
         ref: ${{ inputs.mandrel-packaging-version }}
         path: ${{ env.MANDREL_PACKAGING_REPO }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' #&& inputs.builder-image == 'null'
       with:
         path: ~/.mx
@@ -246,7 +246,7 @@ jobs:
       - get-test-matrix
       - build-vars
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       with:
         repository: ${{ inputs.repo }}
@@ -254,7 +254,7 @@ jobs:
         ref: ${{ inputs.version }}
         path: graal
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
     - name: Checkout MX
@@ -264,7 +264,7 @@ jobs:
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
         ./mx/mx --version
       shell: bash
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' #&& inputs.builder-image == 'null'
       with:
         path: ~/.mx
@@ -348,18 +348,18 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: graalvm/mandrel
         fetch-depth: 1
         path: workflow-mandrel
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: ${{ inputs.quarkus-repo }}
         fetch-depth: 1
         ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
         path: quarkus
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: base-windows-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -374,7 +374,7 @@ jobs:
           bash ../workflow-mandrel/.github/update_quarkus_version.sh 2.2.999
         fi
     # Use Java 17 to build Quarkus as that's the lowest supported JDK version currently
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'
@@ -413,7 +413,7 @@ jobs:
     steps:
       - name: Support longpaths on Windows
         run: git config --global core.longpaths true
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
@@ -428,21 +428,21 @@ jobs:
         if: startsWith(matrix.os-name, 'windows')
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: startsWith(matrix.os-name, 'windows')
         with:
           repository: ${{ inputs.quarkus-repo }}
           fetch-depth: 1
           ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
           path: ${{ env.QUARKUS_PATH }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         if: startsWith(matrix.os-name, 'windows')
         with:
           path: ~/.m2/repository
           key: base-windows-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: base-windows-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-
       # Use Java 17 for Quarkus as it doesn't work with Java 21 yet
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         if: startsWith(matrix.os-name, 'windows')
         with:
           distribution: 'temurin'
@@ -538,7 +538,7 @@ jobs:
       matrix: ${{ fromJson(needs.get-test-matrix.outputs.tests-matrix) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
@@ -577,12 +577,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
           path: workflow-mandrel
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: Karm/mandrel-integration-tests
           fetch-depth: 1
@@ -595,7 +595,7 @@ jobs:
         shell: bash
         run: tar -xzvf maven-repo.tgz -C ~
       # Use Java 17 for Quarkus as it doesn't work with Java 21 yet
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -181,7 +181,7 @@ jobs:
       - get-test-matrix
       - build-vars
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       with:
         repository: ${{ inputs.repo }}
@@ -189,7 +189,7 @@ jobs:
         ref: ${{ inputs.version }}
         path: ${{ env.MANDREL_REPO }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
     - name: Checkout MX
@@ -198,13 +198,13 @@ jobs:
         VERSION=$(jq -r .mx_version ${MANDREL_REPO}/common.json)
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_PATH}
         ./mx/mx --version
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       with:
         repository: ${{ inputs.mandrel-packaging-repo }}
         ref: ${{ inputs.mandrel-packaging-version }}
         path: ${{ env.MANDREL_PACKAGING_REPO }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'}}
       with:
         path: ~/.mx
@@ -270,7 +270,7 @@ jobs:
       - get-test-matrix
       - build-vars
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       with:
         repository: ${{ inputs.repo }}
@@ -278,7 +278,7 @@ jobs:
         ref: ${{ inputs.version }}
         path: graal
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
     - name: Checkout MX
@@ -287,7 +287,7 @@ jobs:
         VERSION=$(jq -r .mx_version graal/common.json)
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_PATH}
         ./mx/mx --version
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: ${{ fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'}}
       with:
         path: ~/.mx
@@ -392,18 +392,18 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: graalvm/mandrel
         fetch-depth: 1
         path: workflow-mandrel
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: ${{ inputs.quarkus-repo }}
         fetch-depth: 1
         ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
         path: ${{ env.QUARKUS_PATH }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -417,7 +417,7 @@ jobs:
           bash ../workflow-mandrel/.github/update_quarkus_version.sh 2.2.999
         fi
     # Use Java 17 to build Quarkus as that's the lowest supported JDK version currently
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'
@@ -495,7 +495,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.get-test-matrix.outputs.tests-matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
@@ -511,7 +511,7 @@ jobs:
         shell: bash
         run: tar -xzvf maven-repo.tgz -C ~
       # Use Java 17 for Quarkus as it doesn't work with Java 21 yet
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         if: "!startsWith(matrix.os-name, 'windows')"
         with:
           distribution: 'temurin'
@@ -528,7 +528,7 @@ jobs:
         run: |
           mkdir -p ${GRAALVM_HOME}
           tar -xzvf jdk.tgz -C ${GRAALVM_HOME} --strip-components=1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: "!startsWith(matrix.os-name, 'windows')"
         with:
           repository: ${{ inputs.quarkus-repo }}
@@ -628,7 +628,7 @@ jobs:
       matrix: ${{ fromJson(needs.get-test-matrix.outputs.tests-matrix) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
@@ -667,12 +667,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
           path: workflow-mandrel
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: Karm/mandrel-integration-tests
           fetch-depth: 1
@@ -685,7 +685,7 @@ jobs:
       - name: Extract Maven Repo
         run: tar -xzvf maven-repo.tgz -C ~
       # Use Java 17 for Quarkus as it doesn't work with Java 21 yet
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         if: "!startsWith(matrix.os-name, 'windows')"
         with:
           distribution: 'temurin'

--- a/.github/workflows/github-issue-updater.yml
+++ b/.github/workflows/github-issue-updater.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
             echo "Triggering Workflow Run ID: ${{ github.event.workflow_run.id }}"
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout graal/master branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: graal/master
         fetch-depth: 0


### PR DESCRIPTION
We see many of the "node 16" reached EOL warnings. Example:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20:
actions/checkout@v3, actions/setup-python@v4, actions/cache@v3, actions/upload-artifact@v3.
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

From: https://github.com/graalvm/mandrel/actions/runs/8413746359

See:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Update actions to fix this.