### PR TITLE
[CI] Explicitly set `quarkus.native.container-build` to false

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -502,7 +502,7 @@ jobs:
           $opts=@()
           -split $Env:NATIVE_TEST_MAVEN_OPTS | foreach { $opts += "`"$_`"" }
           #if ( "${{ inputs.builder-image }}" -eq "null" ) {
-          mvn -f integration-tests -pl "$Env:TEST_MODULES" -amd $opts install
+          mvn -f integration-tests -pl "$Env:TEST_MODULES" -amd "-Dquarkus.native.container-build=false" $opts install
           #} else {
           #  mvn -pl $do_modules "-Dquarkus.native.container-build=true" "-Dquarkus.native.builder-image=${{ inputs.builder-image }}" $opts package
           #}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -565,7 +565,7 @@ jobs:
           cd ${QUARKUS_PATH}
           if [[ ${{ inputs.builder-image }} == "null" ]]
           then
-            export BUILDER_IMAGE=""
+            export BUILDER_IMAGE="-Dquarkus.native.container-build=false"
             ${GRAALVM_HOME}/bin/native-image --version
           else
             export BUILDER_IMAGE="-Dquarkus.native.container-build=true -Dquarkus.native.builder-image=${{ inputs.builder-image }}"


### PR DESCRIPTION
Since https://github.com/quarkusio/quarkus/pull/37622,
integration-tests/main sets quarkus.native.container-build to true
resulting in our CI building and testing it with the default builder
image instead of our Mandrel build.

It's yet not clear to me why this change was necessary (expecting an
answer in [1], but either way enforcing non-container-builds seems the
right thing to do in the CI when testing builds from source.

[1] https://github.com/quarkusio/quarkus/pull/37622/files#r1551481449),
