### PR TITLE
[CI] Include delimiter in job title when filtering issues

### DIFF
--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
+ * Copyright 2020,2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 //usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS org.kohsuke:github-api:1.321
-//DEPS info.picocli:picocli:4.2.0
+//JAVA 21
+//DEPS org.kohsuke:github-api:1.326
+//DEPS info.picocli:picocli:4.7.6
 
 import org.kohsuke.github.*;
 import org.kohsuke.github.GHWorkflowRun.Conclusion;
@@ -32,7 +33,6 @@ import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/.github/workflows/github-issue-updater.yml
+++ b/.github/workflows/github-issue-updater.yml
@@ -25,13 +25,13 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '21'
       - name: Setup jbang and report results
         env:
             BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
         run: |
             echo "Installing JBang"
-            wget https://github.com/jbangdev/jbang/releases/download/v0.87.0/jbang.zip
+            wget https://github.com/jbangdev/jbang/releases/download/v0.121.0/jbang.zip
             unzip jbang.zip
             echo "Attempting to report results"
             ./jbang/bin/jbang ./workflow-mandrel/.github/quarkus-ecosystem-issue.java \


### PR DESCRIPTION
Top level jobs might share a common prefix, e.g. "Q main M24 latest" is shared in both linux and windows builds. Including the delimiter we ensure that we are getting the full top level job title and prevent false negatives in our reports.

Also updates quarkus-ecosystem-issue.java script dependencies

Resolves issue observed in https://github.com/graalvm/mandrel/issues/755#issuecomment-2490481362