### PR TITLE
[CI] Upload build stats from a single GH runner

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -500,13 +500,10 @@ jobs:
     needs:
       - native-tests
       - get-test-matrix
-    strategy:
-      matrix: ${{ fromJson(needs.get-test-matrix.outputs.tests-matrix) }}
     uses: ./.github/workflows/native-tests-stats-upload.yml
     with:
       artifacts-suffix: ${{ needs.get-test-matrix.outputs.artifacts-suffix }}
       build-stats-tag: ${{ inputs.build-stats-tag }}
-      category: ${{ matrix.category }}
     secrets:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
 

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -548,13 +548,10 @@ jobs:
     needs:
       - native-tests
       - get-test-matrix
-    strategy:
-      matrix: ${{ fromJson(needs.get-test-matrix.outputs.tests-matrix) }}
     uses: ./.github/workflows/native-tests-stats-upload.yml
     with:
       artifacts-suffix: ${{ needs.get-test-matrix.outputs.artifacts-suffix }}
       build-stats-tag: ${{ inputs.build-stats-tag }}
-      category: ${{ matrix.category }}
     secrets:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
 

--- a/.github/workflows/native-tests-stats-upload.yml
+++ b/.github/workflows/native-tests-stats-upload.yml
@@ -11,10 +11,6 @@ on:
         type: string
         description: 'The tag to use for build stats upload of native tests (e.g. 22.3.0-dev-jdk17-mytest-patch-before)'
         default: "null"
-      category:
-        type: string
-        description: 'The native integration test category to upload stats for'
-        default: "null"
     secrets:
       UPLOAD_COLLECTOR_TOKEN:
         description: 'A token used to report build statistics to a collector'
@@ -32,7 +28,7 @@ jobs:
           path: workflow-mandrel
       - uses: actions/download-artifact@v4
         with:
-          name: build-stats-${{inputs.category}}-${{ inputs.artifacts-suffix }}
+          pattern: build-stats-*-${{ inputs.artifacts-suffix }}
           path: .
       - name: Extract and import build stats
         env:
@@ -41,6 +37,12 @@ jobs:
           COLLECTOR_URL: https://collector.foci.life/api/v1/image-stats
         shell: bash
         run: |
-          tar -xf build-stats.tgz
+          ls ./build-stats-*/
           echo "Tag for stat upload is going to be: '${BUILD_STATS_TAG}'"
-          DIR=quarkus/ TAG="${BUILD_STATS_TAG}" TOKEN="${UPLOAD_TOKEN}" URL="${COLLECTOR_URL}" bash workflow-mandrel/.github/import_stats.sh
+          for directory in ./build-stats-*/; do
+            echo "Processing $directory"
+            cd "$directory"
+            tar -xvf build-stats.tgz
+            DIR=./quarkus TAG="${BUILD_STATS_TAG}" TOKEN="${UPLOAD_TOKEN}" URL="${COLLECTOR_URL}" bash workflow-mandrel/.github/import_stats.sh
+            cd -
+          done


### PR DESCRIPTION
Avoid spawning a separate github runner for each test category to upload
the build stats.