### PR TITLE
[CI] Remove weekly testing for Mandrel for JDK 23

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -64,39 +64,6 @@ jobs:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
-  # Test Q main and Mandrel 24.1 JDK 23
-  ####
-  q-main-mandrel-24_1-ea:
-    name: "Q main M 24.1 JDK 23 EA"
-    uses: ./.github/workflows/base.yml
-    with:
-      quarkus-version: "main"
-      version: "mandrel/24.1"
-      jdk: "23/ea"
-      issue-number: "742"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "244"
-      build-stats-tag: "gha-linux-qmain-m24_1-jdk23ea"
-      mandrel-packaging-version: "24.1"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-mandrel-24_1-ea-win:
-    name: "Q main M 24.1 JDK 23 EA windows"
-    uses: ./.github/workflows/base-windows.yml
-    with:
-      quarkus-version: "main"
-      version: "mandrel/24.1"
-      jdk: "23/ea"
-      issue-number: "743"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "243"
-      build-stats-tag: "gha-win-qmain-m24_1-jdk23ea"
-      mandrel-packaging-version: "24.1"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  ####
   # Test Q main and Mandrel 23.1 JDK 21
   ####
   q-main-mandrel-23_1:


### PR DESCRIPTION
There will not be any more releases for that train. The last one was in January 2025 (23.0.2). Soon to be replaced by the Mandrel for JDK 24 (24.2) release.