### PR TITLE
[CI] Add JDK 24 ea/ga in base wrappers

### DIFF
--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -58,6 +58,8 @@ on:
           - "22/ea"
           - "23/ga"
           - "23/ea"
+          - "24/ga"
+          - "24/ea"
           - "latest/labsjdk"
       builder-image:
         type: string

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -60,6 +60,8 @@ on:
           - "22/ea"
           - "23/ga"
           - "23/ea"
+          - "24/ga"
+          - "24/ea"
           - "latest/labsjdk"
       builder-image:
         type: string


### PR DESCRIPTION
Allows us to use the latest JDK 24 builds in the interactive workflow dispatch.