### PR TITLE
[CI] Refactoring: Move build-vars and get-test-matrix jobs to separate workflows

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -85,81 +85,16 @@ env:
 
 jobs:
   build-vars:
-    name: Set distribution and build-from-source variables based on build-type
-    runs-on: ubuntu-latest
-    outputs:
-      build-from-source: ${{ steps.source-build.outputs.build-from-source }}
-      distribution: ${{ steps.distro.outputs.distribution }}
-    steps:
-    - name: Set build-from-source output
-      id: source-build
-      run: |
-        echo "${{ inputs.build-type }}"
-        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f2)
-        if [ "${bfs_token}" == "release" ]
-        then
-          source_build=false
-        elif [ "${bfs_token}" == "source" ]
-        then
-          source_build=true
-        else
-          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
-          exit 1
-        fi
-        echo "source_build=$source_build"
-        echo "build-from-source=$source_build" >> $GITHUB_OUTPUT
-    - name: Set distribution output
-      id: distro
-      run: |
-        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f1)
-        if [ "${bfs_token}" == "graal" ]
-        then
-          distro="graalvm"
-        elif [ "${bfs_token}" == "mandrel" ]
-        then
-          distro="mandrel"
-        else
-          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
-          exit 1
-        fi
-        echo "distro=$distro"
-        echo "distribution=$distro" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/build-vars.yml
+    with:
+      build-type: ${{ inputs.build-type }}
 
   get-test-matrix:
-    name: Get test matrix
-    runs-on: ubuntu-latest
-    outputs:
-      quarkus-version: ${{ steps.version.outputs.quarkus-version }}
-      tests-matrix: ${{ steps.version.outputs.tests-matrix }}
-      artifacts-suffix: ${{ steps.suffix.outputs.suffix }}
-    steps:
-    - id: suffix
-      run: |
-        export SUFFIX=$(echo '${{ toJson(inputs) }}' | jq -j 'del(."build-stats-tag", ."mandrel-it-issue-number", ."issue-repo", ."issue-number") | to_entries[] | "-\(.value)"' | tr '":<>|*?\\r\n\/' '-')
-        echo $SUFFIX
-        echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
-    - name: Get Quarkus version and test matrix
-      id: version
-      run: |
-        if [ ${{ inputs.quarkus-version }} == "latest" ]
-        then
-          export QUARKUS_VERSION=$(curl -s https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/Final/ {print $3}' | sort -V | tail -n 1)
-        elif $(expr match "${{ inputs.quarkus-version }}" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
-        then
-          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
-        else
-          export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ inputs.quarkus-repo }} | grep "refs/heads/${{ inputs.quarkus-version }}$\|refs/tags/${{ inputs.quarkus-version }}$" | cut -f 1)
-        fi
-        if [ "$QUARKUS_VERSION" == "" ]
-        then
-          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
-        fi
-        echo ${QUARKUS_VERSION}
-        echo "quarkus-version=${QUARKUS_VERSION}" >> $GITHUB_OUTPUT
-        curl --output native-tests.json https://raw.githubusercontent.com/${{ inputs.quarkus-repo }}/${QUARKUS_VERSION}/.github/native-tests.json
-        tests_json=$(jq -c '.include |= map(select(.["os-name"] | startswith("windows")))' native-tests.json)
-        echo ${tests_json}
-        echo "tests-matrix=${tests_json}" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/get-test-matrix.yml
+    with:
+      quarkus-version: ${{ inputs.quarkus-version }}
+      quarkus-repo: ${{ inputs.quarkus-repo }}
+      os: 'windows'
 
   build-mandrel:
     name: Mandrel build

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -85,94 +85,16 @@ env:
 
 jobs:
   build-vars:
