### PR TITLE
[CI] Stop testing Mandrel 24.0 with JDK 22 EA

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -121,39 +121,6 @@ jobs:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
-  # Test Q main and Mandrel 24.0 JDK 22
-  ####
-  q-main-mandrel-24_0-ea:
-    name: "Q main M 24.0 JDK 22 EA"
-    uses: ./.github/workflows/base.yml
-    with:
-      quarkus-version: "main"
-      version: "mandrel/24.0"
-      jdk: "22/ea"
-      issue-number: "644"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "240"
-      build-stats-tag: "gha-linux-qmain-m24_0-jdk22ea"
-      mandrel-packaging-version: "24.0"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-mandrel-24_0-ea-win:
-    name: "Q main M 24.0 EA windows"
-    uses: ./.github/workflows/base-windows.yml
-    with:
-      quarkus-version: "main"
-      version: "mandrel/24.0"
-      jdk: "22/ea"
-      issue-number: "645"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "241"
-      build-stats-tag: "gha-win-qmain-m24_0-jdk22ea"
-      mandrel-packaging-version: "24.0"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  ####
   # Test Q main and Mandrel 23.1 JDK 21
   ####
   q-main-mandrel-23_1:


### PR DESCRIPTION
There are no further CPU updates planned for 24.0 so there is no point
in testing this configuration.

Note that we still keep testing Quarkus main with the jdk-22 builder image.
