### PR TITLE
[CI] Skip weekends for nightly runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,8 @@ on:
       - '.github/workflows/base.yml'
       - '.github/workflows/base-windows.yml'
   schedule:
-    - cron: '15 0 * * *'
+    # Don't run on weekends as merges are infrequent
+    - cron: '15 0 * * 2-6'
   workflow_dispatch:
 
 # The following aims to reduce CI CPU cycles by:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,7 +12,8 @@ on:
       - '.github/workflows/base.yml'
       - '.github/workflows/base-windows.yml'
   schedule:
-    - cron: '15 0 * * 6'
+    # Run at 00:00 on Sundays
+    - cron: '0 0 * * 0'
   workflow_dispatch:
 
 # The following aims to reduce CI CPU cycles by:


### PR DESCRIPTION
The repositories we are testing are typically quiet during weekends.
