### PR TITLE
[23.0] Backport: Adopt "JDK-8324646: Avoid Class.forName in SecureRandom constructor"

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
@@ -675,7 +675,15 @@ public class SecurityServicesFeature extends JNIRegistrationUtil implements Inte
     private static Function<String, Class<?>> getConstructorParameterClassAccessor(ImageClassLoader loader) {
         Map<String, /* EngineDescription */ Object> knownEngines = ReflectionUtil.readStaticField(Provider.class, "knownEngines");
         Class<?> clazz = loader.findClassOrFail("java.security.Provider$EngineDescription");
-        Field consParamClassNameField = ReflectionUtil.lookupField(clazz, "constructorParameterClassName");
+        Field consParamClassField;
+
+        try {
+            consParamClassField = ReflectionUtil.lookupField(clazz, "constructorParameterClassName");
+        } catch (ReflectionUtil.ReflectionUtilError e) {
+            consParamClassField = ReflectionUtil.lookupField(clazz, "constructorParameterClass");
+        }
+
+        final Field consParamClassFieldFinal = consParamClassField;
 
         /*
          * The returned lambda captures the value of the Provider.knownEngines map retrieved above
@@ -700,9 +708,12 @@ public class SecurityServicesFeature extends JNIRegistrationUtil implements Inte
                 if (engineDescription == null) {
                     return null;
                 }
-                String constrParamClassName = (String) consParamClassNameField.get(engineDescription);
-                if (constrParamClassName != null) {
-                    return loader.findClass(constrParamClassName).get();
+                if (consParamClassFieldFinal.getName().equals("constructorParameterClass")) {
+                    return (Class<?>) consParamClassFieldFinal.get(engineDescription);
+                }
+                String constructorParameterClassName = (String) consParamClassFieldFinal.get(engineDescription);
+                if (constructorParameterClassName != null) {
+                    return loader.findClass(constructorParameterClassName).get();
                 }
             } catch (IllegalAccessException e) {
                 VMError.shouldNotReachHere(e);


### PR DESCRIPTION
Partial backport of https://github.com/oracle/graal/pull/8387

Version agnostic adaptation of 05c1e79d360a9ab375eac31d1ce6946a311d74bc 
(cherry picked from commit 0edb942475a39226d5c68495433e3ea5049b2459)

Fix missing null check in 'Adopt "JDK-8324646: Avoid Class.forName in SecureRandom constructor"'
(cherry picked from commit dcecff795eb9c216bfea170c302b83bf9a43a035)

Fixes https://github.com/graalvm/mandrel/issues/779