### PR TITLE
[CI] Bump github-api version to 1.321

### DIFF
--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -16,7 +16,7 @@
 
 //usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS org.kohsuke:github-api:1.319
+//DEPS org.kohsuke:github-api:1.321
 //DEPS info.picocli:picocli:4.2.0
 
 import org.kohsuke.github.*;


### PR DESCRIPTION
That release has a fix (https://github.com/hub4j/github-api/pull/1791) which we need according to @zakkak analysis.

See changelog in:
https://github.com/hub4j/github-api/releases/tag/github-api-1.320

Closes: #687