### PR TITLE
[23.1] Backports resolving OpenJDK 21.0.4 updates compatibility issues

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u3OrEarlier.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u3OrEarlier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+
+public class JDK21u3OrEarlier implements BooleanSupplier {
+
+    public static final boolean jdk21u3OrEarlier = JavaVersionUtil.JAVA_SPEC < 21 ||
+            (JavaVersionUtil.JAVA_SPEC == 21 && Runtime.version().update() <= 3);
+
+    @Override
+    public boolean getAsBoolean() {
+        return jdk21u3OrEarlier;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u4OrLater.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u4OrLater.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+
+public class JDK21u4OrLater implements BooleanSupplier {
+
+    public static final boolean jdk21u4OrLater = JavaVersionUtil.JAVA_SPEC > 21 ||
+            (JavaVersionUtil.JAVA_SPEC == 21 && Runtime.version().update() >= 4);
+
+    @Override
+    public boolean getAsBoolean() {
+        return jdk21u4OrLater;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
@@ -57,17 +57,20 @@ public final class Target_java_lang_VirtualThread {
     // Checkstyle: stop
     @Alias static int NEW;
     @Alias static int STARTED;
-    @Alias static int RUNNABLE;
+    @Alias //
+    @TargetElement(onlyWith = JDK21u3OrEarlier.class) static int RUNNABLE;
     @Alias static int RUNNING;
     @Alias static int PARKING;
     @Alias static int PARKED;
     @Alias static int PINNED;
     @Alias static int YIELDING;
+    @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int YIELDED;
     @Alias static int TERMINATED;
     @Alias static int SUSPENDED;
     @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int TIMED_PARKING;
     @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int TIMED_PARKED;
     @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int TIMED_PINNED;
+    @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int UNPARKED;
     @Alias static Target_jdk_internal_vm_ContinuationScope VTHREAD_SCOPE;
     // Checkstyle: resume
 
@@ -168,7 +171,9 @@ public final class Target_java_lang_VirtualThread {
             } else {
                 return Thread.State.RUNNABLE;
             }
-        } else if (state == RUNNABLE) {
+        } else if (JDK21u3OrEarlier.jdk21u3OrEarlier && state == RUNNABLE) {
+            return Thread.State.RUNNABLE;
+        } else if (JDK21u4OrLater.jdk21u4OrLater && (state == UNPARKED || state == YIELDED)) {
             return Thread.State.RUNNABLE;
         } else if (state == RUNNING) {
             Object token = VirtualThreadHelper.acquireInterruptLockMaybeSwitch(this);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
@@ -43,6 +43,7 @@ import com.oracle.svm.core.jdk.JDK19OrLater;
 import com.oracle.svm.core.jdk.JDK20OrEarlier;
 import com.oracle.svm.core.jdk.JDK20OrLater;
 import com.oracle.svm.core.jdk.JDK21OrLater;
+import com.oracle.svm.core.jdk.JDK21u3OrEarlier;
 import com.oracle.svm.core.jdk.LoomJDK;
 import com.oracle.svm.core.jfr.HasJfrSupport;
 import com.oracle.svm.core.jfr.SubstrateJVM;
@@ -62,8 +63,12 @@ public final class Target_java_lang_VirtualThread {
     @Alias static int PINNED;
     @Alias static int YIELDING;
     @Alias static int TERMINATED;
-    @Alias static int RUNNABLE_SUSPENDED;
-    @Alias static int PARKED_SUSPENDED;
+    @Alias //
+    @TargetElement(onlyWith = JDK21u3OrEarlier.class) //
+    static int RUNNABLE_SUSPENDED;
+    @Alias //
+    @TargetElement(onlyWith = JDK21u3OrEarlier.class) //
+    static int PARKED_SUSPENDED;
     @Alias static Target_jdk_internal_vm_ContinuationScope VTHREAD_SCOPE;
     // Checkstyle: resume
 
@@ -164,7 +169,7 @@ public final class Target_java_lang_VirtualThread {
             } else {
                 return Thread.State.RUNNABLE;
             }
-        } else if (state == RUNNABLE || state == RUNNABLE_SUSPENDED) {
+        } else if (state == RUNNABLE || (JDK21u3OrEarlier.jdk21u3OrEarlier && state == RUNNABLE_SUSPENDED)) {
             return Thread.State.RUNNABLE;
         } else if (state == RUNNING) {
             Object token = VirtualThreadHelper.acquireInterruptLockMaybeSwitch(this);
@@ -179,7 +184,7 @@ public final class Target_java_lang_VirtualThread {
             return Thread.State.RUNNABLE;
         } else if (state == PARKING || state == YIELDING) {
             return Thread.State.RUNNABLE;
-        } else if (state == PARKED || state == PARKED_SUSPENDED || state == PINNED) {
+        } else if (state == PARKED || (JDK21u3OrEarlier.jdk21u3OrEarlier && state == PARKED_SUSPENDED) || state == PINNED) {
             int parkedThreadStatus = MonitorSupport.singleton().getParkedThreadStatus(asThread(this), false);
             switch (parkedThreadStatus) {
                 case ThreadStatus.BLOCKED_ON_MONITOR_ENTER:


### PR DESCRIPTION
Resolves issues introduced by the JDK 21 backports of:

* [JDK-8315373](https://bugs.openjdk.org/browse/JDK-8315373) (which included [JDK-8312498](https://bugs.openjdk.org/browse/JDK-8312498), [JDK-8312777](https://bugs.openjdk.org/browse/JDK-8312777), [JDK-8321270](https://bugs.openjdk.org/browse/JDK-8321270), [JDK-8322818](https://bugs.openjdk.org/browse/JDK-8322818), [JDK-8323002](https://bugs.openjdk.org/browse/JDK-8323002), [JDK-8323296](https://bugs.openjdk.org/browse/JDK-8323296), [JDK-8316924](https://bugs.openjdk.org/browse/JDK-8316924))
* [JDK-8310913](https://bugs.openjdk.org/browse/JDK-8310913)
* [JDK-8324646](https://bugs.openjdk.org/browse/JDK-8324646)

It does so by backporting the following:
- [svm: adopt "JDK-8312498 Thread::getState and JVM TI GetThreadState should return TIMED_WAITING virtual thread is timed parked" [GR-48899]](https://github.com/graalvm/mandrel/commit/421ff9926f7d6177f188cb698eaab1e27dbd980d)
- [[GR-48899] Support TIMED_WAITING for virtual threads.](https://github.com/graalvm/mandrel/commit/4fad6c2661356dfd51afe82d88009b549bfdbedb)
- [[svm: adopt "JDK-8321270: Virtual Thread.yield consumes parking permit" [GR-50851]]](https://github.com/graalvm/mandrel/commit/595ac63036c8888330cc1f4eb4e381f5c70629f3)
- [[svm: adapt "Move ReferencedKeyMap to jdk.internal so it may be shared" [JDK-8310913]]](https://github.com/graalvm/mandrel/commit/0f2c3c1e3ba6d44d53e77fac67ab1e81adee7c93)
- [[Adopt "JDK-8324646: Avoid Class.forName in SecureRandom constructor"]](https://github.com/graalvm/mandrel/commit/39988d343d32ec99d86dbd57f2c55200233c9815)

and applying a fix on top:

- **svm: fix for JDK 21.0.4 after the downport of "8315373: Change VirtualThread to unmount after freezing, re-mount before thawing" and dependnet changes**