### PR TITLE
[24.1] Backport: Updated JFR substitutions from [GR-54877] 

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixPlatformTimeUtils.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixPlatformTimeUtils.java
@@ -35,7 +35,7 @@ import com.oracle.svm.core.util.PlatformTimeUtils;
 public final class PosixPlatformTimeUtils extends PlatformTimeUtils {
 
     @Override
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/os/posix/os_posix.cpp#L1409-L1415")
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-23+9/src/hotspot/os/posix/os_posix.cpp#L1387-L1393")
     protected SecondsNanos javaTimeSystemUTC() {
         Time.timespec ts = StackValue.get(Time.timespec.class);
         int status = PosixUtils.clock_gettime(Time.CLOCK_REALTIME(), ts);

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsPlatformTimeUtils.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsPlatformTimeUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.windows;
+
+import static com.oracle.svm.core.windows.headers.SysinfoAPI.GetSystemTimeAsFileTime;
+
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.word.WordFactory;
+
+import com.oracle.svm.core.feature.AutomaticallyRegisteredImageSingleton;
+import com.oracle.svm.core.util.BasedOnJDKFile;
+import com.oracle.svm.core.util.PlatformTimeUtils;
+import com.oracle.svm.core.windows.headers.WinBase.FILETIME;
+
+@AutomaticallyRegisteredImageSingleton(PlatformTimeUtils.class)
+public final class WindowsPlatformTimeUtils extends PlatformTimeUtils {
+
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/os/windows/os_windows.cpp#L1123") //
+    private static final long OFFSET = 116444736000000000L;
+
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/os/windows/os_windows.cpp#L1153-L1155")
+    private static long offset() {
+        return OFFSET;
+    }
+
+    /* Returns time ticks in (10th of micro seconds) */
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/os/windows/os_windows.cpp#L1158-L1161")
+    private static long windowsToTimeTicks(FILETIME wt) {
+        long a = WordFactory.unsigned(wt.dwHighDateTime()).shiftLeft(32).or(WordFactory.unsigned(wt.dwLowDateTime())).rawValue();
+        return (a - offset());
+    }
+
+    @Override
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/os/windows/os_windows.cpp#L1198-L1205")
+    protected SecondsNanos javaTimeSystemUTC() {
+        FILETIME wt = StackValue.get(FILETIME.class);
+        GetSystemTimeAsFileTime(wt);
+        long ticks = windowsToTimeTicks(wt); // 10th of micros
+        long secs = ticks / 10000000L; // 10000 * 1000
+        long seconds = secs;
+        long nanos = (ticks - (secs * 10000000L)) * 100L;
+        return new SecondsNanos(seconds, nanos);
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsPlatformTimeUtils.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsPlatformTimeUtils.java
@@ -37,23 +37,23 @@ import com.oracle.svm.core.windows.headers.WinBase.FILETIME;
 @AutomaticallyRegisteredImageSingleton(PlatformTimeUtils.class)
 public final class WindowsPlatformTimeUtils extends PlatformTimeUtils {
 
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/os/windows/os_windows.cpp#L1123") //
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-23+9/src/hotspot/os/windows/os_windows.cpp#L1012") //
     private static final long OFFSET = 116444736000000000L;
 
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/os/windows/os_windows.cpp#L1153-L1155")
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-23+9/src/hotspot/os/windows/os_windows.cpp#L1042-L1044")
     private static long offset() {
         return OFFSET;
     }
 
     /* Returns time ticks in (10th of micro seconds) */
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/os/windows/os_windows.cpp#L1158-L1161")
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-23+9/src/hotspot/os/windows/os_windows.cpp#L1047-L1050")
     private static long windowsToTimeTicks(FILETIME wt) {
         long a = WordFactory.unsigned(wt.dwHighDateTime()).shiftLeft(32).or(WordFactory.unsigned(wt.dwLowDateTime())).rawValue();
         return (a - offset());
     }
 
     @Override
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/os/windows/os_windows.cpp#L1198-L1205")
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-23+9/src/hotspot/os/windows/os_windows.cpp#L1087-L1094")
     protected SecondsNanos javaTimeSystemUTC() {
         FILETIME wt = StackValue.get(FILETIME.class);
         GetSystemTimeAsFileTime(wt);

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/SysinfoAPI.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/SysinfoAPI.java
@@ -34,6 +34,7 @@ import org.graalvm.nativeimage.c.struct.CStruct;
 import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.word.PointerBase;
 
+import com.oracle.svm.core.windows.headers.WinBase.FILETIME;
 import com.oracle.svm.core.windows.headers.WindowsLibC.WCharPointer;
 
 // Checkstyle: stop
@@ -88,6 +89,13 @@ public class SysinfoAPI {
         @CField
         short wProcessorRevision();
     }
+
+    /**
+     * Retrieves the current system date and time. The information is in Coordinated Universal Time
+     * (UTC) format.
+     */
+    @CFunction(transition = NO_TRANSITION)
+    public static native void GetSystemTimeAsFileTime(FILETIME lpSystemTimeAsFileTime);
 
     /** Retrieves the path of the Windows directory. */
     @CFunction(transition = NO_TRANSITION)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_HiddenWait.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_HiddenWait.java
@@ -27,8 +27,8 @@
 package com.oracle.svm.core.jfr;
 
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK21OrEarlier;
+import com.oracle.svm.core.jdk.JDK23OrLater;
 
-@TargetClass(className = "jdk.jfr.internal.JVM$ChunkRotationMonitor", onlyWith = {HasJfrSupport.class, JDK21OrEarlier.class})
-public final class Target_jdk_jfr_internal_JVM_ChunkRotationMonitor {
+@TargetClass(className = "jdk.jfr.internal.HiddenWait", onlyWith = {HasJfrSupport.class, JDK23OrLater.class})
+public final class Target_jdk_jfr_internal_HiddenWait {
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -43,6 +43,7 @@ import com.oracle.svm.core.heap.PhysicalMemory.PhysicalMemorySupport;
 import com.oracle.svm.core.jdk.JDK22OrLater;
 import com.oracle.svm.core.jdk.JDK23OrLater;
 import com.oracle.svm.core.jfr.traceid.JfrTraceId;
+import com.oracle.svm.core.util.PlatformTimeUtils;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.util.ReflectionUtil;
 
@@ -196,6 +197,13 @@ public final class Target_jdk_jfr_internal_JVM {
     @TargetElement(onlyWith = JDK22OrLater.class)
     public static long getTicksFrequency() {
         return JfrTicks.getTicksFrequency();
+    }
+
+    /** See {@code JVM#nanosNow}. */
+    @Substitute
+    @TargetElement(onlyWith = JDK23OrLater.class)
+    public static long nanosNow() {
+        return PlatformTimeUtils.singleton().nanosNow();
     }
 
     /** See {@link JVM#log}. */

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -26,8 +26,6 @@
 
 package com.oracle.svm.core.jfr.events;
 
-import jdk.graal.compiler.word.Word;
-
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.jfr.HasJfrSupport;
 import com.oracle.svm.core.jfr.JfrEvent;
@@ -36,11 +34,14 @@ import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
 import com.oracle.svm.core.jfr.JfrTicks;
 import com.oracle.svm.core.jfr.SubstrateJVM;
+import com.oracle.svm.core.jfr.Target_jdk_jfr_internal_HiddenWait;
 import com.oracle.svm.core.jfr.Target_jdk_jfr_internal_JVM_ChunkRotationMonitor;
+
+import jdk.graal.compiler.word.Word;
 
 public class JavaMonitorWaitEvent {
     public static void emit(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
-        if (HasJfrSupport.get() && obj != null && !Target_jdk_jfr_internal_JVM_ChunkRotationMonitor.class.equals(obj.getClass())) {
+        if (HasJfrSupport.get() && obj != null && !Target_jdk_jfr_internal_JVM_ChunkRotationMonitor.class.equals(obj.getClass()) && !Target_jdk_jfr_internal_HiddenWait.class.equals(obj.getClass())) {
             emit0(startTicks, obj, notifier, timeout, timedOut);
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/PlatformTimeUtils.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/PlatformTimeUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.util;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import jdk.graal.compiler.api.replacements.Fold;
+
+/**
+ * Platform dependent time related utils. See also {@link TimeUtils} for platform independent utils.
+ */
+public abstract class PlatformTimeUtils {
+
+    @Fold
+    public static PlatformTimeUtils singleton() {
+        return ImageSingletons.lookup(PlatformTimeUtils.class);
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    protected PlatformTimeUtils() {
+    }
+
+    private long last = 0;
+
+    public record SecondsNanos(long seconds, long nanos) {
+    }
+
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/share/jfr/recorder/repository/jfrChunk.cpp#L38-L54")
+    public long nanosNow() {
+        // Use same clock source as Instant.now() to ensure
+        // that Recording::getStopTime() returns an Instant that
+        // is in sync.
+        var t = javaTimeSystemUTC();
+        long seconds = t.seconds;
+        long nanos = t.nanos;
+        long now = seconds * 1000000000 + nanos;
+        if (now > last) {
+            last = now;
+        } else {
+            ++last;
+        }
+        return last;
+    }
+
+    protected abstract SecondsNanos javaTimeSystemUTC();
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/PlatformTimeUtils.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/PlatformTimeUtils.java
@@ -49,7 +49,7 @@ public abstract class PlatformTimeUtils {
     public record SecondsNanos(long seconds, long nanos) {
     }
 
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-24+3/src/hotspot/share/jfr/recorder/repository/jfrChunk.cpp#L38-L54")
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-23+9/src/hotspot/share/jfr/recorder/repository/jfrChunk.cpp#L38-L54")
     public long nanosNow() {
         // Use same clock source as Instant.now() to ensure
         // that Recording::getStopTime() returns an Instant that


### PR DESCRIPTION
(cherry picked from commit fbc44e955f24be7de1c6364fc3256273c0763073)

Related issue: https://github.com/graalvm/mandrel/issues/763

[A change to OpenJDK JFR](https://bugs.openjdk.org/browse/JDK-8304732) was introduced in JDK 24 and later backported to JDK23+29. The Mandrel GHAs are using JDK23+29 so builds that include JFR will fail due to out of date substitutions. 


