### PR TITLE
[23.1] Backport: Minor JNI and libchelper fixes

### DIFF
--- a/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
+++ b/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
@@ -31,7 +31,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/socket.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netdb.h>
 #include <errno.h>
 #include <dlfcn.h>
@@ -311,10 +311,15 @@ JNIEXPORT jobject JNICALL JVM_DoPrivileged(JNIEnv *env, jclass cls, jobject acti
             return (*env)->CallObjectMethod(env, action, run);
         }
     }
+
+    /* Some error occurred - clear pending exception and try to report the error. */
+    (*env)->ExceptionClear(env);
+
     jclass errorClass = (*env)->FindClass(env, "java/lang/InternalError");
     if (errorClass != NULL && !(*env)->ExceptionCheck(env)) {
         (*env)->ThrowNew(env, errorClass, "Could not invoke PrivilegedAction");
     } else {
+        (*env)->ExceptionClear(env);
         (*env)->FatalError(env, "PrivilegedAction could not be invoked and the error could not be reported");
     }
     return NULL;

--- a/substratevm/src/com.oracle.svm.native.libchelper/src/getThreadId.c
+++ b/substratevm/src/com.oracle.svm.native.libchelper/src/getThreadId.c
@@ -28,6 +28,7 @@
 
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 /*
  * Based on os::Linux::gettid() from jdk-20-ga, see

--- a/substratevm/src/com.oracle.svm.native.libchelper/src/getThreadUserTime.c
+++ b/substratevm/src/com.oracle.svm.native.libchelper/src/getThreadUserTime.c
@@ -26,6 +26,7 @@
 
 #ifdef __linux__
 
+#include <ctype.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>


### PR DESCRIPTION
Backport of https://github.com/oracle/graal/pull/7955

- **Fix missing headers in libchelper.**
- **Fix potentially pending JNI exceptions.**

Resolves build issues like:

```
[7/10] CC src/getThreadId.o
FAILED: src/getThreadId.o 
gcc -MMD -MF src/getThreadId.o.d -I/home/zakkak/code/mandrel/substratevm/src/com.oracle.svm.native.libchelper/include  -fdebug-prefix-map=/home/zakkak/code/mandrel=mandrel -fdebug-prefix-map=/home/zakkak/code/mandrel/substratevm/mxbuild/jdk21=jdk21 -fdebug-prefix-map=/home/zakkak/jvms/jdk-21.0.4+2=jdk-21.0.4+2 -gno-record-gcc-switches -g -gdwarf-4 -fPIC -O2 -D_LITTLE_ENDIAN -ffunction-sections -fdata-sections -fvisibility=hidden -D_FORTIFY_SOURCE=0 -c /home/zakkak/code/mandrel/substratevm/src/com.oracle.svm.native.libchelper/src/getThreadId.c -o src/getThreadId.o
/home/zakkak/code/mandrel/substratevm/src/com.oracle.svm.native.libchelper/src/getThreadId.c: In function ‘getThreadId’:
/home/zakkak/code/mandrel/substratevm/src/com.oracle.svm.native.libchelper/src/getThreadId.c:39:17: error: implicit declaration of function ‘syscall’ [-Wimplicit-function-declaration]
   39 |   return (pid_t)syscall(SYS_gettid);
      |                 ^~~~~~~
ninja: build stopped: subcommand failed.
, -2)
```