### PR TITLE
[24.1] October CPU sync

### DIFF
--- a/common.json
+++ b/common.json
@@ -45,13 +45,13 @@
     "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.2+13-jvmci-23.1-b33-sulong", "platformspecific": true },
     "graalvm-ee-21":      {"name": "graalvm-java21", "version": "23.1.3", "platformspecific": true },
 
-    "oraclejdk-latest":       {"name": "jpg-jdk",   "version": "23",      "build_id": "jdk-23+37", "platformspecific": true, "extrabundles": ["static-libs"]},
-    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01", "platformspecific": true },
-    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01-debug", "platformspecific": true },
-    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01-sulong", "platformspecific": true },
-    "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23+37-jvmci-b01", "platformspecific": true },
-    "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23+37-jvmci-b01-debug", "platformspecific": true },
-    "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23+37-jvmci-b01-sulong", "platformspecific": true }
+    "oraclejdk-latest":       {"name": "jpg-jdk",   "version": "23",      "build_id": "jdk-23.0.1+9", "platformspecific": true, "extrabundles": ["static-libs"]},
+    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23.0.1+9-jvmci-b01", "platformspecific": true },
+    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23.0.1+9-jvmci-b01-debug", "platformspecific": true },
+    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23.0.1+9-jvmci-b01-sulong", "platformspecific": true },
+    "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23.0.1+9-jvmci-b01", "platformspecific": true },
+    "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23.0.1+9-jvmci-b01-debug", "platformspecific": true },
+    "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23.0.1+9-jvmci-b01-sulong", "platformspecific": true }
   },
 
   "eclipse": {

--- a/common.json
+++ b/common.json
@@ -46,9 +46,9 @@
     "graalvm-ee-21":      {"name": "graalvm-java21", "version": "23.1.3", "platformspecific": true },
 
     "oraclejdk-latest":       {"name": "jpg-jdk",   "version": "23",      "build_id": "jdk-23.0.1+10", "platformspecific": true, "extrabundles": ["static-libs"]},
-    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9", "platformspecific": true },
-    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9-debug", "platformspecific": true },
-    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9-sulong", "platformspecific": true },
+    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01", "platformspecific": true },
+    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01-debug", "platformspecific": true },
+    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01-sulong", "platformspecific": true },
     "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9+456f3d01e0", "platformspecific": true },
     "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9+456f3d01e0-debug", "platformspecific": true },
     "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9+456f3d01e0-sulong", "platformspecific": true }

--- a/common.json
+++ b/common.json
@@ -45,13 +45,13 @@
     "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.2+13-jvmci-23.1-b33-sulong", "platformspecific": true },
     "graalvm-ee-21":      {"name": "graalvm-java21", "version": "23.1.3", "platformspecific": true },
 
-    "oraclejdk-latest":       {"name": "jpg-jdk",   "version": "23",      "build_id": "jdk-23.0.1+10", "platformspecific": true, "extrabundles": ["static-libs"]},
-    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01", "platformspecific": true },
-    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-debug", "platformspecific": true },
-    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-sulong", "platformspecific": true },
-    "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01", "platformspecific": true },
-    "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-debug", "platformspecific": true },
-    "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-sulong", "platformspecific": true }
+    "oraclejdk-latest":       {"name": "jpg-jdk",   "version": "23",      "build_id": "jdk-23.0.1+11", "platformspecific": true, "extrabundles": ["static-libs"]},
+    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23.0.1+11-jvmci-b01", "platformspecific": true },
+    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23.0.1+11-jvmci-b01-debug", "platformspecific": true },
+    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23.0.1+11-jvmci-b01-sulong", "platformspecific": true },
+    "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23.0.1+11-jvmci-b01", "platformspecific": true },
+    "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23.0.1+11-jvmci-b01-debug", "platformspecific": true },
+    "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23.0.1+11-jvmci-b01-sulong", "platformspecific": true }
   },
 
   "eclipse": {

--- a/common.json
+++ b/common.json
@@ -49,9 +49,9 @@
     "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01", "platformspecific": true },
     "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01-debug", "platformspecific": true },
     "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01-sulong", "platformspecific": true },
-    "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9+456f3d01e0", "platformspecific": true },
-    "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9+456f3d01e0-debug", "platformspecific": true },
-    "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9+456f3d01e0-sulong", "platformspecific": true }
+    "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01", "platformspecific": true },
+    "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-debug", "platformspecific": true },
+    "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-sulong", "platformspecific": true }
   },
 
   "eclipse": {

--- a/common.json
+++ b/common.json
@@ -45,13 +45,13 @@
     "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.2+13-jvmci-23.1-b33-sulong", "platformspecific": true },
     "graalvm-ee-21":      {"name": "graalvm-java21", "version": "23.1.3", "platformspecific": true },
 
-    "oraclejdk-latest":       {"name": "jpg-jdk",   "version": "23",      "build_id": "jdk-23.0.1+9", "platformspecific": true, "extrabundles": ["static-libs"]},
-    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23.0.1+9-jvmci-b01", "platformspecific": true },
-    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23.0.1+9-jvmci-b01-debug", "platformspecific": true },
-    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23.0.1+9-jvmci-b01-sulong", "platformspecific": true },
-    "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23.0.1+9-jvmci-b01", "platformspecific": true },
-    "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23.0.1+9-jvmci-b01-debug", "platformspecific": true },
-    "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23.0.1+9-jvmci-b01-sulong", "platformspecific": true }
+    "oraclejdk-latest":       {"name": "jpg-jdk",   "version": "23",      "build_id": "jdk-23.0.1+10", "platformspecific": true, "extrabundles": ["static-libs"]},
+    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9", "platformspecific": true },
+    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9-debug", "platformspecific": true },
+    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9-sulong", "platformspecific": true },
+    "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9+456f3d01e0", "platformspecific": true },
+    "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9+456f3d01e0-debug", "platformspecific": true },
+    "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-20240911195242-519b5c19b9+456f3d01e0-sulong", "platformspecific": true }
   },
 
   "eclipse": {

--- a/common.json
+++ b/common.json
@@ -4,7 +4,7 @@
     "Jsonnet files should not include this file directly but use ci/common.jsonnet instead."
   ],
 
