### PR TITLE
2024-03-27 backports 21 sync

### DIFF
--- a/common.json
+++ b/common.json
@@ -22,9 +22,9 @@
     "labsjdk-ce-21":      {"name": "labsjdk",   "version": "ce-21.0.2+13-jvmci-23.1-b30", "platformspecific": true },
     "labsjdk-ce-21Debug": {"name": "labsjdk",   "version": "ce-21.0.2+13-jvmci-23.1-b30-debug", "platformspecific": true },
     "labsjdk-ce-21-llvm": {"name": "labsjdk",   "version": "ce-21.0.2+13-jvmci-23.1-b30-sulong", "platformspecific": true },
-    "labsjdk-ee-21":      {"name": "labsjdk",   "version": "ee-21.0.3+6-jvmci-23.1-b36", "platformspecific": true },
-    "labsjdk-ee-21Debug": {"name": "labsjdk",   "version": "ee-21.0.3+6-jvmci-23.1-b36-debug", "platformspecific": true },
-    "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.3+6-jvmci-23.1-b36-sulong", "platformspecific": true },
+    "labsjdk-ee-21":      {"name": "labsjdk",   "version": "ee-21.0.3+7-jvmci-23.1-b37", "platformspecific": true },
+    "labsjdk-ee-21Debug": {"name": "labsjdk",   "version": "ee-21.0.3+7-jvmci-23.1-b37-debug", "platformspecific": true },
+    "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.3+7-jvmci-23.1-b37-sulong", "platformspecific": true },
 
     "oraclejdk22":        {"name": "jpg-jdk",   "version": "22",      "build_id": "2", "release": true, "platformspecific": true, "extrabundles": ["static-libs"]}
   },

