### PR TITLE
[CI] Move to dev cycle 25.0

### DIFF
--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -60,6 +60,8 @@ on:
           - "23/ea"
           - "24/ga"
           - "24/ea"
+          - "25/ga"
+          - "25/ea"
           - "latest/labsjdk"
       builder-image:
         type: string

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -62,6 +62,8 @@ on:
           - "23/ea"
           - "24/ga"
           - "24/ea"
+          - "25/ga"
+          - "25/ea"
           - "latest/labsjdk"
       builder-image:
         type: string

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,42 +32,42 @@ jobs:
   ####
   # Test Quarkus main with latest graal sources built as Mandrel and GraalVM
   ####
-  q-main-graal-24-latest:
-    name: "Q main G 24 latest"
+  q-main-graal-25-latest:
+    name: "Q main G 25 latest"
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
       version: "graal/master"
       build-type: "graal-source"
       jdk: "latest/ea"
-      build-stats-tag: "gha-linux-graal-qmain-glatest-jdk24ea"
+      build-stats-tag: "gha-linux-graal-qmain-glatest-jdk25ea"
     secrets:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-mandrel-24-latest:
-    name: "Q main M 24 latest"
+  q-main-mandrel-25-latest:
+    name: "Q main M 25 latest"
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
       version: "graal/master"
-      jdk: "24/ea"
-      issue-number: "755"
+      jdk: "25/ea"
+      issue-number: "812"
       issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "266"
-      build-stats-tag: "gha-linux-mandrel-qmain-mlatest-jdk24ea"
+      mandrel-it-issue-number: "300"
+      build-stats-tag: "gha-linux-mandrel-qmain-mlatest-jdk25ea"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-mandrel-24-latest-win:
-    name: "Q main M 24 latest windows"
+  q-main-mandrel-25-latest-win:
+    name: "Q main M 25 latest windows"
     uses: ./.github/workflows/base-windows.yml
     with:
       quarkus-version: "main"
       version: "graal/master"
-      issue-number: "756"
+      issue-number: "813"
       issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "267"
-      jdk: "24/ea"
-      build-stats-tag: "gha-win-mandrel-qmain-mlatest-jdk24ea"
+      mandrel-it-issue-number: "301"
+      jdk: "25/ea"
+      build-stats-tag: "gha-win-mandrel-qmain-mlatest-jdk25ea"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,6 +30,39 @@ concurrency:
 
 jobs:
   ####
+  # Test Q main and Mandrel 24.2 JDK 24
+  ####
+  q-main-mandrel-24_2-ea:
+    name: "Q main M 24.2 JDK 24 EA"
+    uses: ./.github/workflows/base.yml
+    with:
+      quarkus-version: "main"
+      version: "mandrel/24.2"
+      jdk: "24/ea"
+      issue-number: "814"
+      issue-repo: "graalvm/mandrel"
+      mandrel-it-issue-number: "302"
+      build-stats-tag: "gha-linux-qmain-m24_2-jdk24ea"
+      mandrel-packaging-version: "24.2"
+    secrets:
+      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+  q-main-mandrel-24_2-ea-win:
+    name: "Q main M 24.2 JDK 23 EA windows"
+    uses: ./.github/workflows/base-windows.yml
+    with:
+      quarkus-version: "main"
+      version: "mandrel/24.2"
+      jdk: "24/ea"
+      issue-number: "815"
+      issue-repo: "graalvm/mandrel"
+      mandrel-it-issue-number: "303"
+      build-stats-tag: "gha-win-qmain-m24_2-jdk24ea"
+      mandrel-packaging-version: "24.2"
+    secrets:
+      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+  ####
   # Test Q main and Mandrel 24.1 JDK 23
   ####
   q-main-mandrel-24_1-ea:


### PR DESCRIPTION
* Mandrel 24.2 for JDK 24 is now branched in `mandrel/24.2`
* `graal/master` moved to JDK 25

> [!NOTE]
> Our nightly builds will be broken for some time since temurin JDK 25 binaries are not available yet.