-  "mx_version": "7.27.5",
+  "mx_version": "7.27.5.1",
 
   "COMMENT.jdks": "When adding or removing JDKs keep in sync with JDKs in ci/common.jsonnet",
   "jdks": {

--- a/common.json
+++ b/common.json
@@ -46,9 +46,9 @@
     "graalvm-ee-21":      {"name": "graalvm-java21", "version": "23.1.3", "platformspecific": true },
 
     "oraclejdk-latest":       {"name": "jpg-jdk",   "version": "23",      "build_id": "jdk-23.0.1+10", "platformspecific": true, "extrabundles": ["static-libs"]},
-    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01", "platformspecific": true },
-    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01-debug", "platformspecific": true },
-    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23+37-jvmci-b01-sulong", "platformspecific": true },
+    "labsjdk-ce-latest":      {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01", "platformspecific": true },
+    "labsjdk-ce-latestDebug": {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-debug", "platformspecific": true },
+    "labsjdk-ce-latest-llvm": {"name": "labsjdk",   "version": "ce-23.0.1+10-jvmci-b01-sulong", "platformspecific": true },
     "labsjdk-ee-latest":      {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01", "platformspecific": true },
     "labsjdk-ee-latestDebug": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-debug", "platformspecific": true },
     "labsjdk-ee-latest-llvm": {"name": "labsjdk",   "version": "ee-23.0.1+10-jvmci-b01-sulong", "platformspecific": true }

--- a/compiler/ci/ci_common/gate.jsonnet
+++ b/compiler/ci/ci_common/gate.jsonnet
@@ -487,7 +487,7 @@
   local jdk_latest_version_check_builds = [self.make_build(self.jdk_latest, "linux-amd64", "build", extra_tasks={build:: s.base("build"),}).build + galahad.exclude {
       environment+: {
         # Run the strict JVMCI version check, i.e., that JVMCIVersionCheck.JVMCI_MIN_VERSION matches the versions in common.json.
-        JVMCI_VERSION_CHECK: "strict",
+        JVMCI_VERSION_CHECK: "ignore",
       },
   }],
 

--- a/compiler/ci/ci_common/gate.jsonnet
+++ b/compiler/ci/ci_common/gate.jsonnet
@@ -487,7 +487,7 @@
   local jdk_latest_version_check_builds = [self.make_build(self.jdk_latest, "linux-amd64", "build", extra_tasks={build:: s.base("build"),}).build + galahad.exclude {
       environment+: {
         # Run the strict JVMCI version check, i.e., that JVMCIVersionCheck.JVMCI_MIN_VERSION matches the versions in common.json.
-        JVMCI_VERSION_CHECK: "ignore",
+        JVMCI_VERSION_CHECK: "strict",
       },
   }],
 

--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -4,8 +4,8 @@ suite = {
   "sourceinprojectwhitelist" : [],
 
   "groupId" : "org.graalvm.compiler",
-  "version" : "24.1.0",
-  "release" : True,
+  "version" : "24.1.1",
+  "release" : False,
   "url" : "http://www.graalvm.org/",
   "developer" : {
     "name" : "GraalVM Development",

--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -5,7 +5,7 @@ suite = {
 
   "groupId" : "org.graalvm.compiler",
   "version" : "24.1.1",
-  "release" : False,
+  "release" : True,
   "url" : "http://www.graalvm.org/",
   "developer" : {
     "name" : "GraalVM Development",

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
@@ -56,7 +56,7 @@ public final class JVMCIVersionCheck {
                     "21", Map.of(DEFAULT_VENDOR_ENTRY, createLegacyVersion(23, 1, 33)),
                     "23", Map.of(
                                     "Oracle Corporation", createLabsJDKVersion("23.0.1+10", 1),
-                                    DEFAULT_VENDOR_ENTRY, createLabsJDKVersion("23+37", 1)));
+                                    DEFAULT_VENDOR_ENTRY, createLabsJDKVersion("23.0.1+10", 1)));
     private static final int NA = 0;
     /**
      * Minimum Java release supported by Graal.

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
@@ -55,7 +55,7 @@ public final class JVMCIVersionCheck {
     private static final Map<String, Map<String, Version>> JVMCI_MIN_VERSIONS = Map.of(
                     "21", Map.of(DEFAULT_VENDOR_ENTRY, createLegacyVersion(23, 1, 33)),
                     "23", Map.of(
-                                    "Oracle Corporation", createLabsJDKVersion("23.0.1+9", 1),
+                                    "Oracle Corporation", createLabsJDKVersion("23.0.1+10", 1),
                                     DEFAULT_VENDOR_ENTRY, createLabsJDKVersion("23+37", 1)));
     private static final int NA = 0;
     /**

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
@@ -55,8 +55,8 @@ public final class JVMCIVersionCheck {
     private static final Map<String, Map<String, Version>> JVMCI_MIN_VERSIONS = Map.of(
                     "21", Map.of(DEFAULT_VENDOR_ENTRY, createLegacyVersion(23, 1, 33)),
                     "23", Map.of(
-                                    "Oracle Corporation", createLabsJDKVersion("23+37", 1),
-                                    DEFAULT_VENDOR_ENTRY, createLabsJDKVersion("23+37", 1)));
+                                    "Oracle Corporation", createLabsJDKVersion("23.0.1+9", 1),
+                                    DEFAULT_VENDOR_ENTRY, createLabsJDKVersion("23.0.1+9", 1)));
     private static final int NA = 0;
     /**
      * Minimum Java release supported by Graal.

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
@@ -55,8 +55,8 @@ public final class JVMCIVersionCheck {
     private static final Map<String, Map<String, Version>> JVMCI_MIN_VERSIONS = Map.of(
                     "21", Map.of(DEFAULT_VENDOR_ENTRY, createLegacyVersion(23, 1, 33)),
                     "23", Map.of(
-                                    "Oracle Corporation", createLabsJDKVersion("23.0.1+10", 1),
-                                    DEFAULT_VENDOR_ENTRY, createLabsJDKVersion("23.0.1+10", 1)));
+                                    "Oracle Corporation", createLabsJDKVersion("23.0.1+11", 1),
+                                    DEFAULT_VENDOR_ENTRY, createLabsJDKVersion("23.0.1+11", 1)));
     private static final int NA = 0;
     /**
      * Minimum Java release supported by Graal.

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/JVMCIVersionCheck.java
@@ -56,7 +56,7 @@ public final class JVMCIVersionCheck {
                     "21", Map.of(DEFAULT_VENDOR_ENTRY, createLegacyVersion(23, 1, 33)),
                     "23", Map.of(
                                     "Oracle Corporation", createLabsJDKVersion("23.0.1+9", 1),
-                                    DEFAULT_VENDOR_ENTRY, createLabsJDKVersion("23.0.1+9", 1)));
+                                    DEFAULT_VENDOR_ENTRY, createLabsJDKVersion("23+37", 1)));
     private static final int NA = 0;
     /**
      * Minimum Java release supported by Graal.

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/meta/HotSpotGraphBuilderPlugins.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/meta/HotSpotGraphBuilderPlugins.java
@@ -212,7 +212,7 @@ public class HotSpotGraphBuilderPlugins {
                     OptionValues options,
                     TargetDescription target,
                     BarrierSet barrierSet) {
-        InvocationPlugins invocationPlugins = new HotSpotInvocationPlugins(graalRuntime, config, compilerConfiguration, options);
+        InvocationPlugins invocationPlugins = new HotSpotInvocationPlugins(graalRuntime, config, compilerConfiguration, options, target);
 
         Plugins plugins = new Plugins(invocationPlugins);
         plugins.appendNodePlugin(new HotSpotExceptionDispatchPlugin(config, wordTypes.getWordKind()));

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/meta/HotSpotInvocationPlugins.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/meta/HotSpotInvocationPlugins.java
@@ -24,8 +24,8 @@
  */
 package jdk.graal.compiler.hotspot.meta;
 
-import static jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime;
 import static jdk.graal.compiler.hotspot.HotSpotGraalServices.isIntrinsicAvailable;
+import static jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -37,6 +37,7 @@ import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.EconomicSet;
 import org.graalvm.collections.MapCursor;
 import org.graalvm.collections.Pair;
+
 import jdk.graal.compiler.debug.GraalError;
 import jdk.graal.compiler.debug.TTY;
 import jdk.graal.compiler.graph.Node;
@@ -49,7 +50,7 @@ import jdk.graal.compiler.nodes.graphbuilderconf.InvocationPlugins;
 import jdk.graal.compiler.options.OptionValues;
 import jdk.graal.compiler.phases.tiers.CompilerConfiguration;
 import jdk.graal.compiler.replacements.nodes.MacroInvokable;
-
+import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.hotspot.VMIntrinsicMethod;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
@@ -73,11 +74,11 @@ final class HotSpotInvocationPlugins extends InvocationPlugins {
 
     private final EconomicMap<String, EconomicSet<MethodKey>> disabledIntrinsics = EconomicMap.create();
 
-    HotSpotInvocationPlugins(HotSpotGraalRuntimeProvider graalRuntime, GraalHotSpotVMConfig config, CompilerConfiguration compilerConfiguration, OptionValues options) {
+    HotSpotInvocationPlugins(HotSpotGraalRuntimeProvider graalRuntime, GraalHotSpotVMConfig config, CompilerConfiguration compilerConfiguration, OptionValues options, TargetDescription target) {
         this.graalRuntime = graalRuntime;
         this.config = config;
         if (Options.WarnMissingIntrinsic.getValue(options)) {
-            this.unimplementedIntrinsics = new UnimplementedGraalIntrinsics(graalRuntime.getTarget().arch);
+            this.unimplementedIntrinsics = new UnimplementedGraalIntrinsics(target.arch);
         } else {
             this.unimplementedIntrinsics = null;
         }

--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -24,8 +24,8 @@
 suite = {
     "mxversion": "7.27.1",
     "name": "espresso",
-    "version" : "24.1.0",
-    "release" : True,
+    "version" : "24.1.1",
+    "release" : False,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer" : {

--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -25,7 +25,7 @@ suite = {
     "mxversion": "7.27.1",
     "name": "espresso",
     "version" : "24.1.1",
-    "release" : False,
+    "release" : True,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer" : {

--- a/regex/mx.regex/suite.py
+++ b/regex/mx.regex/suite.py
@@ -43,8 +43,8 @@ suite = {
 
   "name" : "regex",
 
-  "version" : "24.1.0",
-  "release" : True,
+  "version" : "24.1.1",
+  "release" : False,
   "groupId" : "org.graalvm.regex",
   "url" : "http://www.graalvm.org/",
   "developer" : {

--- a/regex/mx.regex/suite.py
+++ b/regex/mx.regex/suite.py
@@ -44,7 +44,7 @@ suite = {
   "name" : "regex",
 
   "version" : "24.1.1",
-  "release" : False,
+  "release" : True,
   "groupId" : "org.graalvm.regex",
   "url" : "http://www.graalvm.org/",
   "developer" : {

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -41,8 +41,8 @@
 suite = {
   "mxversion": "7.27.0",
   "name" : "sdk",
-  "version" : "24.1.0",
-  "release" : True,
+  "version" : "24.1.1",
+  "release" : False,
   "sourceinprojectwhitelist" : [],
   "url" : "https://github.com/oracle/graal",
   "groupId" : "org.graalvm.sdk",

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "7.27.0",
   "name" : "sdk",
   "version" : "24.1.1",
-  "release" : False,
+  "release" : True,
   "sourceinprojectwhitelist" : [],
   "url" : "https://github.com/oracle/graal",
   "groupId" : "org.graalvm.sdk",

--- a/substratevm/CHANGELOG.md
+++ b/substratevm/CHANGELOG.md
@@ -28,6 +28,8 @@ This changelog summarizes major changes to GraalVM Native Image.
 * (GR-52844) Add `-Os`, a new optimization mode to configure the optimizer in a way to get the smallest code size.
 * (GR-49770) Add support for glob patterns in resource-config files in addition to regexp. The Tracing agent now prints entries in the glob format.
 * (GR-46386) Throw missing registration errors for JNI queries when the query was not included in the reachability metadata.
+* (GR-54241) Streamline Native Image reachability metadata into a single `reachability-metadata.json`. The formerly-used individual metadata files (`reflection-config.json`, `resource-config.json`, etc.) are now deprecated, but will still be accepted.
+  Native Image will only output `reachability-metadata.json` files, and those will be readable on the previous LTS versions of GraalVM. See the [documentation](../docs/reference-manual/native-image/ReachabilityMetadata.md).
 
 ## GraalVM for JDK 22 (Internal Version 24.0.0)
 * (GR-48304) Red Hat added support for the JFR event ThreadAllocationStatistics.

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1139,7 +1139,9 @@ native_image = mx_sdk_vm.GraalVmJreComponent(
             build_args=driver_build_args + [
                 '--features=com.oracle.svm.agent.NativeImageAgent$RegistrationFeature',
                 '--enable-url-protocols=jar',
-            ],
+            ] + svm_experimental_options([
+                '-H:+TreatAllTypeReachableConditionsAsTypeReached',
+            ]),
             headers=False,
             home_finder=False,
         ),
@@ -1448,6 +1450,7 @@ mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
             main_class='com.oracle.svm.configure.ConfigurationTool',
             build_args=svm_experimental_options([
                 '-H:-ParseRuntimeOptions',
+                '-H:+TreatAllTypeReachableConditionsAsTypeReached',
             ]),
             extra_jvm_args=_native_image_configure_extra_jvm_args(),
             home_finder=False,

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -2,8 +2,8 @@
 suite = {
     "mxversion": "7.27.1",
     "name": "substratevm",
-    "version" : "24.1.0",
-    "release" : True,
+    "version" : "24.1.1",
+    "release" : False,
     "url" : "https://github.com/oracle/graal/tree/master/substratevm",
 
     "groupId" : "org.graalvm.nativeimage",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -3,7 +3,7 @@ suite = {
     "mxversion": "7.27.1",
     "name": "substratevm",
     "version" : "24.1.1",
-    "release" : False,
+    "release" : True,
     "url" : "https://github.com/oracle/graal/tree/master/substratevm",
 
     "groupId" : "org.graalvm.nativeimage",

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
@@ -211,6 +211,12 @@ public class ObjectScanner {
 
         } catch (UnsupportedFeatureException | AnalysisError.TypeNotFoundError ex) {
             unsupportedFeatureDuringFieldScan(bb, field, receiver, ex, reason);
+        } catch (AnalysisError analysisError) {
+            if (analysisError.getCause() instanceof UnsupportedFeatureException ex) {
+                unsupportedFeatureDuringFieldScan(bb, field, receiver, ex, reason);
+            } else {
+                throw analysisError;
+            }
         }
     }
 

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationConditionPrintable.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationConditionPrintable.java
@@ -35,10 +35,14 @@ import org.graalvm.nativeimage.impl.UnresolvedConfigurationCondition;
 import jdk.graal.compiler.util.json.JsonWriter;
 
 final class ConfigurationConditionPrintable {
-    static void printConditionAttribute(UnresolvedConfigurationCondition condition, JsonWriter writer) throws IOException {
+    static void printConditionAttribute(UnresolvedConfigurationCondition condition, JsonWriter writer, boolean combinedFile) throws IOException {
         if (!condition.isAlwaysTrue()) {
             writer.quote(CONDITIONAL_KEY).appendFieldSeparator().appendObjectStart();
-            writer.quote(condition.isRuntimeChecked() ? TYPE_REACHED_KEY : TYPE_REACHABLE_KEY).appendFieldSeparator().quote(condition.getTypeName());
+            /*
+             * typeReachable conditions are emitted as typeReached in reachability-metadata.json.
+             * typeReached conditions are emitted as typeReachable in resource-config.json
+             */
+            writer.quote(combinedFile ? TYPE_REACHED_KEY : TYPE_REACHABLE_KEY).appendFieldSeparator().quote(condition.getTypeName());
             writer.appendObjectEnd().appendSeparator();
         }
     }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationType.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationType.java
@@ -460,7 +460,7 @@ public class ConfigurationType implements JsonPrintable {
     @Override
     public synchronized void printJson(JsonWriter writer) throws IOException {
         writer.appendObjectStart();
-        ConfigurationConditionPrintable.printConditionAttribute(condition, writer);
+        ConfigurationConditionPrintable.printConditionAttribute(condition, writer, true);
         writer.quote("type").appendFieldSeparator();
         typeDescriptor.printJson(writer);
 

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ParserConfigurationAdapter.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ParserConfigurationAdapter.java
@@ -103,73 +103,73 @@ public class ParserConfigurationAdapter implements ReflectionConfigurationParser
 
     @Override
     public void registerPublicClasses(UnresolvedConfigurationCondition condition, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllPublicClasses();
     }
 
     @Override
     public void registerDeclaredClasses(UnresolvedConfigurationCondition condition, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllDeclaredClasses();
     }
 
     @Override
     public void registerRecordComponents(UnresolvedConfigurationCondition condition, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllRecordComponents();
     }
 
     @Override
     public void registerPermittedSubclasses(UnresolvedConfigurationCondition condition, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllPermittedSubclasses();
     }
 
     @Override
     public void registerNestMembers(UnresolvedConfigurationCondition condition, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllNestMembers();
     }
 
     @Override
     public void registerSigners(UnresolvedConfigurationCondition condition, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllSigners();
     }
 
     @Override
     public void registerPublicFields(UnresolvedConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllPublicFields(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
     public void registerDeclaredFields(UnresolvedConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllDeclaredFields(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
     public void registerPublicMethods(UnresolvedConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllPublicMethods(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
     public void registerDeclaredMethods(UnresolvedConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllDeclaredMethods(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
     public void registerPublicConstructors(UnresolvedConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllPublicConstructors(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
     public void registerDeclaredConstructors(UnresolvedConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
-        VMError.guarantee(condition.equals(type.getCondition()), "condition is already a part of the type");
+        VMError.guarantee(condition.isAlwaysTrue() || condition.equals(type.getCondition()), "condition is already a part of the type");
         type.setAllDeclaredConstructors(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ProxyConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ProxyConfiguration.java
@@ -116,7 +116,7 @@ public final class ProxyConfiguration extends ConfigurationBase<ProxyConfigurati
         for (ConditionalElement<List<String>> list : lists) {
             writer.append(prefix).newline();
             writer.append('{').indent().newline();
-            ConfigurationConditionPrintable.printConditionAttribute(list.condition(), writer);
+            ConfigurationConditionPrintable.printConditionAttribute(list.condition(), writer, false);
             writer.quote("interfaces").append(":").append('[');
             String typePrefix = "";
             for (String type : list.element()) {

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ProxyConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ProxyConfiguration.java
@@ -110,25 +110,30 @@ public final class ProxyConfiguration extends ConfigurationBase<ProxyConfigurati
     public static void printProxyInterfaces(JsonWriter writer, List<ConditionalElement<List<String>>> lists) throws IOException {
         lists.sort(ConditionalElement.comparator(ProxyConfiguration::compareList));
 
-        writer.append('[');
-        writer.indent();
-        String prefix = "";
+        writer.appendArrayStart();
+        boolean firstProxy = true;
         for (ConditionalElement<List<String>> list : lists) {
-            writer.append(prefix).newline();
-            writer.append('{').indent().newline();
-            ConfigurationConditionPrintable.printConditionAttribute(list.condition(), writer, false);
-            writer.quote("interfaces").append(":").append('[');
-            String typePrefix = "";
-            for (String type : list.element()) {
-                writer.append(typePrefix).quote(type);
-                typePrefix = ",";
+            if (firstProxy) {
+                firstProxy = false;
+            } else {
+                writer.appendSeparator();
             }
-            writer.append(']').unindent().newline();
-            writer.append('}');
-            prefix = ",";
+            writer.appendObjectStart();
+            ConfigurationConditionPrintable.printConditionAttribute(list.condition(), writer, false);
+            writer.quote("interfaces").appendFieldSeparator().appendArrayStart();
+            boolean firstType = true;
+            for (String type : list.element()) {
+                if (firstType) {
+                    firstType = false;
+                } else {
+                    writer.appendSeparator();
+                }
+                writer.quote(type);
+            }
+            writer.appendArrayEnd();
+            writer.appendObjectEnd();
         }
-        writer.unindent().newline();
-        writer.append(']');
+        writer.appendArrayEnd();
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ResourceConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ResourceConfiguration.java
@@ -337,7 +337,7 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
     public void printJson(JsonWriter writer) throws IOException {
         printGlobsJson(writer, true);
         writer.appendSeparator().newline();
-        printBundlesJson(writer);
+        printBundlesJson(writer, true);
     }
 
     @Override
@@ -345,7 +345,7 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
         writer.appendObjectStart().indent().newline();
         printResourcesJson(writer);
         writer.appendSeparator().newline();
-        printBundlesJson(writer);
+        printBundlesJson(writer, false);
         writer.appendSeparator().newline();
         printGlobsJson(writer, false);
         writer.unindent().newline().appendObjectEnd();
@@ -363,14 +363,14 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
         writer.appendObjectEnd();
     }
 
-    void printBundlesJson(JsonWriter writer) throws IOException {
+    void printBundlesJson(JsonWriter writer, boolean combinedFile) throws IOException {
         writer.quote(BUNDLES_KEY).appendFieldSeparator();
-        JsonPrinter.printCollection(writer, bundles.keySet(), ConditionalElement.comparator(), (p, w) -> printResourceBundle(bundles.get(p), w));
+        JsonPrinter.printCollection(writer, bundles.keySet(), ConditionalElement.comparator(), (p, w) -> printResourceBundle(bundles.get(p), w, combinedFile));
     }
 
-    void printGlobsJson(JsonWriter writer, boolean useResourcesFieldName) throws IOException {
-        writer.quote(useResourcesFieldName ? RESOURCES_KEY : GLOBS_KEY).appendFieldSeparator();
-        JsonPrinter.printCollection(writer, addedGlobs, ConditionalElement.comparator(ResourceEntry.comparator()), ResourceConfiguration::conditionalGlobElementJson);
+    void printGlobsJson(JsonWriter writer, boolean combinedFile) throws IOException {
+        writer.quote(combinedFile ? RESOURCES_KEY : GLOBS_KEY).appendFieldSeparator();
+        JsonPrinter.printCollection(writer, addedGlobs, ConditionalElement.comparator(ResourceEntry.comparator()), (p, w) -> conditionalGlobElementJson(p, w, combinedFile));
     }
 
     @Override
@@ -378,9 +378,9 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
         return ResourceConfigurationParser.create(strictMetadata, ConfigurationConditionResolver.identityResolver(), new ResourceConfiguration.ParserAdapter(this), true);
     }
 
-    private static void printResourceBundle(BundleConfiguration config, JsonWriter writer) throws IOException {
+    private static void printResourceBundle(BundleConfiguration config, JsonWriter writer, boolean combinedFile) throws IOException {
         writer.appendObjectStart();
-        ConfigurationConditionPrintable.printConditionAttribute(config.condition, writer);
+        ConfigurationConditionPrintable.printConditionAttribute(config.condition, writer, combinedFile);
         writer.quote("name").appendFieldSeparator().quote(config.baseName);
         if (!config.locales.isEmpty()) {
             writer.appendSeparator().quote("locales").appendFieldSeparator();
@@ -411,11 +411,11 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
         return true;
     }
 
-    private static void conditionalGlobElementJson(ConditionalElement<ResourceEntry> p, JsonWriter w) throws IOException {
+    private static void conditionalGlobElementJson(ConditionalElement<ResourceEntry> p, JsonWriter w, boolean combinedFile) throws IOException {
         String pattern = p.element().pattern();
         String module = p.element().module();
         w.appendObjectStart();
-        ConfigurationConditionPrintable.printConditionAttribute(p.condition(), w);
+        ConfigurationConditionPrintable.printConditionAttribute(p.condition(), w, combinedFile);
         if (module != null) {
             w.quote("module").appendFieldSeparator().quote(module).appendSeparator();
         }
@@ -425,7 +425,7 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
 
     private static void conditionalRegexElementJson(ConditionalElement<String> p, JsonWriter w) throws IOException {
         w.appendObjectStart();
-        ConfigurationConditionPrintable.printConditionAttribute(p.condition(), w);
+        ConfigurationConditionPrintable.printConditionAttribute(p.condition(), w, false);
         w.quote("pattern").appendFieldSeparator().quote(p.element());
         w.appendObjectEnd();
     }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ResourceConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ResourceConfiguration.java
@@ -336,19 +336,19 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
     @Override
     public void printJson(JsonWriter writer) throws IOException {
         printGlobsJson(writer, true);
-        writer.appendSeparator().newline();
+        writer.appendSeparator();
         printBundlesJson(writer, true);
     }
 
     @Override
     public void printLegacyJson(JsonWriter writer) throws IOException {
-        writer.appendObjectStart().indent().newline();
+        writer.appendObjectStart();
         printResourcesJson(writer);
-        writer.appendSeparator().newline();
+        writer.appendSeparator();
         printBundlesJson(writer, false);
-        writer.appendSeparator().newline();
+        writer.appendSeparator();
         printGlobsJson(writer, false);
-        writer.unindent().newline().appendObjectEnd();
+        writer.appendObjectEnd();
     }
 
     void printResourcesJson(JsonWriter writer) throws IOException {

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfigurationLambdaCapturingType.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfigurationLambdaCapturingType.java
@@ -57,7 +57,7 @@ public class SerializationConfigurationLambdaCapturingType implements JsonPrinta
     @Override
     public void printJson(JsonWriter writer) throws IOException {
         writer.append('{').indent().newline();
-        ConfigurationConditionPrintable.printConditionAttribute(condition, writer);
+        ConfigurationConditionPrintable.printConditionAttribute(condition, writer, false);
 
         writer.quote(SerializationConfigurationParser.NAME_KEY).append(":").quote(qualifiedJavaName);
         writer.unindent().newline().append('}');

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfigurationType.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfigurationType.java
@@ -35,6 +35,9 @@ import com.oracle.svm.core.configure.SerializationConfigurationParser;
 import jdk.graal.compiler.util.json.JsonPrintable;
 import jdk.graal.compiler.util.json.JsonWriter;
 
+import static com.oracle.svm.core.configure.ConfigurationParser.NAME_KEY;
+import static com.oracle.svm.core.configure.ConfigurationParser.TYPE_KEY;
+
 public class SerializationConfigurationType implements JsonPrintable, Comparable<SerializationConfigurationType> {
     private final UnresolvedConfigurationCondition condition;
     private final String qualifiedJavaName;
@@ -66,17 +69,17 @@ public class SerializationConfigurationType implements JsonPrintable, Comparable
 
     @Override
     public void printJson(JsonWriter writer) throws IOException {
-        printJson(writer, SerializationConfigurationParser.TYPE_KEY);
+        printJson(writer, true);
     }
 
     public void printLegacyJson(JsonWriter writer) throws IOException {
-        printJson(writer, SerializationConfigurationParser.NAME_KEY);
+        printJson(writer, false);
     }
 
-    private void printJson(JsonWriter writer, String key) throws IOException {
+    private void printJson(JsonWriter writer, boolean combinedFile) throws IOException {
         writer.appendObjectStart();
-        ConfigurationConditionPrintable.printConditionAttribute(condition, writer);
-        writer.quote(key).appendFieldSeparator().quote(qualifiedJavaName);
+        ConfigurationConditionPrintable.printConditionAttribute(condition, writer, combinedFile);
+        writer.quote(combinedFile ? TYPE_KEY : NAME_KEY).appendFieldSeparator().quote(qualifiedJavaName);
         if (qualifiedCustomTargetConstructorJavaName != null) {
             writer.appendSeparator();
             writer.quote(SerializationConfigurationParser.CUSTOM_TARGET_CONSTRUCTOR_CLASS_KEY).appendFieldSeparator()

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
@@ -1327,8 +1327,8 @@ public class SubstrateAArch64Backend extends SubstrateBackend implements LIRGene
             // A branch estimation was wrong, now retry with conservative label ranges, this
             // should always work
             resetForEmittingCode(crb);
-            crb.setConservativeLabelRanges();
             crb.resetForEmittingCode();
+            crb.setConservativeLabelRanges();
             crb.emitLIR();
             finalizeCode(crb);
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ResourceMetadataParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ResourceMetadataParser.java
@@ -26,6 +26,9 @@ package com.oracle.svm.core.configure;
 
 import java.net.URI;
 
+import org.graalvm.collections.EconomicMap;
+import org.graalvm.nativeimage.impl.UnresolvedConfigurationCondition;
+
 final class ResourceMetadataParser<C> extends ResourceConfigurationParser<C> {
     ResourceMetadataParser(ConfigurationConditionResolver<C> conditionResolver, ResourcesRegistry<C> registry, boolean strictConfiguration) {
         super(conditionResolver, registry, strictConfiguration);
@@ -41,5 +44,10 @@ final class ResourceMetadataParser<C> extends ResourceConfigurationParser<C> {
         if (bundlesJson != null) {
             parseBundlesObject(bundlesJson);
         }
+    }
+
+    @Override
+    protected UnresolvedConfigurationCondition parseCondition(EconomicMap<String, Object> condition) {
+        return parseCondition(condition, true);
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SecuritySubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SecuritySubstitutions.java
@@ -199,6 +199,18 @@ final class Target_java_security_Provider {
     private static Target_java_security_Provider_ServiceKey previousKey;
 }
 
+@TargetClass(value = java.security.Provider.class, innerClass = "Service")
+final class Target_java_security_Provider_Service {
+
+    /**
+     * The field is lazily initialized on first access. We already have the necessary reflection
+     * configuration for the reflective lookup at image run time.
+     */
+    @Alias //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    private Object constructorCache;
+}
+
 @Platforms(Platform.HOSTED_ONLY.class)
 class ServiceKeyComputer implements FieldValueTransformer {
     @Override

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -91,7 +91,8 @@ public class BundleLauncher {
     }
 
     public static void main(String[] args) {
-        bundleFilePath = Paths.get(BundleLauncher.class.getProtectionDomain().getCodeSource().getLocation().getPath());
+        String bundleLauncherPath = BundleLauncher.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        bundleFilePath = Paths.get(isWindows() ? bundleLauncherPath.substring(1) : bundleLauncherPath);
         bundleName = bundleFilePath.getFileName().toString().replace(BUNDLE_FILE_EXTENSION, "");
         agentOutputDir = bundleFilePath.getParent().resolve(Paths.get(bundleName + ".output", "launcher"));
         unpackBundle();
@@ -342,6 +343,10 @@ public class BundleLauncher {
         return getJavaHomeExecutable(binJava);
     }
 
+    private static boolean isWindows() {
+        return System.getProperty("os.name").contains("Windows");
+    }
+
     private static Path getJavaHomeExecutable(Path executable) {
         String javaHome = System.getenv("JAVA_HOME");
         if (javaHome == null) {
@@ -358,7 +363,7 @@ public class BundleLauncher {
     }
 
     private static Path getNativeImageExecutable() {
-        Path binNativeImage = Paths.get("bin", System.getProperty("os.name").contains("Windows") ? "native-image.exe" : "native-image");
+        Path binNativeImage = Paths.get("bin", isWindows() ? "native-image.exe" : "native-image");
         if (Files.isExecutable(buildTimeJavaHome.resolve(binNativeImage))) {
             return buildTimeJavaHome.resolve(binNativeImage);
         }

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -696,9 +696,10 @@ final class BundleSupport {
             nativeImage.deleteAllFiles(metaInfDir);
         }
 
-        Path bundleLauncherFile = Paths.get("/").resolve(BundleLauncher.class.getName().replace(".", "/") + ".class");
-        try (FileSystem fs = FileSystems.newFileSystem(BundleSupport.class.getResource(bundleLauncherFile.toString()).toURI(), new HashMap<>());
-                        Stream<Path> walk = Files.walk(fs.getPath(bundleLauncherFile.getParent().toString()))) {
+        String bundleLauncherClassResource = "/" + BundleLauncher.class.getName().replace(".", "/") + ".class";
+        String bundleLauncherPackageResource = "/" + BundleLauncher.class.getPackageName().replace(".", "/");
+        try (FileSystem fs = FileSystems.newFileSystem(BundleSupport.class.getResource(bundleLauncherClassResource).toURI(), new HashMap<>());
+                        Stream<Path> walk = Files.walk(fs.getPath(bundleLauncherPackageResource))) {
             walk.filter(Predicate.not(Files::isDirectory))
                             .map(Path::toString)
                             .forEach(sourcePath -> {
@@ -714,7 +715,7 @@ final class BundleSupport {
                                 }
                             });
         } catch (Exception e) {
-            throw NativeImage.showError("Failed to read bundle launcher resources '" + bundleLauncherFile.getParent() + "'", e);
+            throw NativeImage.showError("Failed to read bundle launcher resources '" + bundleLauncherPackageResource + "'", e);
         }
 
         Path pathCanonicalizationsFile = stageDir.resolve("path_canonicalizations.json");

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
@@ -86,7 +86,6 @@ import com.oracle.svm.core.configure.RuntimeConditionSet;
 import com.oracle.svm.core.hub.ClassForNameSupport;
 import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.reflect.SubstrateAccessor;
-import com.oracle.svm.core.util.UserError;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.ConditionalConfigurationRegistry;
 import com.oracle.svm.hosted.FeatureImpl.BeforeAnalysisAccessImpl;
@@ -178,7 +177,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
     private void runConditionalInAnalysisTask(ConfigurationCondition condition, Consumer<ConfigurationCondition> task) {
         if (sealed) {
-            throw UserError.abort("Too late to add classes, methods, and fields for reflective access. Registration must happen in a Feature before the analysis has finished.");
+            throw new UnsupportedFeatureException("Too late to add classes, methods, and fields for reflective access. Registration must happen in a Feature before the analysis has finished.");
         }
 
         if (universe != null) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
@@ -1167,11 +1167,15 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
     @Override
     public void registerHeapDynamicHub(Object object, ScanReason reason) {
-        assert !sealed;
         DynamicHub hub = (DynamicHub) object;
         Class<?> javaClass = hub.getHostedJavaClass();
-        if (heapDynamicHubs.add(hub) && !SubstitutionReflectivityFilter.shouldExclude(javaClass, metaAccess, universe)) {
-            registerTypesForClass(metaAccess.lookupJavaType(javaClass), javaClass);
+        if (heapDynamicHubs.add(hub)) {
+            if (sealed) {
+                throw new UnsupportedFeatureException("Registering new class for reflection when the image heap is already sealed: " + javaClass);
+            }
+            if (!SubstitutionReflectivityFilter.shouldExclude(javaClass, metaAccess, universe)) {
+                registerTypesForClass(metaAccess.lookupJavaType(javaClass), javaClass);
+            }
         }
     }
 
@@ -1183,24 +1187,32 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
     @Override
     public void registerHeapReflectionField(Field reflectField, ScanReason reason) {
-        assert !sealed;
         AnalysisField analysisField = metaAccess.lookupJavaField(reflectField);
-        if (heapFields.put(analysisField, reflectField) == null && !SubstitutionReflectivityFilter.shouldExclude(reflectField, metaAccess, universe)) {
-            registerTypesForField(analysisField, reflectField, false);
-            if (analysisField.getDeclaringClass().isAnnotation()) {
-                processAnnotationField(ConfigurationCondition.alwaysTrue(), reflectField);
+        if (heapFields.put(analysisField, reflectField) == null) {
+            if (sealed) {
+                throw new UnsupportedFeatureException("Registering new field for reflection when the image heap is already sealed: " + reflectField);
+            }
+            if (!SubstitutionReflectivityFilter.shouldExclude(reflectField, metaAccess, universe)) {
+                registerTypesForField(analysisField, reflectField, false);
+                if (analysisField.getDeclaringClass().isAnnotation()) {
+                    processAnnotationField(ConfigurationCondition.alwaysTrue(), reflectField);
+                }
             }
         }
     }
 
     @Override
     public void registerHeapReflectionExecutable(Executable reflectExecutable, ScanReason reason) {
-        assert !sealed;
         AnalysisMethod analysisMethod = metaAccess.lookupJavaMethod(reflectExecutable);
-        if (heapMethods.put(analysisMethod, reflectExecutable) == null && !SubstitutionReflectivityFilter.shouldExclude(reflectExecutable, metaAccess, universe)) {
-            registerTypesForMethod(analysisMethod, reflectExecutable);
-            if (reflectExecutable instanceof Method && reflectExecutable.getDeclaringClass().isAnnotation()) {
-                processAnnotationMethod(false, (Method) reflectExecutable);
+        if (heapMethods.put(analysisMethod, reflectExecutable) == null) {
+            if (sealed) {
+                throw new UnsupportedFeatureException("Registering new method for reflection when the image heap is already sealed: " + reflectExecutable);
+            }
+            if (!SubstitutionReflectivityFilter.shouldExclude(reflectExecutable, metaAccess, universe)) {
+                registerTypesForMethod(analysisMethod, reflectExecutable);
+                if (reflectExecutable instanceof Method && reflectExecutable.getDeclaringClass().isAnnotation()) {
+                    processAnnotationMethod(false, (Method) reflectExecutable);
+                }
             }
         }
     }

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleJFRFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleJFRFeature.java
@@ -66,6 +66,6 @@ public class TruffleJFRFeature implements InternalFeature {
     }
 
     private static boolean isEnabled() {
-        return ImageSingletons.contains(TruffleFeature.class) && ImageSingletons.contains(JfrFeature.class);
+        return ImageSingletons.contains(TruffleFeature.class) && JfrFeature.isInConfiguration(true);
     }
 }

--- a/tools/mx.tools/suite.py
+++ b/tools/mx.tools/suite.py
@@ -27,7 +27,7 @@ suite = {
 
     "groupId" : "org.graalvm.tools",
     "version" : "24.1.1",
-    "release" : False,
+    "release" : True,
     "url" : "http://openjdk.java.net/projects/graal",
     "developer" : {
         "name" : "GraalVM Development",

--- a/tools/mx.tools/suite.py
+++ b/tools/mx.tools/suite.py
@@ -26,8 +26,8 @@ suite = {
     "defaultLicense" : "GPLv2-CPE",
 
     "groupId" : "org.graalvm.tools",
-    "version" : "24.1.0",
-    "release" : True,
+    "version" : "24.1.1",
+    "release" : False,
     "url" : "http://openjdk.java.net/projects/graal",
     "developer" : {
         "name" : "GraalVM Development",

--- a/truffle/external_repos/simplelanguage/pom.xml
+++ b/truffle/external_repos/simplelanguage/pom.xml
@@ -47,7 +47,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <m2e.apt.activation>jdt_apt</m2e.apt.activation>
-    <graalvm.version>24.1.0-dev</graalvm.version>
+    <graalvm.version>24.1.1-dev</graalvm.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <launcherClass>org.graalvm.sl.launcher/com.oracle.truffle.sl.launcher.SLMain</launcherClass>

--- a/truffle/external_repos/simpletool/pom.xml
+++ b/truffle/external_repos/simpletool/pom.xml
@@ -48,7 +48,7 @@
     <version>${graalvm.version}</version>
     <name>simpletool</name>
     <properties>
-        <graalvm.version>24.1.0-dev</graalvm.version>
+        <graalvm.version>24.1.1-dev</graalvm.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -41,8 +41,8 @@
 suite = {
   "mxversion": "7.27.1",
   "name" : "truffle",
-  "version" : "24.1.0",
-  "release" : True,
+  "version" : "24.1.1",
+  "release" : False,
   "groupId" : "org.graalvm.truffle",
   "sourceinprojectwhitelist" : [],
   "url" : "http://openjdk.java.net/projects/graal",

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "7.27.1",
   "name" : "truffle",
   "version" : "24.1.1",
-  "release" : False,
+  "release" : True,
   "groupId" : "org.graalvm.truffle",
   "sourceinprojectwhitelist" : [],
   "url" : "http://openjdk.java.net/projects/graal",

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/debug/TraceCompilationListener.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/debug/TraceCompilationListener.java
@@ -85,7 +85,7 @@ public final class TraceCompilationListener extends AbstractGraalTruffleRuntimeL
     private static final String QUEUED_FORMAT   = "opt queued " + TARGET_FORMAT + "|" + TIER_FORMAT + "|" + COUNT_THRESHOLD_FORMAT + "|" + QUEUE_FORMAT + "|UTC %s|Src %s";
     private static final String UNQUEUED_FORMAT = "opt unque. " + TARGET_FORMAT + "|" + TIER_FORMAT + "|" + COUNT_THRESHOLD_FORMAT + "|" + QUEUE_FORMAT + "|UTC %s|Src %s|Reason %s";
     private static final String START_FORMAT    = "opt start  " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Priority %9d|Rate %.6f|"         + QUEUE_FORMAT + "|UTC %s|Src %s";
-    private static final String DONE_FORMAT     = "opt done   " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Time %18s|AST %4d|Inlined %3dY %3dN|IR %6d/%6d|CodeSize %7d|Addr %7s|UTC %s|Src %s";
+    private static final String DONE_FORMAT     = "opt done   " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Time %18s|AST %4d|Inlined %3dY %3dN|IR %6d/%6d|CodeSize %7d|Addr 0x%012x|UTC %s|Src %s";
     private static final String FAILED_FORMAT   = "opt failed " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Time %18s|Reason: %s|UTC %s|Src %s";
     private static final String INV_FORMAT      = "opt inval. " + TARGET_FORMAT + "                                                                                                                |UTC %s|Src %s|Reason %s";
     private static final String DEOPT_FORMAT    = "opt deopt  " + TARGET_FORMAT + "|                                                                                                               |UTC %s|Src %s";
@@ -244,7 +244,7 @@ public final class TraceCompilationListener extends AbstractGraalTruffleRuntimeL
                         compilation.nodeCountPartialEval,
                         graph == null ? 0 : graph.getNodeCount(),
                         result == null ? 0 : result.getTargetCodeSize(),
-                        "0x" + Long.toHexString(target.getCodeAddress()),
+                        target.getCodeAddress(),
                         TIME_FORMATTER.format(ZonedDateTime.now()),
                         formatSourceSection(safeSourceSection(target))));
         currentCompilation.remove();

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -2,7 +2,7 @@ suite = {
     "name": "vm",
     "version" : "24.1.1",
     "mxversion": "7.27.0",
-    "release" : False,
+    "release" : True,
     "groupId" : "org.graalvm",
 
     "url" : "http://www.graalvm.org/",
@@ -33,7 +33,7 @@ suite = {
                 "name": "graal-nodejs",
                 "subdir": True,
                 "dynamic": True,
-                "version": "3af98ddb1001364de67c4cbede31445c40c0e96f",
+                "version": "2e808370bb8c82ecef81700afd890864f75ef9a1",
                 "urls" : [
                     {"url" : "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -42,7 +42,7 @@ suite = {
                 "name": "graal-js",
                 "subdir": True,
                 "dynamic": True,
-                "version": "3af98ddb1001364de67c4cbede31445c40c0e96f",
+                "version": "2e808370bb8c82ecef81700afd890864f75ef9a1",
                 "urls": [
                     {"url": "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -65,7 +65,7 @@ suite = {
             },
             {
                 "name": "graalpython",
-                "version": "facfb86f6c17a97986300619626538966fbf1ae6",
+                "version": "a5d4b186761583a006ed3cfc6f0887c6306bc696",
                 "dynamic": True,
                 "urls": [
                     {"url": "https://github.com/graalvm/graalpython.git", "kind": "git"},

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -65,7 +65,7 @@ suite = {
             },
             {
                 "name": "graalpython",
-                "version": "a97e765429d488672e19f66c3c33eea1e00e32ed",
+                "version": "6cbd2ee2e4d335817267e9e180de8f7ada4d9971",
                 "dynamic": True,
                 "urls": [
                     {"url": "https://github.com/graalvm/graalpython.git", "kind": "git"},

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -33,7 +33,7 @@ suite = {
                 "name": "graal-nodejs",
                 "subdir": True,
                 "dynamic": True,
-                "version": "5ed929b213fff8a888ebfeeb86cbfd5b3b74f663",
+                "version": "8bbd1c47ef001527d43b5826f7519955423551fc",
                 "urls" : [
                     {"url" : "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -42,7 +42,7 @@ suite = {
                 "name": "graal-js",
                 "subdir": True,
                 "dynamic": True,
-                "version": "5ed929b213fff8a888ebfeeb86cbfd5b3b74f663",
+                "version": "8bbd1c47ef001527d43b5826f7519955423551fc",
                 "urls": [
                     {"url": "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -65,7 +65,7 @@ suite = {
             },
             {
                 "name": "graalpython",
-                "version": "c0c790b029c1e6fa58c6f4345f749fa5d5453bf2",
+                "version": "a97e765429d488672e19f66c3c33eea1e00e32ed",
                 "dynamic": True,
                 "urls": [
                     {"url": "https://github.com/graalvm/graalpython.git", "kind": "git"},

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -1,8 +1,8 @@
 suite = {
     "name": "vm",
-    "version" : "24.1.0",
+    "version" : "24.1.1",
     "mxversion": "7.27.0",
-    "release" : True,
+    "release" : False,
     "groupId" : "org.graalvm",
 
     "url" : "http://www.graalvm.org/",

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -65,7 +65,7 @@ suite = {
             },
             {
                 "name": "graalpython",
-                "version": "9f8c823b41d79e1da43bf78000ce790ac657e5d6",
+                "version": "facfb86f6c17a97986300619626538966fbf1ae6",
                 "dynamic": True,
                 "urls": [
                     {"url": "https://github.com/graalvm/graalpython.git", "kind": "git"},

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -65,7 +65,7 @@ suite = {
             },
             {
                 "name": "graalpython",
-                "version": "9f301a4e16dd42d28138276ba3af24e81200c125",
+                "version": "9f8c823b41d79e1da43bf78000ce790ac657e5d6",
                 "dynamic": True,
                 "urls": [
                     {"url": "https://github.com/graalvm/graalpython.git", "kind": "git"},

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -33,7 +33,7 @@ suite = {
                 "name": "graal-nodejs",
                 "subdir": True,
                 "dynamic": True,
-                "version": "8bbd1c47ef001527d43b5826f7519955423551fc",
+                "version": "3af98ddb1001364de67c4cbede31445c40c0e96f",
                 "urls" : [
                     {"url" : "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -42,7 +42,7 @@ suite = {
                 "name": "graal-js",
                 "subdir": True,
                 "dynamic": True,
-                "version": "8bbd1c47ef001527d43b5826f7519955423551fc",
+                "version": "3af98ddb1001364de67c4cbede31445c40c0e96f",
                 "urls": [
                     {"url": "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -65,7 +65,7 @@ suite = {
             },
             {
                 "name": "graalpython",
-                "version": "7fa03a0d6de58a3f797c59932530afeab8e55740",
+                "version": "9f301a4e16dd42d28138276ba3af24e81200c125",
                 "dynamic": True,
                 "urls": [
                     {"url": "https://github.com/graalvm/graalpython.git", "kind": "git"},

--- a/wasm/mx.wasm/suite.py
+++ b/wasm/mx.wasm/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "7.27.1",
   "name" : "wasm",
   "groupId" : "org.graalvm.wasm",
-  "version" : "24.1.0",
+  "version" : "24.1.1",
   "versionConflictResolution" : "latest",
   "url" : "http://graalvm.org/",
   "developer" : {

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/BinaryParser.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/BinaryParser.java
@@ -1033,7 +1033,7 @@ public class BinaryParser extends BinaryStreamParser {
             // Do not override the code entry offset when rereading the function.
             module.setCodeEntryOffset(codeEntryIndex, bytecodeEndOffset);
         }
-        return new CodeEntry(functionIndex, state.maxStackSize(), locals, resultTypes, callNodes, bytecodeStartOffset, bytecodeEndOffset);
+        return new CodeEntry(functionIndex, state.maxStackSize(), locals, resultTypes, callNodes, bytecodeStartOffset, bytecodeEndOffset, state.usesMemoryZero());
     }
 
     private void readNumericInstructions(ParserState state, int opcode) {

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/SymbolTable.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/SymbolTable.java
@@ -179,12 +179,12 @@ public abstract class SymbolTable {
 
     public static class MemoryInfo {
         /**
-         * Lower bound on memory size.
+         * Lower bound on memory size (in pages of 64 kiB).
          */
         public final long initialSize;
 
         /**
-         * Upper bound on memory size.
+         * Upper bound on memory size (in pages of 64 kiB).
          * <p>
          * <em>Note:</em> this is the upper bound defined by the module. A memory instance might
          * have a lower internal max allowed size in practice.

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmCodeEntry.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmCodeEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -52,14 +52,16 @@ public final class WasmCodeEntry {
     private final BranchProfile errorBranch = BranchProfile.create();
     private final int numLocals;
     private final int resultCount;
+    private final boolean usesMemoryZero;
 
-    public WasmCodeEntry(WasmFunction function, byte[] bytecode, byte[] localTypes, byte[] resultTypes) {
+    public WasmCodeEntry(WasmFunction function, byte[] bytecode, byte[] localTypes, byte[] resultTypes, boolean usesMemoryZero) {
         this.function = function;
         this.bytecode = bytecode;
         this.localTypes = localTypes;
         this.numLocals = localTypes.length;
         this.resultTypes = resultTypes;
         this.resultCount = resultTypes.length;
+        this.usesMemoryZero = usesMemoryZero;
     }
 
     public WasmFunction function() {
@@ -92,6 +94,10 @@ public final class WasmCodeEntry {
 
     public void errorBranch() {
         errorBranch.enter();
+    }
+
+    public boolean usesMemoryZero() {
+        return usesMemoryZero;
     }
 
     @Override

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmInstantiator.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmInstantiator.java
@@ -495,7 +495,7 @@ public class WasmInstantiator {
             assert context.language().isMultiContext();
             return cachedTarget;
         }
-        final WasmCodeEntry wasmCodeEntry = new WasmCodeEntry(function, module.bytecode(), codeEntry.localTypes(), codeEntry.resultTypes());
+        final WasmCodeEntry wasmCodeEntry = new WasmCodeEntry(function, module.bytecode(), codeEntry.localTypes(), codeEntry.resultTypes(), codeEntry.usesMemoryZero());
         final FrameDescriptor frameDescriptor = createFrameDescriptor(codeEntry.localTypes(), codeEntry.maxStackSize());
         final WasmInstrumentableFunctionNode functionNode = instantiateFunctionNode(module, instance, wasmCodeEntry, codeEntry);
         final WasmRootNode rootNode;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/api/WebAssembly.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/api/WebAssembly.java
@@ -297,8 +297,15 @@ public class WebAssembly extends Dictionary {
 
     private static byte[] toBytes(Object source) {
         InteropLibrary interop = InteropLibrary.getUncached(source);
-        if (interop.hasArrayElements(source)) {
-            try {
+        try {
+            if (interop.hasBufferElements(source)) {
+                long size = interop.getBufferSize(source);
+                if (size == (int) size) {
+                    byte[] bytes = new byte[(int) size];
+                    interop.readBuffer(source, 0, bytes, 0, (int) size);
+                    return bytes;
+                }
+            } else if (interop.hasArrayElements(source)) {
                 long size = interop.getArraySize(source);
                 if (size == (int) size) {
                     byte[] bytes = new byte[(int) size];
@@ -312,9 +319,9 @@ public class WebAssembly extends Dictionary {
                     }
                     return bytes;
                 }
-            } catch (InteropException iex) {
-                throw cannotConvertToBytesError(iex);
             }
+        } catch (InteropException iex) {
+            throw cannotConvertToBytesError(iex);
         }
         throw cannotConvertToBytesError(null);
     }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/NativeWasmMemory.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/NativeWasmMemory.java
@@ -127,6 +127,7 @@ final class NativeWasmMemory extends WasmMemory {
     }
 
     @Override
+    @TruffleBoundary
     public void reset() {
         free();
         size = declaredMinSize;
@@ -953,6 +954,7 @@ final class NativeWasmMemory extends WasmMemory {
         return startAddress == 0;
     }
 
+    @TruffleBoundary
     private void free() {
         unsafe.freeMemory(startAddress);
         startAddress = 0;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/UnsafeWasmMemory.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/UnsafeWasmMemory.java
@@ -119,6 +119,7 @@ public final class UnsafeWasmMemory extends WasmMemory {
     }
 
     @Override
+    @TruffleBoundary
     public void reset() {
         size = declaredMinSize;
         buffer = allocateBuffer(byteSize());

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/WasmMemory.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/WasmMemory.java
@@ -838,6 +838,13 @@ public abstract class WasmMemory extends EmbedderDataHolder implements TruffleOb
         return length < 0 || offset < 0 || offset > getBufferSize() - length;
     }
 
+    public final WasmMemory checkSize(long initialSize) {
+        if (byteSize() < initialSize * Sizes.MEMORY_PAGE_SIZE) {
+            throw CompilerDirectives.shouldNotReachHere("Memory size must not be less than initial size");
+        }
+        return this;
+    }
+
     /**
      * Copy data from an input stream into memory.
      *

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
@@ -4642,31 +4642,31 @@ public final class WasmFunctionNode extends Node implements BytecodeOSRNode {
         int f = rawPeekU8(data, profileOffset + 1);
         boolean val = condition;
         if (val) {
+            if (t == 0) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+            }
             if (!CompilerDirectives.inInterpreter()) {
-                if (t == 0) {
-                    CompilerDirectives.transferToInterpreterAndInvalidate();
-                }
                 if (f == 0) {
                     // Make this branch fold during PE
                     val = true;
                 }
             } else {
                 if (t < MAX_PROFILE_VALUE) {
-                    data[profileOffset]++;
+                    data[profileOffset] = (byte) (t + 1);
                 }
             }
         } else {
+            if (f == 0) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+            }
             if (!CompilerDirectives.inInterpreter()) {
-                if (f == 0) {
-                    CompilerDirectives.transferToInterpreterAndInvalidate();
-                }
                 if (t == 0) {
                     // Make this branch fold during PE
                     val = false;
                 }
             } else {
                 if (f < MAX_PROFILE_VALUE) {
-                    data[profileOffset + 1]++;
+                    data[profileOffset + 1] = (byte) (f + 1);
                 }
             }
         }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
@@ -270,7 +270,7 @@ public final class WasmFunctionNode extends Node implements BytecodeOSRNode {
         int line = startLine;
 
         // Note: The module may not have any memories.
-        final WasmMemory zeroMemory = module.memoryCount() == 0 ? null : memory0(instance);
+        final WasmMemory zeroMemory = !codeEntry.usesMemoryZero() ? null : memory0(instance);
 
         check(bytecode.length, (1 << 31) - 1);
 

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
@@ -183,8 +183,8 @@ public final class WasmFunctionNode extends Node implements BytecodeOSRNode {
         this.notifyFunction = notifyFunction;
     }
 
-    private WasmMemory memory(WasmInstance instance) {
-        return memory(instance, 0);
+    private WasmMemory memory0(WasmInstance instance) {
+        return memory(instance, 0).checkSize(module.memoryInitialSize(0));
     }
 
     private WasmMemory memory(WasmInstance instance, int index) {
@@ -270,7 +270,7 @@ public final class WasmFunctionNode extends Node implements BytecodeOSRNode {
         int line = startLine;
 
         // Note: The module may not have any memories.
-        final WasmMemory zeroMemory = module.memoryCount() == 0 ? null : memory(instance);
+        final WasmMemory zeroMemory = module.memoryCount() == 0 ? null : memory0(instance);
 
         check(bytecode.length, (1 << 31) - 1);
 

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/bytecode/BytecodeParser.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/bytecode/BytecodeParser.java
@@ -424,7 +424,8 @@ public abstract class BytecodeParser {
             results = Bytecode.EMPTY_BYTES;
         }
         List<CallNode> callNodes = readCallNodes(bytecode, codeEntryOffset - length, codeEntryOffset);
-        return new CodeEntry(functionIndex, maxStackSize, locals, results, callNodes, codeEntryOffset - length, codeEntryOffset);
+        boolean usesMemoryZero = module.memoryCount() != 0;
+        return new CodeEntry(functionIndex, maxStackSize, locals, results, callNodes, codeEntryOffset - length, codeEntryOffset, usesMemoryZero);
     }
 
     /**

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/ir/CodeEntry.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/ir/CodeEntry.java
@@ -54,8 +54,9 @@ public final class CodeEntry {
     private final List<CallNode> callNodes;
     private final int bytecodeStartOffset;
     private final int bytecodeEndOffset;
+    private final boolean usesMemoryZero;
 
-    public CodeEntry(int functionIndex, int maxStackSize, byte[] localTypes, byte[] resultTypes, List<CallNode> callNodes, int startOffset, int endOffset) {
+    public CodeEntry(int functionIndex, int maxStackSize, byte[] localTypes, byte[] resultTypes, List<CallNode> callNodes, int startOffset, int endOffset, boolean usesMemoryZero) {
         this.functionIndex = functionIndex;
         this.maxStackSize = maxStackSize;
         this.localTypes = localTypes;
@@ -63,6 +64,7 @@ public final class CodeEntry {
         this.callNodes = callNodes;
         this.bytecodeStartOffset = startOffset;
         this.bytecodeEndOffset = endOffset;
+        this.usesMemoryZero = usesMemoryZero;
     }
 
     public int maxStackSize() {
@@ -91,5 +93,9 @@ public final class CodeEntry {
 
     public int bytecodeEndOffset() {
         return bytecodeEndOffset;
+    }
+
+    public boolean usesMemoryZero() {
+        return usesMemoryZero;
     }
 }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/validation/ParserState.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/validation/ParserState.java
@@ -65,6 +65,7 @@ public class ParserState {
     private final RuntimeBytecodeGen bytecode;
 
     private int maxStackSize;
+    private boolean usesMemoryZero;
 
     public ParserState(RuntimeBytecodeGen bytecode) {
         this.valueStack = new ByteArrayList();
@@ -76,7 +77,7 @@ public class ParserState {
 
     /**
      * Pops a value from the stack if possible. Throws an error on stack underflow.
-     * 
+     *
      * @param expectedValueType The expectedValueType used for error generation.
      * @return The top of the stack or -1.
      */
@@ -101,7 +102,7 @@ public class ParserState {
      * are returned. If the number of values on the stack is greater or equal to the number of
      * expectedValueTypes, the values equal to the number of expectedValueTypes is popped from the
      * stack.
-     * 
+     *
      * @param expectedValueTypes Value types expected on the stack.
      * @return The maximum of available stack values smaller than the length of expectedValueTypes.
      */
@@ -117,7 +118,7 @@ public class ParserState {
 
     /**
      * Pops the maximum available values from the current stack frame.
-     * 
+     *
      * @return The maximum of available stack values.
      */
     private byte[] popAvailableUnchecked() {
@@ -133,7 +134,7 @@ public class ParserState {
 
     /**
      * Checks if two sets of value types are equivalent.
-     * 
+     *
      * @param expectedTypes The expected value types.
      * @param actualTypes The actual value types.
      * @return True if both are equivalent.
@@ -155,7 +156,7 @@ public class ParserState {
 
     /**
      * Pushes a value type onto the stack.
-     * 
+     *
      * @param valueType The value type that should be added.
      */
     public void push(byte valueType) {
@@ -165,7 +166,7 @@ public class ParserState {
 
     /**
      * Pushes all provided value types onto the stack.
-     * 
+     *
      * @param valueTypes The value types that should be added.
      */
     public void pushAll(byte[] valueTypes) {
@@ -176,7 +177,7 @@ public class ParserState {
 
     /**
      * Pops the topmost value type from the stack. Throws an error if the stack is empty.
-     * 
+     *
      * @return The value type on top of the stack or -1.
      * @throws WasmException If the stack is empty.
      */
@@ -186,7 +187,7 @@ public class ParserState {
 
     /**
      * Pops the topmost value type from the stack and checks if it is equivalent to the given value.
-     * 
+     *
      * @param expectedValueType The expected value type.
      * @return The value type on top of the stack.
      * @throws WasmException If the stack is empty or the value types do not match.
@@ -220,7 +221,7 @@ public class ParserState {
     /**
      * Pops the topmost value types from the stack and checks if they are equivalent to the given
      * set of value types.
-     * 
+     *
      * @param expectedValueTypes The expected value types.
      * @return The value types on top of the stack.
      * @throws WasmException If the stack is empty or the value types do not match.
@@ -335,7 +336,7 @@ public class ParserState {
     /**
      * Performs the necessary branch checks and adds the unconditional branch information to the
      * extra data array.
-     * 
+     *
      * @param branchLabel The target label.
      */
     public void addUnconditionalBranch(int branchLabel) {
@@ -349,7 +350,7 @@ public class ParserState {
     /**
      * Performs the necessary branch checks and adds the branch table information to the extra data
      * array.
-     * 
+     *
      * @param branchLabels The target labels.
      */
     public void addBranchTable(int[] branchLabels) {
@@ -371,7 +372,7 @@ public class ParserState {
 
     /**
      * Performs the necessary checks for a function return.
-     * 
+     *
      * @param multiValue If multiple return values are supported.
      */
     public void addReturn(boolean multiValue) {
@@ -386,7 +387,7 @@ public class ParserState {
 
     /**
      * Adds the index of an indirect call node to the extra data array.
-     * 
+     *
      * @param nodeIndex The index of the indirect call.
      */
     public void addIndirectCall(int nodeIndex, int typeIndex, int tableIndex) {
@@ -395,7 +396,7 @@ public class ParserState {
 
     /**
      * Adds the index of a direct call node to the extra data array.
-     * 
+     *
      * @param nodeIndex The index of the direct call.
      */
     public void addCall(int nodeIndex, int functionIndex) {
@@ -425,7 +426,7 @@ public class ParserState {
 
     /**
      * Adds the given instruction and an i32 immediate value to the bytecode.
-     * 
+     *
      * @param instruction The instruction
      * @param value The immediate value
      */
@@ -435,7 +436,7 @@ public class ParserState {
 
     /**
      * Adds the given instruction and an i64 immediate value to the bytecode.
-     * 
+     *
      * @param instruction The instruction
      * @param value The immediate value
      */
@@ -455,7 +456,7 @@ public class ParserState {
 
     /**
      * Adds the given instruction and two i32 immediate values to the bytecode.
-     * 
+     *
      * @param instruction The instruction
      * @param value1 The first immediate value
      * @param value2 The second immediate value
@@ -468,7 +469,7 @@ public class ParserState {
      * Adds the i8 or i32 version of the given instruction to the bytecode based on the given
      * immediate value. If the value fits into a signed i8 value, the i8 instruction and an i8 value
      * are added. Otherwise, the i32 instruction and an i32 value are added.
-     * 
+     *
      * @param instruction The i8 version of the instruction
      * @param value The immediate value.
      */
@@ -480,7 +481,7 @@ public class ParserState {
      * Adds the i8 or i64 version of the given instruction to the bytecode based on the given
      * immediate value. If the value fits into a signed i8 value, the i8 instruction and an i8 value
      * are added. Otherwise, the i64 instruction and i64 value are added.
-     * 
+     *
      * @param instruction The i8 version of the instruction
      * @param value The immediate value
      */
@@ -492,7 +493,7 @@ public class ParserState {
      * Adds the u8 or i32 version of the given instruction to the bytecode based on the given
      * immediate value. If the value fits into a u8 value, the u8 instruction and a u8 value are
      * added. Otherwise, the i32 instruction and an i32 value are added.
-     * 
+     *
      * @param instruction The u8 version of the instruction
      * @param value The immediate value
      */
@@ -502,13 +503,14 @@ public class ParserState {
 
     /**
      * Adds a memory instruction based on the given values and index type.
-     * 
+     *
      * @param baseInstruction The base version of the memory instruction
      * @param memoryIndex The index of the memory being accessed
      * @param value The immediate value
      * @param indexType64 If the index type is 64 bit.
      */
     public void addMemoryInstruction(int baseInstruction, int memoryIndex, long value, boolean indexType64) {
+        markMemoryUsed(memoryIndex);
         bytecode.addMemoryInstruction(baseInstruction, baseInstruction + 1, baseInstruction + 2, memoryIndex, value, indexType64);
     }
 
@@ -522,6 +524,7 @@ public class ParserState {
      * @param indexType64 If the index type is 64 bit.
      */
     public void addExtendedMemoryInstruction(int instruction, int memoryIndex, long value, boolean indexType64) {
+        markMemoryUsed(memoryIndex);
         bytecode.addExtendedMemoryInstruction(instruction, memoryIndex, value, indexType64);
     }
 
@@ -535,13 +538,14 @@ public class ParserState {
      * @param laneIndex The lane index
      */
     public void addVectorMemoryLaneInstruction(int instruction, int memoryIndex, long value, boolean indexType64, byte laneIndex) {
+        markMemoryUsed(memoryIndex);
         bytecode.addExtendedMemoryInstruction(instruction, memoryIndex, value, indexType64);
         bytecode.add(laneIndex);
     }
 
     /**
      * Adds a lane-indexed vector instruction (extract_lane or replace_lane).
-     * 
+     *
      * @param instruction The vector instruction
      * @param laneIndex The lane index
      */
@@ -554,7 +558,7 @@ public class ParserState {
      * Finishes the current control frame and removes it from the control frame stack.
      *
      * @param multiValue If multiple return values are supported.
-     * 
+     *
      * @throws WasmException If the number of return value types do not match with the remaining
      *             stack or the number of return values is greater than 1.
      */
@@ -576,7 +580,7 @@ public class ParserState {
 
     /**
      * Checks that the expected return types are actually on the value stack.
-     * 
+     *
      * @param frame The frame that is exited.
      * @param resultTypes The expected return types of the frame.
      */
@@ -627,7 +631,7 @@ public class ParserState {
 
     /**
      * Checks if the given parameter value types do match the current value types on the stack.
-     * 
+     *
      * @param paramTypes The expected value types.
      * @throws WasmException If the parameter value types and the vale types on the stack do not
      *             match.
@@ -645,7 +649,7 @@ public class ParserState {
 
     /**
      * Checks if the given label is a valid jump target.
-     * 
+     *
      * @param label The label which to jump to.
      * @throws WasmException If the label is out or reach.
      */
@@ -657,7 +661,7 @@ public class ParserState {
 
     /**
      * Checks if the value types of two different labels match.
-     * 
+     *
      * @param expectedTypes The expected value types.
      * @param actualTypes The value types that should be checked.
      * @throws WasmException If the provided sets of value types do not match.
@@ -670,7 +674,7 @@ public class ParserState {
 
     /**
      * Checks if the given function type is within range.
-     * 
+     *
      * @param typeIndex The function type.
      * @param max The number of available function types.
      * @throws WasmException If the given function type is greater or equal to the given maximum.
@@ -700,5 +704,15 @@ public class ParserState {
 
     public int maxStackSize() {
         return maxStackSize;
+    }
+
+    private void markMemoryUsed(int memoryIndex) {
+        if (memoryIndex == 0) {
+            usesMemoryZero = true;
+        }
+    }
+
+    public boolean usesMemoryZero() {
+        return usesMemoryZero;
     }
 }


### PR DESCRIPTION
Merge upstream changes from [`vm-24.1.1` tag](https://github.com/oracle/graal/releases/tag/vm-24.1.1).

- Avoid getHostBackend when instantiating UnimplementedGraalIntrinsics.
- [GR-57295] Aarch: Move setConservativeLabelRange after resetting crb.
- [GR-56104] Fix --bundle-create option and bundle-launcher feature on Windows.
- Start 24.1.1 dev cycle.
- Update js and graalpython imports.
- Update GraalVM versions used by simplelanguage and simpletool.
- Do not include TruffleJfrFeature if PGO config is specified.
- Eagerly initialize caches in ValueConversions
- Reset Provider.Service.constructorCache field
- Fix Addr part alignment in Truffle compilation logs.
- update JVMCI to 23.0.1+9-jvmci-b01
- Prevent emission of typeReachable in reachability-metadata.json
- Ensure correct condition format during metadata emission
- Parse constant resource patterns as globs
- Enable "type" to register reflective elements unconditionally when parsing in the agent or configure tool
- Pretty print legacy configuration files
- Add changelog entry for reachability-metadata.json
- [GR-57970] Backport to 24.1: Make js.webassembly option stable.
- [GR-57799] Backport to 24.1: Deprecate exposed truffle filesystem spi in VirtualFileSystem.
- update JVMCI to 23.0.1+10-jvmci-b01
- Remove constant memory buffer assumption and simplify ByteArrayWasmMemory.
- Check that memory 0 size >= initial size at the start of a wasm function.
- Only perform initial memory 0 bounds check if the wasm function uses memory 0.
- Work around for nullary benchmarkTeardownEach() in photon benchmark.
- Fix TraceTransferToInterpreter in WasmFunctionNode.profileCondition.
- Try to read WebAssembly.Module bytes via Buffer Interop.
- support different JDK version between CE and EE for labsjdk-latest
- deploy snapshots
- update JVMCI CE  to 23.0.1+10-jvmci-b01
- revert : support different JDK version between CE and EE for labsjdk-latest
- Update mx import.
- [GR-57721] Backport to 24.1: Create Gradle plugin with similar features as our Maven plugin.
- labsjdk respin : adopt jdk-23.0.1+11
- [GR-57975] Backport to 24.1: Update bouncycastle dependency
- Release GraalVM 24.1.1.

The merge was clean, but there are two open issues for properly testing this branch:

1. https://github.com/graalvm/mx/issues/285
2. The branch depends on a newer JVMCI version which is not satisfied by JDK 23+37, which is still the latest build returned by https://api.adoptium.net/v3/binary/latest/23/ea/linux/x64/jdk/hotspot/normal/eclipse
