### PR TITLE
[24.1] Add reflection metadata for jfrTracing field.

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -635,6 +635,7 @@ suite = {
                     "jdk.internal.module",
                     "sun.text.spi",
                     "jdk.internal.reflect",
+                    "sun.nio.ch",
                     "sun.util.cldr",
                     "sun.util.locale",
                     "sun.invoke.util",

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventFeature.java
@@ -24,14 +24,17 @@
  */
 package com.oracle.svm.hosted.jfr;
 
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.RandomAccessFile;
 import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
@@ -45,10 +48,12 @@ import com.oracle.svm.core.jfr.traceid.JfrTraceIdMap;
 import com.oracle.svm.core.meta.SharedType;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.FeatureImpl;
+import com.oracle.svm.hosted.reflect.ReflectionFeature;
 
 import jdk.internal.event.Event;
 import jdk.jfr.internal.JVM;
 import jdk.vm.ci.meta.MetaAccessProvider;
+import sun.nio.ch.FileChannelImpl;
 
 /**
  * Support for Java-level JFR events. This feature is only present if the {@link JfrFeature} is used
@@ -63,7 +68,16 @@ public class JfrEventFeature implements InternalFeature {
 
     @Override
     public List<Class<? extends Feature>> getRequiredFeatures() {
-        return Collections.singletonList(JfrFeature.class);
+        return List.of(JfrFeature.class, ReflectionFeature.class);
+    }
+
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        RuntimeReflection.registerFieldLookup(Throwable.class, "jfrTracing");
+        RuntimeReflection.registerFieldLookup(FileInputStream.class, "jfrTracing");
+        RuntimeReflection.registerFieldLookup(FileOutputStream.class, "jfrTracing");
+        RuntimeReflection.registerFieldLookup(FileChannelImpl.class, "jfrTracing");
+        RuntimeReflection.registerFieldLookup(RandomAccessFile.class, "jfrTracing");
     }
 
     @Override


### PR DESCRIPTION
(cherry picked from commit e816ad6355cf8f4afa5fcf68177bda24456cebbf)

Related issue: https://github.com/graalvm/mandrel/issues/761

Even with this backport, I'm able to intermittently reproduce the failure here: https://github.com/Karm/mandrel-integration-tests/issues/268

I think there's more the the problem in https://github.com/Karm/mandrel-integration-tests/issues/268. I'll look into this more.