### PR TITLE
[24.0] Adopt "JDK-8324646: Avoid Class.forName in SecureRandom constructor"

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
@@ -659,7 +659,15 @@ public class SecurityServicesFeature extends JNIRegistrationUtil implements Inte
     private static Function<String, Class<?>> getConstructorParameterClassAccessor(ImageClassLoader loader) {
         Map<String, /* EngineDescription */ Object> knownEngines = ReflectionUtil.readStaticField(Provider.class, "knownEngines");
         Class<?> clazz = loader.findClassOrFail("java.security.Provider$EngineDescription");
-        Field consParamClassNameField = ReflectionUtil.lookupField(clazz, "constructorParameterClassName");
+        Field consParamClassField;
+
+        try {
+            consParamClassField = ReflectionUtil.lookupField(clazz, "constructorParameterClassName");
+        } catch (ReflectionUtil.ReflectionUtilError e) {
+            consParamClassField = ReflectionUtil.lookupField(clazz, "constructorParameterClass");
+        }
+
+        final Field consParamClassFieldFinal = consParamClassField;
 
         /*
          * The returned lambda captures the value of the Provider.knownEngines map retrieved above
@@ -684,10 +692,10 @@ public class SecurityServicesFeature extends JNIRegistrationUtil implements Inte
                 if (engineDescription == null) {
                     return null;
                 }
-                String constrParamClassName = (String) consParamClassNameField.get(engineDescription);
-                if (constrParamClassName != null) {
-                    return loader.findClass(constrParamClassName).get();
+                if (consParamClassFieldFinal.getName().equals("constructorParameterClassName")) {
+                    return loader.findClass((String) consParamClassFieldFinal.get(engineDescription)).get();
                 }
+                return (Class<?>) consParamClassFieldFinal.get(engineDescription);
             } catch (IllegalAccessException e) {
                 VMError.shouldNotReachHere(e);
             }


### PR DESCRIPTION
Adapted backport of
https://github.com/oracle/graal/pull/8387/commits/05c1e79d360a9ab375eac31d1ce6946a311d74bc

Fixes https://github.com/graalvm/mandrel/issues/716
