### PR TITLE
[24.1] Backport: Avoid using deprecated pipes module

### DIFF
--- a/sdk/mx.sdk/mx_sdk_shaded.py
+++ b/sdk/mx.sdk/mx_sdk_shaded.py
@@ -335,8 +335,8 @@ def glob_match(path, pattern):
     """
     assert isinstance(path, PurePath), path
     if sys.version_info[:2] >= (3, 13):
-        # Since Python 3.13, PurePath.match already supports '**'.
-        return path.match(pattern)
+        # Python 3.13+: PurePath.full_match already supports '**'.
+        return path.full_match(pattern)
 
     pathType = type(path)
     patternParts = pathType(pattern).parts

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -30,7 +30,7 @@ from glob import glob
 from contextlib import contextmanager
 from itertools import islice
 from os.path import join, exists, dirname
-import pipes
+import shlex
 from argparse import ArgumentParser
 import fnmatch
 import collections
@@ -645,7 +645,7 @@ def _native_junit(native_image, unittest_args, build_args=None, run_args=None, b
         unittest_image = native_image(['-ea', '-esa'] + build_args + extra_image_args + [macro_junit + '=' + unittest_file] + svm_experimental_options(['-H:Path=' + junit_test_dir]), env=custom_env)
         image_pattern_replacement = unittest_image + ".exe" if mx.is_windows() else unittest_image
         run_args = [arg.replace('${unittest.image}', image_pattern_replacement) for arg in run_args]
-        mx.log('Running: ' + ' '.join(map(pipes.quote, [unittest_image] + run_args)))
+        mx.log('Running: ' + ' '.join(map(shlex.quote, [unittest_image] + run_args)))
 
         if not test_classes_per_run:
             # Run all tests in one go. The default behavior.

--- a/sulong/mx.sulong/mx_sulong.py
+++ b/sulong/mx.sulong/mx_sulong.py
@@ -29,7 +29,7 @@
 #
 import sys
 import os
-import pipes
+import shlex
 import tempfile
 from os.path import join
 import shutil
@@ -166,7 +166,7 @@ mx_subst.path_substitutions.register_no_arg('jacoco', get_jacoco_setting)
 def _subst_get_jvm_args(dep):
     java = mx.get_jdk().java
     main_class = mx.distribution(dep).mainClass
-    jvm_args = [pipes.quote(arg) for arg in mx.get_runtime_jvm_args([dep])]
+    jvm_args = [shlex.quote(arg) for arg in mx.get_runtime_jvm_args([dep])]
     cmd = [java] + jvm_args + [main_class]
     return " ".join(cmd)
 

--- a/sulong/mx.sulong/mx_sulong_suite_constituents.py
+++ b/sulong/mx.sulong/mx_sulong_suite_constituents.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 
 import abc
 import fnmatch
-import pipes
+import shlex
 
 import mx
 import mx_cmake
@@ -419,7 +419,7 @@ class BootstrapToolchainLauncherBuildTask(mx.BuildTask):
     def contents(self, tool, exe):
         # platform support
         all_params = '%*' if mx.is_windows() else '"$@"'
-        _quote = _quote_windows if mx.is_windows() else pipes.quote
+        _quote = _quote_windows if mx.is_windows() else shlex.quote
         # build command line
         java = mx.get_jdk().java
         classpath_deps = [dep for dep in self.subject.buildDependencies if isinstance(dep, mx.ClasspathDependency)]


### PR DESCRIPTION
Backport of https://github.com/oracle/graal/pull/9877

The `pipes` python module has been removed in Python 3.13.

Fedora 41, for example has Python 3.13. This allows one to build the GraalVM for JDK 21 repo to build on that platform. The only difference to the graal/master commit is context change in `substratevm/mx.substratevm/mx_substratevm.py` and copyright year updates since the gates check for it.