### PR TITLE
Fix missing null check in 'Adopt "JDK-8324646: Avoid Class.forName in SecureRandom constructor"'

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
@@ -687,7 +687,12 @@ public class SecurityServicesFeature extends JNIRegistrationUtil implements Inte
                     return null;
                 }
                 if (consParamClassFieldFinal.getName().equals("constructorParameterClassName")) {
-                    return loader.findClass((String) consParamClassFieldFinal.get(engineDescription)).get();
+                    String constructorParameterClassName = (String) consParamClassFieldFinal.get(engineDescription);
+                    if (constructorParameterClassName != null) {
+                        return loader.findClass(constructorParameterClassName).get();
+                    } else {
+                        return null;
+                    }
                 }
                 return (Class<?>) consParamClassFieldFinal.get(engineDescription);
             } catch (IllegalAccessException e) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
@@ -686,15 +686,13 @@ public class SecurityServicesFeature extends JNIRegistrationUtil implements Inte
                 if (engineDescription == null) {
                     return null;
                 }
-                if (consParamClassFieldFinal.getName().equals("constructorParameterClassName")) {
-                    String constructorParameterClassName = (String) consParamClassFieldFinal.get(engineDescription);
-                    if (constructorParameterClassName != null) {
-                        return loader.findClass(constructorParameterClassName).get();
-                    } else {
-                        return null;
-                    }
+                if (consParamClassFieldFinal.getName().equals("constructorParameterClass")) {
+                    return (Class<?>) consParamClassFieldFinal.get(engineDescription);
                 }
-                return (Class<?>) consParamClassFieldFinal.get(engineDescription);
+                String constructorParameterClassName = (String) consParamClassFieldFinal.get(engineDescription);
+                if (constructorParameterClassName != null) {
+                    return loader.findClass(constructorParameterClassName).get();
+                }
             } catch (IllegalAccessException e) {
                 VMError.shouldNotReachHere(e);
             }


### PR DESCRIPTION
We are missing a null-check in `SecurityServicesFeature::getConstructorParameterClassAccessor()` introduced by #738  because `consParamClassFieldFinal.get(engineDescription)` can be null:
```java
if (consParamClassFieldFinal.getName().equals("constructorParameterClassName")) {
    return loader.findClass((String) consParamClassFieldFinal.get(engineDescription)).get();
}
```