--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/ConditionalEliminationTest17.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/ConditionalEliminationTest17.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.test;
+
+import java.util.EnumSet;
+
+import org.graalvm.compiler.api.directives.GraalDirectives;
+import org.graalvm.compiler.core.common.GraalOptions;
+import org.graalvm.compiler.options.OptionValues;
+import org.junit.Test;
+
+import jdk.vm.ci.meta.DeoptimizationReason;
+
+public class ConditionalEliminationTest17 extends ConditionalEliminationTestBase {
+
+    static final class A {
+    }
+
+    static final class B {
+        int value = 1337;
+
+        int value() {
+            return value;
+        }
+    }
+
+    private static boolean equals(byte[] a, byte[] b) {
+        if (a == b) {
+            return true;
+        } else if (a.length != b.length) {
+            return false;
+        } else {
+            for (int i = 0; i < a.length; i++) {
+                if (a[i] != b[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    private static final Object X = new Object();
+    private static final Object Y = new Object();
+
+    public static int test1Snippet(byte[][] haystack, byte[] needle, Object[] otherValues) {
+        Object someValue = otherValues[0];
+        Object anotherValue1 = otherValues[1];
+        Object anotherValue2 = otherValues[2];
+        if (haystack.length != 0) {
+            for (int i = 0; i < haystack.length; i++) {
+                byte[] hay = haystack[i];
+                if (equals(hay, needle)) {
+                    int result = 42;
+                    if (anotherValue1 == X) {
+                        if (anotherValue2 == Y) {
+                            result++;
+                            GraalDirectives.controlFlowAnchor();
+                        }
+                        GraalDirectives.controlFlowAnchor();
+                    }
+                    if (someValue.getClass() != A.class) {
+                        GraalDirectives.deoptimizeAndInvalidate();
+                    }
+                    GraalDirectives.controlFlowAnchor();
+                    return result;
+                }
+            }
+        }
+        return ((B) someValue).value();
+    }
+
+    @Test
+    public void test1() {
+        Object[] args = {new byte[][]{"foo".getBytes(), "bar".getBytes()}, "neither".getBytes(), new Object[]{new B(), X, Y}};
+        test(getInitialOptions(), EnumSet.allOf(DeoptimizationReason.class), "test1Snippet", args);
+    }
+
+    public static int test2Snippet(byte[][] haystack, byte[] needle, Object[] otherValues) {
+        Object someValue = otherValues[0];
+        Object anotherValue1 = otherValues[1];
+        Object anotherValue2 = otherValues[2];
+        if (haystack.length != 0) {
+            for (int i = 0; i < haystack.length; i++) {
+                byte[] hay = haystack[i];
+                if (equals(hay, needle)) {
+                    int result = 42;
+                    if (anotherValue1 == X) {
+                        if (anotherValue2 == Y) {
+                            result++;
+                            GraalDirectives.controlFlowAnchor();
+                        }
+                        GraalDirectives.controlFlowAnchor();
+                    }
+                    if (someValue == null || someValue.getClass() != A.class) {
+                        GraalDirectives.deoptimizeAndInvalidate();
+                    }
+                    GraalDirectives.controlFlowAnchor();
+                    return result;
+                }
+            }
+        }
+        return ((B) someValue).value();
+    }
+
+    @Test
+    public void test2() {
+        Object[] args = {new byte[][]{"foo".getBytes(), "bar".getBytes()}, "bad".getBytes(), new Object[]{new B(), X, Y}};
+        test(getInitialOptions(), EnumSet.allOf(DeoptimizationReason.class), "test2Snippet", args);
+    }
+
+    // simplified and reduced version of equals (semantics of this method is not relevant, only IR
+    // shape)
+    private static boolean simpleEquals(byte[][] a) {
+        for (int i = 0; i < a.length; i++) {
+            if (GraalDirectives.sideEffect(i) == 123) {
+                return true;
+            }
+        }
+        return false;
+
+    }
+
+    // simplified and reduced version of test1Snippet (semantics of this method is not relevant,
+    // only IR shape)
+    @SuppressWarnings("unused")
+    public static int test3Snippet(byte[][] haystack, byte[] needle, Object someValue, Object anotherValue1) {
+        for (int i = 0; i < haystack.length; i++) {
+            if (simpleEquals(haystack)) {
+                int result = 42;
+                if (anotherValue1 == X) {
+                    GraalDirectives.controlFlowAnchor();
+                }
+                if (someValue.getClass() != A.class) {
+                    GraalDirectives.deoptimizeAndInvalidate();
+                }
+                return result;
+            }
+        }
+        return 0;
+    }
+
+    @Test
+    public void test3() {
+        Object[] args = {new byte[][]{"foo".getBytes(), "bar".getBytes()}, "neither".getBytes(), X, Y};
+        OptionValues opt = new OptionValues(getInitialOptions(), GraalOptions.OptFloatingReads, false);
+        test(opt, EnumSet.allOf(DeoptimizationReason.class), "test3Snippet", args);
+    }
+
+}

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/java/BytecodeParser.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/java/BytecodeParser.java
@@ -4702,6 +4702,10 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
         if (typeIsResolved(type)) {
             genNewObjectArray((ResolvedJavaType) type);
         } else {
+            /*
+             * The link time effects of an unresolved bytecode always occur before any runtime
+             * exception checks, meaning there is no need to check if the length is positive.
+             */
             handleUnresolvedNewObjectArray(type);
         }
     }
@@ -4730,6 +4734,10 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
             ValueNode[] dims = new ValueNode[rank];
             genNewMultiArray((ResolvedJavaType) type, rank, dims);
         } else {
+            /*
+             * The link time effects of an unresolved bytecode always occur before any runtime
+             * exception checks, meaning there is no need to check if the dims are positive.
+             */
             handleUnresolvedNewMultiArray(type);
         }
     }

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/java/BytecodeParser.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/java/BytecodeParser.java
@@ -3966,22 +3966,6 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
         frameState.push(kind, value);
     }
 
-    @SuppressWarnings("try")
-    public void loadLocalObject(int index) {
-        ValueNode value = frameState.loadLocal(index, JavaKind.Object);
-
-        int nextBCI = stream.nextBCI();
-        int nextBC = stream.readUByte(nextBCI);
-        if (nextBCI <= currentBlock.getEndBci() && nextBC == Bytecodes.GETFIELD) {
-            stream.next();
-            try (DebugCloseable ignored = openNodeContext()) {
-                genGetField(stream.readCPI(), Bytecodes.GETFIELD, value);
-            }
-        } else {
-            frameState.push(JavaKind.Object, value);
-        }
-    }
-
     public void storeLocal(JavaKind kind, int index) {
         ValueNode value = frameState.pop(kind);
         frameState.storeLocal(index, kind, value);
@@ -5279,7 +5263,7 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
             case LLOAD          : loadLocal(stream.readLocalIndex(), JavaKind.Long); break;
             case FLOAD          : loadLocal(stream.readLocalIndex(), JavaKind.Float); break;
             case DLOAD          : loadLocal(stream.readLocalIndex(), JavaKind.Double); break;
-            case ALOAD          : loadLocalObject(stream.readLocalIndex()); break;
+            case ALOAD          : loadLocal(stream.readLocalIndex(), JavaKind.Object); break;
             case ILOAD_0        : // fall through
             case ILOAD_1        : // fall through
             case ILOAD_2        : // fall through
@@ -5299,7 +5283,7 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
             case ALOAD_0        : // fall through
             case ALOAD_1        : // fall through
             case ALOAD_2        : // fall through
-            case ALOAD_3        : loadLocalObject(opcode - ALOAD_0); break;
+            case ALOAD_3        : loadLocal(opcode - ALOAD_0, JavaKind.Object); break;
             case IALOAD         : genLoadIndexed(JavaKind.Int   ); break;
             case LALOAD         : genLoadIndexed(JavaKind.Long  ); break;
             case FALOAD         : genLoadIndexed(JavaKind.Float ); break;

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/java/BytecodeParser.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/java/BytecodeParser.java
@@ -1280,9 +1280,8 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
 
     /**
      * @param type the type of the array being instantiated
-     * @param length the length of the array
      */
-    protected void handleUnresolvedNewObjectArray(JavaType type, ValueNode length) {
+    protected void handleUnresolvedNewObjectArray(JavaType type) {
         assert !graphBuilderConfig.unresolvedIsError();
         DeoptimizeNode deopt = append(new DeoptimizeNode(InvalidateRecompile, Unresolved));
         deopt.updateNodeSourcePosition(() -> createBytecodePosition());
@@ -1290,9 +1289,8 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
 
     /**
      * @param type the type being instantiated
-     * @param dims the dimensions for the multi-array
      */
-    protected void handleUnresolvedNewMultiArray(JavaType type, ValueNode[] dims) {
+    protected void handleUnresolvedNewMultiArray(JavaType type) {
         assert !graphBuilderConfig.unresolvedIsError();
         DeoptimizeNode deopt = append(new DeoptimizeNode(InvalidateRecompile, Unresolved));
         deopt.updateNodeSourcePosition(() -> createBytecodePosition());
@@ -1300,9 +1298,8 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
 
     /**
      * @param field the unresolved field
-     * @param receiver the object containing the field or {@code null} if {@code field} is static
      */
-    protected void handleUnresolvedLoadField(JavaField field, ValueNode receiver) {
+    protected void handleUnresolvedLoadField(JavaField field) {
         assert !graphBuilderConfig.unresolvedIsError();
         DeoptimizeNode deopt = append(new DeoptimizeNode(InvalidateRecompile, Unresolved));
         deopt.updateNodeSourcePosition(() -> createBytecodePosition());
@@ -1310,17 +1307,15 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
 
     /**
      * @param field the unresolved field
-     * @param value the value being stored to the field
-     * @param receiver the object containing the field or {@code null} if {@code field} is static
      */
-    protected void handleUnresolvedStoreField(JavaField field, ValueNode value, ValueNode receiver) {
+    protected void handleUnresolvedStoreField(JavaField field) {
         assert !graphBuilderConfig.unresolvedIsError();
         DeoptimizeNode deopt = append(new DeoptimizeNode(InvalidateRecompile, Unresolved));
         deopt.updateNodeSourcePosition(() -> createBytecodePosition());
     }
 
     /**
-     * @param type
+     * @param type the unresolved type of the exception
      */
     protected void handleUnresolvedExceptionType(JavaType type) {
         assert !graphBuilderConfig.unresolvedIsError();
@@ -1329,8 +1324,8 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
     }
 
     /**
-     * @param javaMethod
-     * @param invokeKind
+     * @param javaMethod the unresolved target method
+     * @param invokeKind the kind of the unresolved invoke
      */
     protected void handleUnresolvedInvoke(JavaMethod javaMethod, InvokeKind invokeKind) {
         assert !graphBuilderConfig.unresolvedIsError();
@@ -4707,8 +4702,7 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
         if (typeIsResolved(type)) {
             genNewObjectArray((ResolvedJavaType) type);
         } else {
-            ValueNode length = maybeEmitExplicitNegativeArraySizeCheck(frameState.pop(JavaKind.Int));
-            handleUnresolvedNewObjectArray(type, length);
+            handleUnresolvedNewObjectArray(type);
         }
     }
 
@@ -4732,14 +4726,11 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
     private void genNewMultiArray(int cpi) {
         JavaType type = lookupType(cpi, MULTIANEWARRAY);
         int rank = getStream().readUByte(bci() + 3);
-        ValueNode[] dims = new ValueNode[rank];
         if (typeIsResolved(type)) {
+            ValueNode[] dims = new ValueNode[rank];
             genNewMultiArray((ResolvedJavaType) type, rank, dims);
         } else {
-            for (int i = rank - 1; i >= 0; i--) {
-                dims[i] = maybeEmitExplicitNegativeArraySizeCheck(frameState.pop(JavaKind.Int));
-            }
-            handleUnresolvedNewMultiArray(type, dims);
+            handleUnresolvedNewMultiArray(type);
         }
     }
 
@@ -4764,21 +4755,17 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
     }
 
     protected void genGetField(int cpi, int opcode) {
-        genGetField(cpi, opcode, frameState.pop(JavaKind.Object));
-    }
-
-    protected void genGetField(int cpi, int opcode, ValueNode receiverInput) {
         JavaField field = lookupField(cpi, opcode);
-        genGetField(field, receiverInput);
+        genGetField(field);
     }
 
-    private void genGetField(JavaField field, ValueNode receiverInput) {
-        if (field instanceof ResolvedJavaField) {
-            ValueNode receiver = maybeEmitExplicitNullCheck(receiverInput);
-            ResolvedJavaField resolvedField = (ResolvedJavaField) field;
+    private void genGetField(JavaField field) {
+        if (field instanceof ResolvedJavaField resolvedField) {
+            // Only pop receiver from frame state if we are not going to deopt.
+            ValueNode receiver = maybeEmitExplicitNullCheck(frameState.pop(JavaKind.Object));
             genGetField(resolvedField, receiver);
         } else {
-            handleUnresolvedLoadField(field, receiverInput);
+            handleUnresolvedLoadField(field);
         }
     }
 
@@ -4879,29 +4866,28 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
     }
 
     protected void genPutField(JavaField field) {
-        genPutField(field, frameState.pop(field.getJavaKind()));
+        if (field instanceof ResolvedJavaField resolvedField) {
+            // Only pop value from frame state if we are not going to deopt.
+            genPutField(resolvedField, frameState.pop(field.getJavaKind()));
+        } else {
+            handleUnresolvedStoreField(field);
+        }
     }
 
-    private void genPutField(JavaField field, ValueNode value) {
+    private void genPutField(ResolvedJavaField field, ValueNode value) {
         ValueNode receiverInput = frameState.pop(JavaKind.Object);
 
-        if (field instanceof ResolvedJavaField) {
-            ValueNode receiver = maybeEmitExplicitNullCheck(receiverInput);
-            ResolvedJavaField resolvedField = (ResolvedJavaField) field;
-
-            for (NodePlugin plugin : graphBuilderConfig.getPlugins().getNodePlugins()) {
-                if (plugin.handleStoreField(this, receiver, resolvedField, value)) {
-                    return;
-                }
+        ValueNode receiver = maybeEmitExplicitNullCheck(receiverInput);
+        for (NodePlugin plugin : graphBuilderConfig.getPlugins().getNodePlugins()) {
+            if (plugin.handleStoreField(this, receiver, field, value)) {
+                return;
             }
-
-            if (resolvedField.isFinal() && method.isConstructor()) {
-                finalBarrierRequired = true;
-            }
-            genStoreField(receiver, resolvedField, value);
-        } else {
-            handleUnresolvedStoreField(field, value, receiverInput);
         }
+
+        if (field.isFinal() && method.isConstructor()) {
+            finalBarrierRequired = true;
+        }
+        genStoreField(receiver, field, value);
     }
 
     protected void genGetStatic(int cpi, int opcode) {
@@ -4910,8 +4896,9 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
     }
 
     private void genGetStatic(JavaField field) {
-        ResolvedJavaField resolvedField = resolveStaticFieldAccess(field, null);
+        ResolvedJavaField resolvedField = resolveStaticFieldAccess(field);
         if (resolvedField == null) {
+            handleUnresolvedLoadField(field);
             return;
         }
 
@@ -4961,7 +4948,7 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
         }
     }
 
-    private ResolvedJavaField resolveStaticFieldAccess(JavaField field, ValueNode value) {
+    private ResolvedJavaField resolveStaticFieldAccess(JavaField field) {
         if (field instanceof ResolvedJavaField) {
             ResolvedJavaField resolvedField = (ResolvedJavaField) field;
             ResolvedJavaType resolvedType = resolvedField.getDeclaringClass();
@@ -4983,12 +4970,6 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
                 }
             }
         }
-        if (value == null) {
-            handleUnresolvedLoadField(field, null);
-        } else {
-            handleUnresolvedStoreField(field, value, null);
-
-        }
         return null;
     }
 
@@ -4999,12 +4980,14 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
 
     protected void genPutStatic(JavaField field) {
         int stackSizeBefore = frameState.stackSize();
-        ValueNode value = frameState.pop(field.getJavaKind());
-        ResolvedJavaField resolvedField = resolveStaticFieldAccess(field, value);
+        ResolvedJavaField resolvedField = resolveStaticFieldAccess(field);
         if (resolvedField == null) {
+            handleUnresolvedStoreField(field);
             return;
         }
 
+        // Only pop value from frame state if we are not going to deopt.
+        ValueNode value = frameState.pop(field.getJavaKind());
         ClassInitializationPlugin classInitializationPlugin = this.graphBuilderConfig.getPlugins().getClassInitializationPlugin();
         ResolvedJavaType holder = resolvedField.getDeclaringClass();
         if (classInitializationPlugin != null) {

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/cfg/ControlFlowGraph.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/cfg/ControlFlowGraph.java
@@ -42,6 +42,7 @@ import org.graalvm.compiler.debug.DebugCloseable;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.debug.MemUseTrackerKey;
+import org.graalvm.compiler.debug.TTY;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.graph.NodeMap;
 import org.graalvm.compiler.graph.iterators.NodeIterable;
@@ -221,6 +222,44 @@ public final class ControlFlowGraph implements AbstractControlFlowGraph<HIRBlock
      */
     public void updateCachedLocalLoopFrequency(LoopBeginNode lb, Function<LoopFrequencyData, LoopFrequencyData> updater) {
         localLoopFrequencyData.put(lb, updater.apply(localLoopFrequencyData.get(lb)));
+    }
+
+    /**
+     * Debug only decorator for {@link RecursiveVisitor} to log all basic blocks how they are
+     * visited one by one.
+     */
+    public static class LoggingCFGDecorator implements ControlFlowGraph.RecursiveVisitor<HIRBlock> {
+        private final ControlFlowGraph.RecursiveVisitor<HIRBlock> visitor;
+        private String indent = "";
+
+        public LoggingCFGDecorator(ControlFlowGraph.RecursiveVisitor<HIRBlock> visitor, ControlFlowGraph cfg) {
+            this.visitor = visitor;
+            TTY.printf("DomTree for %s%n", cfg.graph);
+            printDomTree(cfg.getStartBlock(), "");
+        }
+
+        private static void printDomTree(HIRBlock cur, String indent) {
+            TTY.printf("%s%s [dom %s, post dom %s]%n", indent, cur, cur.getDominator(), cur.getPostdominator());
+            HIRBlock dominated = cur.getFirstDominated();
+            while (dominated != null) {
+                printDomTree(dominated, indent + "\t");
+                dominated = dominated.getDominatedSibling();
+            }
+        }
+
+        @Override
+        public HIRBlock enter(HIRBlock b) {
+            TTY.printf("%sEnter block %s for %s%n", indent, b, visitor);
+            indent += "\t";
+            return visitor.enter(b);
+        }
+
+        @Override
+        public void exit(HIRBlock b, HIRBlock value) {
+            indent = indent.substring(0, indent.length() - 1);
+            TTY.printf("%sExit block %s with value %s for %s%n", indent, b, value, visitor);
+            visitor.exit(b, value);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/phases/common/util/LoopUtility.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/phases/common/util/LoopUtility.java
@@ -26,10 +26,14 @@ package org.graalvm.compiler.phases.common.util;
 
 import java.util.EnumSet;
 
+import org.graalvm.compiler.core.common.cfg.Loop;
 import org.graalvm.compiler.core.common.type.IntegerStamp;
 import org.graalvm.compiler.core.common.type.Stamp;
 import org.graalvm.compiler.graph.Graph.NodeEvent;
 import org.graalvm.compiler.graph.Graph.NodeEventScope;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.nodes.FixedNode;
+import org.graalvm.compiler.nodes.GraphState.StageFlag;
 import org.graalvm.compiler.nodes.LoopExitNode;
 import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ProxyNode;
@@ -39,6 +43,8 @@ import org.graalvm.compiler.nodes.ValuePhiNode;
 import org.graalvm.compiler.nodes.calc.AddNode;
 import org.graalvm.compiler.nodes.calc.IntegerConvertNode;
 import org.graalvm.compiler.nodes.calc.MulNode;
+import org.graalvm.compiler.nodes.cfg.ControlFlowGraph;
+import org.graalvm.compiler.nodes.cfg.HIRBlock;
 import org.graalvm.compiler.nodes.loop.BasicInductionVariable;
 import org.graalvm.compiler.nodes.loop.InductionVariable;
 import org.graalvm.compiler.nodes.loop.LoopEx;
@@ -47,6 +53,47 @@ import org.graalvm.compiler.nodes.spi.CoreProviders;
 import org.graalvm.compiler.phases.common.CanonicalizerPhase;
 
 public class LoopUtility {
+
+    /**
+     * Determine if the def can use node {@code use} without the need for value proxies. This means
+     * there is no loop exit between the schedule point of def and use that would require a
+     * {@link ProxyNode}.
+     */
+    public static boolean canUseWithoutProxy(ControlFlowGraph cfg, Node def, Node use) {
+        if (def.graph() instanceof StructuredGraph g && g.isAfterStage(StageFlag.VALUE_PROXY_REMOVAL)) {
+            return true;
+        }
+        if (!isFixedNode(def) || !isFixedNode(use)) {
+            /*
+             * If def or use are not fixed nodes we cannot determine the schedule point for them.
+             * Without the schedule point we cannot find their basic block in the control flow
+             * graph. If we would schedule the graph we could answer the question for floating nodes
+             * as well but this is too much overhead. Thus, for floating nodes we give up and assume
+             * a proxy is necessary.
+             */
+            return false;
+        }
+        HIRBlock useBlock = cfg.blockFor(use);
+        HIRBlock defBlock = cfg.blockFor(def);
+        Loop<HIRBlock> defLoop = defBlock.getLoop();
+        Loop<HIRBlock> useLoop = useBlock.getLoop();
+        if (defLoop != null) {
+            // the def is inside a loop, either a parent or a disjunct loop
+            if (useLoop != null) {
+                // we are only safe without proxies if we are included in the def loop,
+                // i.e., the def loop is a parent loop
+                return useLoop.isAncestorOrSelf(defLoop);
+            } else {
+                // the use is not in a loop but the def is, needs proxies, fail
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isFixedNode(Node n) {
+        return n instanceof FixedNode;
+    }
 
     public static boolean isNumericInteger(ValueNode v) {
         Stamp s = v.stamp(NodeView.DEFAULT);

--- a/sdk/mx.sdk/mx_sdk_vm_impl.py
+++ b/sdk/mx.sdk/mx_sdk_vm_impl.py
@@ -2762,10 +2762,10 @@ class GraalVmStandaloneComponent(LayoutSuper):  # pylint: disable=R0901
         default_jvm_libs_dir = base_dir + 'jvmlibs/'
         layout = {}
 
-        # JVM standalones do not include the native libraries of LanguageLibraryConfig ('thin launchers') of:
+        # JVM standalones do not include LibraryConfigs (including the native libraries of LanguageLibraryConfig ('thin launchers')) of:
         # - the main component
         # - every other component that defines a language library that overrides (i.e., has the same destination) one of the main component
-        main_libraries_destinations = [base_dir + library_config.destination for library_config in main_component.library_configs if isinstance(library_config, mx_sdk.LanguageLibraryConfig)]
+        main_libraries_destinations = [base_dir + library_config.destination for library_config in main_component.library_configs if isinstance(library_config, mx_sdk.LibraryConfig)]
 
         assert require_svm(self.involved_components), "The '{}' standalone does not require SVM. This has not been tested in a while and might not work as intended. Involved components: '{}'".format(name, [c.name for c in self.involved_components])
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/AbstractRuntimeCodeInstaller.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/AbstractRuntimeCodeInstaller.java
@@ -47,13 +47,11 @@ public class AbstractRuntimeCodeInstaller {
     }
 
     protected void makeCodeMemoryExecutableReadOnly(Pointer start, UnsignedWord size) {
-        int result = RuntimeCodeInfoAccess.makeCodeMemoryExecutableReadOnly((CodePointer) start, size);
-        VMError.guarantee(result == 0, "Failed to make code memory read only.");
+        RuntimeCodeInfoAccess.makeCodeMemoryExecutableReadOnly((CodePointer) start, size);
     }
 
     protected void makeCodeMemoryExecutableWritable(Pointer start, UnsignedWord size) {
-        int result = RuntimeCodeInfoAccess.makeCodeMemoryExecutableWritable((CodePointer) start, size);
-        VMError.guarantee(result == 0, "Failed to make code memory writable.");
+        RuntimeCodeInfoAccess.makeCodeMemoryExecutableWritable((CodePointer) start, size);
     }
 
     protected static void doInstallPrepared(SharedMethod method, CodeInfo codeInfo, SubstrateInstalledCode installedCode) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/RuntimeCodeInfoAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/RuntimeCodeInfoAccess.java
@@ -24,8 +24,6 @@
  */
 package com.oracle.svm.core.code;
 
-import java.util.EnumSet;
-
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.UnmanagedMemory;
 import org.graalvm.nativeimage.c.function.CodePointer;
@@ -46,6 +44,7 @@ import com.oracle.svm.core.heap.CodeReferenceMapDecoder;
 import com.oracle.svm.core.heap.Heap;
 import com.oracle.svm.core.heap.ObjectReferenceVisitor;
 import com.oracle.svm.core.os.CommittedMemoryProvider;
+import com.oracle.svm.core.os.VirtualMemoryProvider;
 import com.oracle.svm.core.util.DuplicatedInNativeCode;
 import com.oracle.svm.core.util.VMError;
 
@@ -235,12 +234,23 @@ public final class RuntimeCodeInfoAccess {
         CommittedMemoryProvider.get().freeExecutableMemory(codeStart, codeSize, WordFactory.unsigned(SubstrateOptions.codeAlignment()));
     }
 
-    public static int makeCodeMemoryExecutableReadOnly(CodePointer codeStart, UnsignedWord codeSize) {
-        return CommittedMemoryProvider.get().protect(codeStart, codeSize, EnumSet.of(CommittedMemoryProvider.Access.READ, CommittedMemoryProvider.Access.EXECUTE));
+    public static void makeCodeMemoryExecutableReadOnly(CodePointer codeStart, UnsignedWord codeSize) {
+        protectCodeMemory(codeStart, codeSize, VirtualMemoryProvider.Access.READ | VirtualMemoryProvider.Access.EXECUTE);
     }
 
-    public static int makeCodeMemoryExecutableWritable(CodePointer start, UnsignedWord size) {
-        return CommittedMemoryProvider.get().protect(start, size, EnumSet.of(CommittedMemoryProvider.Access.READ, CommittedMemoryProvider.Access.WRITE, CommittedMemoryProvider.Access.EXECUTE));
+    public static void makeCodeMemoryExecutableWritable(CodePointer start, UnsignedWord size) {
+        VMError.guarantee(RuntimeCodeCache.Options.WriteableCodeCache.getValue(), "memory must not be writable and executable at the same time unless we have a writable code cache");
+        protectCodeMemory(start, size, VirtualMemoryProvider.Access.READ | VirtualMemoryProvider.Access.WRITE | VirtualMemoryProvider.Access.EXECUTE);
+    }
+
+    private static void protectCodeMemory(CodePointer codeStart, UnsignedWord codeSize, int permissions) {
+        int result = VirtualMemoryProvider.get().protect(codeStart, codeSize, permissions);
+        if (result != 0) {
+            throw VMError.shouldNotReachHere("Failed to modify protection of code memory. This may be caused by " +
+                            "a. a too restrictive OS-limit of allowed memory mappings (see vm.max_map_count on Linux), " +
+                            "b. a too strict security policy if you are running on Security-Enhanced Linux (SELinux), or " +
+                            "c. a Native Image internal error.");
+        }
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/log/RealLog.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/log/RealLog.java
@@ -640,7 +640,12 @@ public class RealLog extends Log {
         }
 
         Throwable cur = t;
-        do {
+        int maxCauses = 25;
+        for (int i = 0; i < maxCauses && cur != null; i++) {
+            if (i > 0) {
+                newline().string("Caused by: ");
+            }
+
             /*
              * We do not want to call getMessage(), since it can be overridden by subclasses of
              * Throwable. So we access the raw detailMessage directly from the field in Throwable.
@@ -660,23 +665,20 @@ public class RealLog extends Log {
             } else {
                 StackTraceElement[] stackTrace = JDKUtils.getRawStackTrace(cur);
                 if (stackTrace != null) {
-                    int i;
-                    for (i = 0; i < stackTrace.length && i < maxFrames; i++) {
-                        StackTraceElement element = stackTrace[i];
+                    int j;
+                    for (j = 0; j < stackTrace.length && j < maxFrames; j++) {
+                        StackTraceElement element = stackTrace[j];
                         if (element != null) {
                             printJavaFrame(element.getClassName(), element.getMethodName(), element.getFileName(), element.getLineNumber());
                         }
                     }
-                    int remaining = stackTrace.length - i;
+                    int remaining = stackTrace.length - j;
                     printRemainingFramesCount(remaining);
                 }
             }
 
             cur = JDKUtils.getRawCause(cur);
-            if (cur != null) {
-                newline().string("Caused by: ");
-            }
-        } while (cur != null);
+        }
 
         return this;
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractCommittedMemoryProvider.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractCommittedMemoryProvider.java
@@ -30,8 +30,6 @@ import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_BEGIN;
 import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_END;
 import static org.graalvm.word.WordFactory.nullPointer;
 
-import java.util.EnumSet;
-
 import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.PointerBase;
@@ -41,11 +39,9 @@ import org.graalvm.word.WordFactory;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.c.function.CEntryPointErrors;
-import com.oracle.svm.core.code.RuntimeCodeCache;
 import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.heap.Heap;
 import com.oracle.svm.core.util.UnsignedUtils;
-import com.oracle.svm.core.util.VMError;
 
 public abstract class AbstractCommittedMemoryProvider implements CommittedMemoryProvider {
     @Fold
@@ -83,24 +79,6 @@ public abstract class AbstractCommittedMemoryProvider implements CommittedMemory
         }
 
         return CEntryPointErrors.NO_ERROR;
-    }
-
-    @Override
-    public int protect(PointerBase start, UnsignedWord nbytes, EnumSet<Access> accessFlags) {
-        int vmAccessBits = VirtualMemoryProvider.Access.NONE;
-        if (accessFlags.contains(CommittedMemoryProvider.Access.READ)) {
-            vmAccessBits |= VirtualMemoryProvider.Access.READ;
-        }
-        if (accessFlags.contains(CommittedMemoryProvider.Access.WRITE)) {
-            vmAccessBits |= VirtualMemoryProvider.Access.WRITE;
-        }
-        if (accessFlags.contains(CommittedMemoryProvider.Access.EXECUTE)) {
-            if ((vmAccessBits & VirtualMemoryProvider.Access.WRITE) != 0 && !RuntimeCodeCache.Options.WriteableCodeCache.getValue()) {
-                throw VMError.shouldNotReachHere("memory should never be writable and executable at the same time");
-            }
-            vmAccessBits |= VirtualMemoryProvider.Access.EXECUTE;
-        }
-        return VirtualMemoryProvider.get().protect(start, nbytes, vmAccessBits);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/CommittedMemoryProvider.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/CommittedMemoryProvider.java
@@ -24,8 +24,6 @@
  */
 package com.oracle.svm.core.os;
 
-import java.util.EnumSet;
-
 import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.c.type.WordPointer;
@@ -117,23 +115,4 @@ public interface CommittedMemoryProvider {
      */
     default void afterGarbageCollection() {
     }
-
-    enum Access {
-        READ,
-        WRITE,
-        EXECUTE
-    }
-
-    /**
-     * Change access permissions for a block of committed memory that was allocated with one of the
-     * allocation methods.
-     *
-     * @param start The start of the address range to be protected, which must be a multiple of the
-     *            {@linkplain #getGranularity() granularity}.
-     * @param nbytes The size in bytes of the address range to be protected, which will be rounded
-     *            up to a multiple of the {@linkplain #getGranularity() granularity}.
-     * @param access The modes in which the memory is permitted to be accessed, see {@link Access}.
-     * @return 0 when successful, or a non-zero implementation-specific error code.
-     */
-    int protect(PointerBase start, UnsignedWord nbytes, EnumSet<Access> access);
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaLangThreadGroupSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaLangThreadGroupSubstitutions.java
@@ -118,7 +118,8 @@ class ThreadGroupIdAccessor {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     static long getId(Target_java_lang_ThreadGroup that) {
         if (that.injectedId == 0) {
-            that.injectedId = nextID.getAndIncrement();
+            Target_java_lang_ThreadGroup virtualThreadGroup = SubstrateUtil.cast(Target_java_lang_Thread.virtualThreadGroup(), Target_java_lang_ThreadGroup.class);
+            that.injectedId = that == virtualThreadGroup ? JfrThreadRepository.VIRTUAL_THREAD_GROUP_ID : nextID.getAndIncrement();
         }
         return that.injectedId;
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
@@ -24,8 +24,6 @@
  */
 package com.oracle.svm.core.thread;
 
-import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
-
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -113,15 +111,14 @@ public final class JavaThreads {
      * code does (e.g., the method below does not check for virtual threads or
      * {@code Thread.isTerminated()}).
      */
-    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static ThreadGroup getRawThreadGroup(Thread thread) {
-        if (isVirtual(thread)) {
-            return Target_java_lang_Thread.virtualThreadGroup();
-        } else {
-            Target_java_lang_Thread t = SubstrateUtil.cast(thread, Target_java_lang_Thread.class);
-            Target_java_lang_Thread_FieldHolder holder = t.holder;
-            return holder != null ? holder.group : null;
+        Target_java_lang_Thread t = SubstrateUtil.cast(thread, Target_java_lang_Thread.class);
+        Target_java_lang_Thread_FieldHolder holder = t.holder;
+        if (holder != null) {
+            return holder.group;
         }
+        return null;
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
@@ -292,7 +292,7 @@ public final class Target_java_lang_Thread {
     @AnnotateOriginal
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     @TargetElement(onlyWith = JDK19OrLater.class)
-    static native ThreadGroup virtualThreadGroup();
+    public static native ThreadGroup virtualThreadGroup();
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     @AnnotateOriginal

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/ParseOnceRuntimeCompilationFeature.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/ParseOnceRuntimeCompilationFeature.java
@@ -105,6 +105,7 @@ import com.oracle.graal.pointsto.phases.InlineBeforeAnalysisPolicy;
 import com.oracle.graal.pointsto.util.CompletionExecutor;
 import com.oracle.svm.common.meta.MultiMethod;
 import com.oracle.svm.core.ParsingReason;
+import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.graal.nodes.DeoptEntryNode;
 import com.oracle.svm.core.graal.nodes.DeoptEntrySupport;
@@ -570,6 +571,17 @@ public class ParseOnceRuntimeCompilationFeature extends RuntimeCompilationFeatur
          * the hosted universe.
          */
         aMethod.setAnalyzedGraph(null);
+
+        /*
+         * The availability of NodeSourcePosition for JIT compilation is controlled by a separate
+         * option and not TrackNodeSourcePosition to decouple AOT and JIT compilation.
+         */
+        boolean trackNodeSourcePosition = SubstrateOptions.IncludeNodeSourcePositions.getValue();
+        if (!trackNodeSourcePosition) {
+            for (Node node : graph.getNodes()) {
+                node.clearNodeSourcePosition();
+            }
+        }
 
         CanonicalizerPhase canonicalizer = CanonicalizerPhase.create();
         IterativeConditionalEliminationPhase conditionalElimination = new IterativeConditionalEliminationPhase(canonicalizer, true);

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedRuntimeCodeInstaller.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedRuntimeCodeInstaller.java
@@ -162,8 +162,8 @@ public final class IsolatedRuntimeCodeInstaller extends RuntimeCodeInstaller {
     }
 
     @CEntryPoint(include = CEntryPoint.NotIncludedAutomatically.class, publishAs = CEntryPoint.Publish.NotPublished)
-    private static int makeCodeMemoryExecutableReadOnly0(@SuppressWarnings("unused") IsolateThread targetIsolate, Pointer start, UnsignedWord size) {
-        return RuntimeCodeInfoAccess.makeCodeMemoryExecutableReadOnly((CodePointer) start, size);
+    private static void makeCodeMemoryExecutableReadOnly0(@SuppressWarnings("unused") IsolateThread targetIsolate, Pointer start, UnsignedWord size) {
+        RuntimeCodeInfoAccess.makeCodeMemoryExecutableReadOnly((CodePointer) start, size);
     }
 
     @Override
@@ -172,7 +172,7 @@ public final class IsolatedRuntimeCodeInstaller extends RuntimeCodeInstaller {
     }
 
     @CEntryPoint(include = CEntryPoint.NotIncludedAutomatically.class, publishAs = CEntryPoint.Publish.NotPublished)
-    private static int makeCodeMemoryExecutableWritable0(@SuppressWarnings("unused") IsolateThread targetIsolate, Pointer start, UnsignedWord size) {
-        return RuntimeCodeInfoAccess.makeCodeMemoryExecutableWritable((CodePointer) start, size);
+    private static void makeCodeMemoryExecutableWritable0(@SuppressWarnings("unused") IsolateThread targetIsolate, Pointer start, UnsignedWord size) {
+        RuntimeCodeInfoAccess.makeCodeMemoryExecutableWritable((CodePointer) start, size);
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/SharedGraphBuilderPhase.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/SharedGraphBuilderPhase.java
@@ -294,12 +294,12 @@ public abstract class SharedGraphBuilderPhase extends GraphBuilderPhase.Instance
         }
 
         @Override
-        protected void handleUnresolvedNewObjectArray(JavaType type, ValueNode length) {
+        protected void handleUnresolvedNewObjectArray(JavaType type) {
             handleUnresolvedType(type);
         }
 
         @Override
-        protected void handleUnresolvedNewMultiArray(JavaType type, ValueNode[] dims) {
+        protected void handleUnresolvedNewMultiArray(JavaType type) {
             handleUnresolvedType(type.getElementalType());
         }
 
@@ -354,12 +354,12 @@ public abstract class SharedGraphBuilderPhase extends GraphBuilderPhase.Instance
         }
 
         @Override
-        protected void handleUnresolvedStoreField(JavaField field, ValueNode value, ValueNode receiver) {
+        protected void handleUnresolvedStoreField(JavaField field) {
             handleUnresolvedField(field);
         }
 
         @Override
-        protected void handleUnresolvedLoadField(JavaField field, ValueNode receiver) {
+        protected void handleUnresolvedLoadField(JavaField field) {
             handleUnresolvedField(field);
         }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsJfrStreaming.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsJfrStreaming.java
@@ -88,7 +88,7 @@ public class TestVirtualThreadsJfrStreaming extends JfrStreamingTest {
 
         VirtualStressor.execute(THREADS, eventEmitter);
         waitUntilTrue(() -> emittedEventsPerType.get() == EXPECTED_EVENTS);
-        waitUntilTrue(() -> expectedThreads.isEmpty());
+        waitUntilTrue(expectedThreads::isEmpty);
         stopStream(stream, null);
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/poolparsers/ThreadGroupConstantPoolParser.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/poolparsers/ThreadGroupConstantPoolParser.java
@@ -28,6 +28,8 @@ package com.oracle.svm.test.jfr.utils.poolparsers;
 
 import java.io.IOException;
 
+import org.junit.Assert;
+
 import com.oracle.svm.core.jfr.JfrThreadRepository;
 import com.oracle.svm.core.jfr.JfrType;
 import com.oracle.svm.test.jfr.utils.JfrFileParser;
@@ -49,7 +51,7 @@ public class ThreadGroupConstantPoolParser extends AbstractRepositoryParser {
             String threadGroupName = input.readUTF(); // ThreadGroupName.
 
             /* For virtual threads, a fixed thread group id is reserved. */
-            assert threadGroupId != JfrThreadRepository.VIRTUAL_THREAD_GROUP_ID || threadGroupName.equals("VirtualThreads");
+            Assert.assertTrue(threadGroupId != JfrThreadRepository.VIRTUAL_THREAD_GROUP_ID || threadGroupName.equals("VirtualThreads"));
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/poolparsers/ThreadGroupConstantPoolParser.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/poolparsers/ThreadGroupConstantPoolParser.java
@@ -28,23 +28,28 @@ package com.oracle.svm.test.jfr.utils.poolparsers;
 
 import java.io.IOException;
 
+import com.oracle.svm.core.jfr.JfrThreadRepository;
 import com.oracle.svm.core.jfr.JfrType;
 import com.oracle.svm.test.jfr.utils.JfrFileParser;
 import com.oracle.svm.test.jfr.utils.RecordingInput;
 
 public class ThreadGroupConstantPoolParser extends AbstractRepositoryParser {
     public ThreadGroupConstantPoolParser(JfrFileParser parser) {
-        /* 0 is the null thread group, 1 is the virtual thread group. */
-        super(parser, 0L, 1L);
+        /* 0 is the null thread group. */
+        super(parser, 0L);
     }
 
     @Override
     public void parse(RecordingInput input) throws IOException {
         int numberOfThreadGroups = input.readInt();
         for (int i = 0; i < numberOfThreadGroups; i++) {
-            addFoundId(input.readLong()); // ThreadGroupId.
+            long threadGroupId = input.readLong();
+            addFoundId(threadGroupId); // ThreadGroupId.
             addExpectedId(JfrType.ThreadGroup, input.readLong()); // ParentThreadGroupId.
-            input.readUTF(); // ThreadGroupName.
+            String threadGroupName = input.readUTF(); // ThreadGroupName.
+
+            /* For virtual threads, a fixed thread group id is reserved. */
+            assert threadGroupId != JfrThreadRepository.VIRTUAL_THREAD_GROUP_ID || threadGroupName.equals("VirtualThreads");
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleFeature.java
@@ -103,6 +103,7 @@ import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
 import java.util.function.UnaryOperator;
 
+import org.graalvm.compiler.phases.common.InsertGuardFencesPhase;
 import org.graalvm.collections.Pair;
 import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
 import org.graalvm.compiler.core.phases.HighTier;
@@ -996,6 +997,15 @@ public class TruffleFeature implements InternalFeature {
          */
         if (hosted && HostInliningPhase.Options.TruffleHostInlining.getValue(HostedOptionValues.singleton()) && suites.getHighTier() instanceof HighTier) {
             suites.getHighTier().prependPhase(new SubstrateHostInliningPhase(CanonicalizerPhase.create()));
+        }
+        /*
+         * On HotSpot, the InsertGuardFencesPhase is inserted into the mid-tier depending on the
+         * runtime option SpectrePHTBarriers. However, TruffleFeature registers phases during
+         * image-build time. Therefore, for Truffle compilations, we need to register the phase
+         * eagerly because the SpectrePHTBarriers options is set only at image-execution time.
+         */
+        if (!hosted && suites.getMidTier().findPhase(InsertGuardFencesPhase.class, true) == null) {
+            suites.getMidTier().appendPhase(new InsertGuardFencesPhase());
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/isolated/IsolatedTruffleCompilerEventForwarder.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/isolated/IsolatedTruffleCompilerEventForwarder.java
@@ -84,7 +84,7 @@ final class IsolatedTruffleCompilerEventForwarder implements TruffleCompilerList
 
     @Override
     public void onCompilationRetry(TruffleCompilable compilable, TruffleCompilationTask task) {
-        onCompilationRetry0(IsolatedCompileContext.get().getClient(), contextHandle, IsolatedCompileClient.get().hand(task));
+        onCompilationRetry0(IsolatedCompileContext.get().getClient(), contextHandle);
     }
 
     @CEntryPoint(include = CEntryPoint.NotIncludedAutomatically.class, publishAs = CEntryPoint.Publish.NotPublished)
@@ -117,8 +117,7 @@ final class IsolatedTruffleCompilerEventForwarder implements TruffleCompilerList
     }
 
     @CEntryPoint(include = CEntryPoint.NotIncludedAutomatically.class, publishAs = CEntryPoint.Publish.NotPublished)
-    private static void onCompilationRetry0(@SuppressWarnings("unused") ClientIsolateThread client, ClientHandle<IsolatedEventContext> contextHandle,
-                    @SuppressWarnings("unused") ClientHandle<TruffleCompilationTask> task) {
+    private static void onCompilationRetry0(@SuppressWarnings("unused") ClientIsolateThread client, ClientHandle<IsolatedEventContext> contextHandle) {
         IsolatedEventContext context = IsolatedCompileClient.get().unhand(contextHandle);
         context.listener.onCompilationRetry(context.compilable, context.task);
     }

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -33,7 +33,7 @@ suite = {
                 "name": "graal-nodejs",
                 "subdir": True,
                 "dynamic": True,
-                "version": "9650ba454ef65a564dd53c3dbe83da24fcba2f8d",
+                "version": "519f34cc89e5b8d579c3c95b2f61a924deeb5a08",
                 "urls" : [
                     {"url" : "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -42,7 +42,7 @@ suite = {
                 "name": "graal-js",
                 "subdir": True,
                 "dynamic": True,
-                "version": "9650ba454ef65a564dd53c3dbe83da24fcba2f8d",
+                "version": "519f34cc89e5b8d579c3c95b2f61a924deeb5a08",
                 "urls": [
                     {"url": "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -33,7 +33,7 @@ suite = {
                 "name": "graal-nodejs",
                 "subdir": True,
                 "dynamic": True,
-                "version": "519f34cc89e5b8d579c3c95b2f61a924deeb5a08",
+                "version": "ed94f244ada44bfd078780ceed9fbb270d776611",
                 "urls" : [
                     {"url" : "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -42,7 +42,7 @@ suite = {
                 "name": "graal-js",
                 "subdir": True,
                 "dynamic": True,
-                "version": "519f34cc89e5b8d579c3c95b2f61a924deeb5a08",
+                "version": "ed94f244ada44bfd078780ceed9fbb270d776611",
                 "urls": [
                     {"url": "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]


### PR DESCRIPTION
Sync with upstream https://github.com/graalvm/graalvm-for-jdk21-community-backports/

- **JVM standalones do not include any library config of the main component (GR-49428).**
- **Remove aload -> getfield optimization from BytecodeParser**
- **BytecodeParser: Do not pop values from FrameState before resolving types/fields**
- **BytecodeParser: add comment explaining removal of checks in handleUnresolvedNewArray**
- **[GR-52396] Backport to 23.1: Fix wasm.jar not being included in nodejs jvm standalone.**
- **[GR-52324] Add InsertGuardFencesPhase into runtime compilation phases.**
- **[GR-52465] Backport to 23.1: Upgrading the underlying Node.js to version 18.19.1.**
- **Fix failing JFR tests.**
- **Changes according to comments.**
- **[GR-52617] Limit Log.exception() output.**
- **[GR-52617] Prevent register writes from floating.**
- **[GR-52435] ExitOnOutOfMemoryError must wait until HeapDumpOnOutOfMemoryError finishes.**
- **[GR-52614] Improve a code installation error message.**
- **[GR-52302] NPE while diagnosing compilation failure when using compilation in isolate.**
- **Backport "GR-52269:MoveGuardsUpwards: respect dom tree." and adapt to 23.1**
- **Avoid unnecessary NodeSourcePosition for runtime compilation**
- **Update JVMCI to 23.1-b37**
