### PR TITLE
Build nightly with the JDK 23 release branch (24.1)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
-      version: "graal/master"
+      version: "mandrel/24.1"
       build-type: "graal-source"
       jdk: "latest/ea"
       build-stats-tag: "gha-linux-graal-qmain-glatest-jdk23ea"
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
-      version: "graal/master"
+      version: "mandrel/24.1"
       jdk: "23/ea"
       issue-number: "742"
       issue-repo: "graalvm/mandrel"
@@ -62,7 +62,7 @@ jobs:
     uses: ./.github/workflows/base-windows.yml
     with:
       quarkus-version: "main"
-      version: "graal/master"
+      version: "mandrel/24.1"
       issue-number: "743"
       issue-repo: "graalvm/mandrel"
       mandrel-it-issue-number: "243"


### PR DESCRIPTION
Partial fix for #749. This switches nightly builds to use the new `mandrel/24.1` branch (currently broken). CI builds for 24.2 (JDK 24) to follow once https://github.com/adoptium/api.adoptium.net/issues/1077 is resolved.