-    name: Set distribution, build-from-source, and maven-deploy-local variables based on build-type
-    runs-on: ubuntu-latest
-    outputs:
-      build-from-source: ${{ steps.source-build.outputs.build-from-source }}
-      distribution: ${{ steps.distro.outputs.distribution }}
-      maven-deploy-local: ${{ steps.maven-deploy-local.outputs.maven-deploy-local }}
-    steps:
-    - name: Set build-from-source output
-      id: source-build
-      run: |
-        echo "${{ inputs.build-type }}"
-        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f2)
-        if [ "${bfs_token}" == "release" ]
-        then
-          source_build=false
-        elif [ "${bfs_token}" == "source" ]
-        then
-          source_build=true
-        else
-          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
-          exit 1
-        fi
-        echo "source_build=$source_build"
-        echo "build-from-source=$source_build" >> $GITHUB_OUTPUT
-    - name: Set distribution output
-      id: distro
-      run: |
-        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f1)
-        if [ "${bfs_token}" == "graal" ]
-        then
-          distro="graalvm"
-        elif [ "${bfs_token}" == "mandrel" ]
-        then
-          distro="mandrel"
-        else
-          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
-          exit 1
-        fi
-        echo "distro=$distro"
-        echo "distribution=$distro" >> $GITHUB_OUTPUT
-    - name: Set maven-deploy-local output
-      id: maven-deploy-local
-      run: |
-        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f3)
-        if [ "${bfs_token}" == "nolocalmvn" ]
-        then
-          maven_deploy_local=""
-        else
-          maven_deploy_local="--maven-deploy-local"
-        fi
-        echo "maven_deploy_local=$maven_deploy_local"
-        echo "maven-deploy-local=$maven_deploy_local" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/build-vars.yml
+    with:
+      build-type: ${{ inputs.build-type }}
 
   get-test-matrix:
-    name: Get test matrix
-    runs-on: ubuntu-latest
-    outputs:
-      quarkus-version: ${{ steps.version.outputs.quarkus-version }}
-      tests-matrix: ${{ steps.version.outputs.tests-matrix }}
-      artifacts-suffix: ${{ steps.suffix.outputs.suffix }}
-    steps:
-    - id: suffix
-      run: |
-        export SUFFIX=$(echo '${{ toJson(inputs) }}' | jq -j 'del(."build-stats-tag", ."mandrel-it-issue-number", ."issue-repo", ."issue-number") | to_entries[] | "-\(.value)"' | tr '":<>|*?\r\n\/' '-')
-        echo $SUFFIX
-        echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
-    - name: Get Quarkus version and test matrix
-      id: version
-      run: |
-        if [ ${{ inputs.quarkus-version }} == "latest" ]
-        then
-          export QUARKUS_VERSION=$(curl -s https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/Final/ {print $3}' | sort -V | tail -n 1)
-        elif $(expr match "${{ inputs.quarkus-version }}" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
-        then
-          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
-        else
-          export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ inputs.quarkus-repo }} | grep "refs/heads/${{ inputs.quarkus-version }}$\|refs/tags/${{ inputs.quarkus-version }}$" | cut -f 1)
-        fi
-        if [ "$QUARKUS_VERSION" == "" ]
-        then
-          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
-        fi
-        echo ${QUARKUS_VERSION}
-        echo "quarkus-version=${QUARKUS_VERSION}" >> $GITHUB_OUTPUT
-        curl --output native-tests.json https://raw.githubusercontent.com/${{ inputs.quarkus-repo }}/${QUARKUS_VERSION}/.github/native-tests.json
-        tests_json=$(jq -c '.include |= map(select(.["os-name"] | startswith("ubuntu")))' native-tests.json)
-        echo ${tests_json}
-        echo "tests-matrix=${tests_json}" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/get-test-matrix.yml
+    with:
+      quarkus-version: ${{ inputs.quarkus-version }}
+      quarkus-repo: ${{ inputs.quarkus-repo }}
+      os: 'ubuntu'
 
   build-mandrel:
     name: Mandrel build

