### PR TITLE
[CI] Set PYTHONIOENCODING to utf-8 to make `mx` happy

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -79,6 +79,7 @@ env:
   MANDREL_HOME: ${{ github.workspace }}\..\mandrelvm
   MX_PATH: ${{ github.workspace }}\mx
   MX_PYTHON: python
+  PYTHONIOENCODING: utf-8
   QUARKUS_PATH: ${{ github.workspace }}\quarkus
   MANDREL_PACKAGING_REPO: ${{ github.workspace }}\mandrel-packaging
   COLLECTOR_URL: https://collector.foci.life/api/v1/image-stats

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -78,6 +78,7 @@ env:
   MANDREL_HOME: ${{ github.workspace }}/../mandrelvm
   MX_PATH: ${{ github.workspace }}/mx
   MX_PYTHON: python
+  PYTHONIOENCODING: utf-8
   QUARKUS_PATH: ${{ github.workspace }}/quarkus
   MANDREL_IT_PATH: ${{ github.workspace }}/mandrel-integration-tests
   MANDREL_PACKAGING_REPO: ${{ github.workspace }}/mandrel-packaging


### PR DESCRIPTION
Starting with `mx` 7.24.0, `mx` checks if the stdout encoding is set to
unicode.

See
https://github.com/graalvm/mx/commit/b6625a410340c52c79d3006fd0fbcaf16f1aa608
