### PR TITLE
[CI] Stop testing Mandrel 24.0 for JDK 22

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,37 +30,6 @@ concurrency:
 
 jobs:
   ####
-  # Test Mandrel with JDK 22
-  ####
-#  q-main-mandrel-jdk-22:
-#    name: "Q main M latest JDK 22"
-#    uses: ./.github/workflows/base.yml
-#    with:
-#      quarkus-version: "main"
-#      version: "graal/master"
-#      jdk: "22/ea"
-#      issue-number: "580"
-#      issue-repo: "graalvm/mandrel"
-#      mandrel-it-issue-number: "208"
-#      build-stats-tag: "gha-linux-qmain-mlatest-jdk22ea"
-#    secrets:
-#      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-#      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-#  q-main-mandrel-jdk-22-win:
-#    name: "Q main M latest JDK 22 windows"
-#    uses: ./.github/workflows/base-windows.yml
-#    with:
-#      quarkus-version: "main"
-#      version: "graal/master"
-#      jdk: "22/ea"
-#      issue-number: "579"
-#      issue-repo: "graalvm/mandrel"
-#      mandrel-it-issue-number: "207"
-#      build-stats-tag: "gha-win-qmain-mlatest-jdk22ea"
-#    secrets:
-#      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-#      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  ####
   # Test Q main and GraalVM CE JDK 21 since Mandrel 21 builds are
   # currently not possible (#598)
   ####
@@ -117,39 +86,6 @@ jobs:
       mandrel-it-issue-number: "243"
       build-stats-tag: "gha-win-qmain-m24_1-jdk23ea"
       mandrel-packaging-version: "24.1"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  ####
-  # Test Q main and Mandrel 24.0 JDK 22
-  ####
-  q-main-mandrel-24_0-ea:
-    name: "Q main M 24.0 JDK 22 EA"
-    uses: ./.github/workflows/base.yml
-    with:
-      quarkus-version: "main"
-      version: "mandrel/24.0"
-      jdk: "22/ea"
-      issue-number: "644"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "240"
-      build-stats-tag: "gha-linux-qmain-m24_0-jdk22ea"
-      mandrel-packaging-version: "24.0"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-mandrel-24_0-ea-win:
-    name: "Q main M 24.0 EA windows"
-    uses: ./.github/workflows/base-windows.yml
-    with:
-      quarkus-version: "main"
-      version: "mandrel/24.0"
-      jdk: "22/ea"
-      issue-number: "645"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "241"
-      build-stats-tag: "gha-win-qmain-m24_0-jdk22ea"
-      mandrel-packaging-version: "24.0"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}


### PR DESCRIPTION
There will be no further CPU updates for 24.0 and Quarkus users should
switch to the new 24.1
