### PR TITLE
[CI] Fix import_stats script path

### DIFF
--- a/.github/workflows/native-tests-stats-upload.yml
+++ b/.github/workflows/native-tests-stats-upload.yml
@@ -43,6 +43,6 @@ jobs:
             echo "Processing $directory"
             cd "$directory"
             tar -xvf build-stats.tgz
-            DIR=./quarkus TAG="${BUILD_STATS_TAG}" TOKEN="${UPLOAD_TOKEN}" URL="${COLLECTOR_URL}" bash workflow-mandrel/.github/import_stats.sh
+            DIR=./quarkus TAG="${BUILD_STATS_TAG}" TOKEN="${UPLOAD_TOKEN}" URL="${COLLECTOR_URL}" bash ../workflow-mandrel/.github/import_stats.sh
             cd -
           done


### PR DESCRIPTION
Fix up of https://github.com/graalvm/mandrel/pull/782