--- a/.github/workflows/build-vars.yml
+++ b/.github/workflows/build-vars.yml
@@ -1,0 +1,71 @@
+name: Generate build variables
+
+on:
+  workflow_call:
+    inputs:
+      build-type:
+        type: string
+        description: 'Build distribution (Mandrel/GraalVM) from source or grab a release, and control of maven should deploy locally'
+        default: "mandrel-source"
+    outputs:
+      build-from-source:
+        value: ${{ jobs.build-vars.outputs.build-from-source }}
+      distribution:
+        value: ${{ jobs.build-vars.outputs.distribution }}
+      maven-deploy-local:
+        value: ${{ jobs.build-vars.outputs.maven-deploy-local }}
+
+jobs:
+  build-vars:
+    name: Set distribution, build-from-source, and maven-deploy-local variables based on build-type
+    runs-on: ubuntu-latest
+    outputs:
+      build-from-source: ${{ steps.source-build.outputs.build-from-source }}
+      distribution: ${{ steps.distro.outputs.distribution }}
+      maven-deploy-local: ${{ steps.maven-deploy-local.outputs.maven-deploy-local }}
+    steps:
+    - name: Set build-from-source output
+      id: source-build
+      run: |
+        echo "${{ inputs.build-type }}"
+        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f2)
+        if [ "${bfs_token}" == "release" ]
+        then
+          source_build=false
+        elif [ "${bfs_token}" == "source" ]
+        then
+          source_build=true
+        else
+          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
+          exit 1
+        fi
+        echo "source_build=$source_build"
+        echo "build-from-source=$source_build" >> $GITHUB_OUTPUT
+    - name: Set distribution output
+      id: distro
+      run: |
+        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f1)
+        if [ "${bfs_token}" == "graal" ]
+        then
+          distro="graalvm"
+        elif [ "${bfs_token}" == "mandrel" ]
+        then
+          distro="mandrel"
+        else
+          echo "Unexpected input 'build-type' = ${{ inputs.build-type }}"
+          exit 1
+        fi
+        echo "distro=$distro"
+        echo "distribution=$distro" >> $GITHUB_OUTPUT
+    - name: Set maven-deploy-local output
+      id: maven-deploy-local
+      run: |
+        bfs_token=$(echo ${{ inputs.build-type }} | cut -d'-' -f3)
+        if [ "${bfs_token}" == "nolocalmvn" ]
+        then
+          maven_deploy_local=""
+        else
+          maven_deploy_local="--maven-deploy-local"
+        fi
+        echo "maven_deploy_local=$maven_deploy_local"
+        echo "maven-deploy-local=$maven_deploy_local" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-test-matrix.yml
+++ b/.github/workflows/get-test-matrix.yml
@@ -1,0 +1,62 @@
+name: Generate build variables
+
+on:
+  workflow_call:
+    inputs:
+      quarkus-version:
+        type: string
+        description: 'Quarkus version to test (branch, tag, commit, or "latest")'
+        # "latest" is replaced by the latest release available in maven
+        default: "main"
+      quarkus-repo:
+        type: string
+        description: 'The Quarkus repository to be used'
+        default: 'quarkusio/quarkus'
+      os:
+        type: string
+        description: 'The operating system we are building for (ubuntu or windows)'
+        default: 'ubuntu'
+    outputs:
+      quarkus-version:
+        value: ${{ jobs.get-test-matrix.outputs.quarkus-version }}
+      tests-matrix:
+        value: ${{ jobs.get-test-matrix.outputs.tests-matrix }}
+      artifacts-suffix:
+        value: ${{ jobs.get-test-matrix.outputs.artifacts-suffix }}
+
+jobs:
+  get-test-matrix:
+    name: Get test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      quarkus-version: ${{ steps.version.outputs.quarkus-version }}
+      tests-matrix: ${{ steps.version.outputs.tests-matrix }}
+      artifacts-suffix: ${{ steps.suffix.outputs.suffix }}
+    steps:
+    - id: suffix
+      run: |
+        export SUFFIX=$(echo '${{ toJson(inputs) }}' | jq -j 'del(."build-stats-tag", ."mandrel-it-issue-number", ."issue-repo", ."issue-number") | to_entries[] | "-\(.value)"' | tr '":<>|*?\r\n\/' '-')
+        echo $SUFFIX
+        echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
+    - name: Get Quarkus version and test matrix
+      id: version
+      run: |
+        if [ ${{ inputs.quarkus-version }} == "latest" ]
+        then
+          export QUARKUS_VERSION=$(curl -s https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/Final/ {print $3}' | sort -V | tail -n 1)
+        elif $(expr match "${{ inputs.quarkus-version }}" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
+        then
+          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
+        else
+          export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ inputs.quarkus-repo }} | grep "refs/heads/${{ inputs.quarkus-version }}$\|refs/tags/${{ inputs.quarkus-version }}$" | cut -f 1)
+        fi
+        if [ "$QUARKUS_VERSION" == "" ]
+        then
+          export QUARKUS_VERSION=${{ inputs.quarkus-version }}
+        fi
+        echo ${QUARKUS_VERSION}
+        echo "quarkus-version=${QUARKUS_VERSION}" >> $GITHUB_OUTPUT
+        curl --output native-tests.json https://raw.githubusercontent.com/${{ inputs.quarkus-repo }}/${QUARKUS_VERSION}/.github/native-tests.json
+        tests_json=$(jq -c '.include |= map(select(.["os-name"] | startswith("${{ inputs.os }}")))' native-tests.json)
+        echo ${tests_json}
+        echo "tests-matrix=${tests_json}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
De-duplicate jobs.

The motivation behind this is to ultimately build quarkus `main` a single time and re-use with different mandrel builds. At the moment we build quarkus for each configuration, which is a waste of time and resources.

Furthermore, we plan to introduce macOS and linux-arm64 builds to the test matrix, and re-using workflows will make this easier.