### PR TITLE
Store markdown error reports when builds fail

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -239,6 +239,16 @@ jobs:
       with:
         name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
+    - name: Prepare failure archive (if maven failed)
+      if: failure()
+      shell: bash
+      run: find . -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
+    - name: Upload failure Archive (if maven failed)
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: mandrel-reports-native-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+        path: 'test-reports.tgz'
 
   build-graal:
     name: GraalVM CE build
@@ -299,7 +309,17 @@ jobs:
       with:
         name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
-
+    - name: Prepare failure archive (if maven failed)
+      if: failure()
+      shell: bash
+      run: find . -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
+    - name: Upload failure Archive (if maven failed)
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: graal-reports-native-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+        path: 'test-reports.tgz'
+  
   get-jdk:
     name: Get JDK ${{ inputs.jdk }}
     runs-on: windows-2022
@@ -512,7 +532,7 @@ jobs:
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
-        run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar czvf test-reports.tgz -T -
+        run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' -o -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -262,6 +262,16 @@ jobs:
       with:
         name: mandrel-maven-version-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: graalvm-version.tgz
+    - name: Prepare failure archive (if maven failed)
+      if: failure()
+      shell: bash
+      run: find . -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
+    - name: Upload failure Archive (if maven failed)
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: mandrel-reports-native-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+        path: 'test-reports.tgz'
 
   build-graal:
     name: GraalVM CE build
@@ -347,6 +357,16 @@ jobs:
       with:
         name: mandrel-maven-version-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: graalvm-version.tgz
+    - name: Prepare failure archive (if maven failed)
+      if: failure()
+      shell: bash
+      run: find . -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
+    - name: Upload failure Archive (if maven failed)
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: graal-reports-native-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
+        path: 'test-reports.tgz'
 
   get-jdk:
     name: Get JDK ${{ inputs.jdk }}
@@ -599,7 +619,8 @@ jobs:
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
-        run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar czvf test-reports.tgz -T -
+        run: |
+          find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' -o -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
         uses: actions/upload-artifact@v4
         if: failure()


### PR DESCRIPTION
Fixes https://github.com/graalvm/mandrel/issues/682

Note: As an alternative we could just `cat` them or even better push them to the [job summary](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/).