### PR TITLE
graalvm-community-jdk21u jdk-21.0.7 for mandrel/23.1

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -5,7 +5,7 @@ suite = {
 
   "groupId" : "org.graalvm.compiler",
   "version" : "23.1.7",
-  "release" : False,
+  "release" : True,
   "url" : "http://www.graalvm.org/",
   "developer" : {
     "name" : "GraalVM Development",

--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -24,7 +24,7 @@ suite = {
     "mxversion": "6.44.0",
     "name": "espresso",
     "version" : "23.1.7",
-    "release" : False,
+    "release" : True,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer" : {

--- a/regex/mx.regex/suite.py
+++ b/regex/mx.regex/suite.py
@@ -44,7 +44,7 @@ suite = {
   "name" : "regex",
 
   "version" : "23.1.7",
-  "release" : False,
+  "release" : True,
   "groupId" : "org.graalvm.regex",
   "url" : "http://www.graalvm.org/",
   "developer" : {

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "6.39.0",
   "name" : "sdk",
   "version" : "23.1.7",
-  "release" : False,
+  "release" : True,
   "sourceinprojectwhitelist" : [],
   "url" : "https://github.com/oracle/graal",
   "groupId" : "org.graalvm.sdk",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -3,7 +3,7 @@ suite = {
     "mxversion": "6.27.1",
     "name": "substratevm",
     "version" : "23.1.7",
-    "release" : False,
+    "release" : True,
     "url" : "https://github.com/oracle/graal/tree/master/substratevm",
 
     "groupId" : "org.graalvm.nativeimage",

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJavaNio.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJavaNio.java
@@ -73,6 +73,7 @@ public class JNIRegistrationJavaNio extends JNIRegistrationUtil implements Inter
         rerunClassInit(a, "sun.nio.ch.Net", "sun.nio.ch.SocketOptionRegistry$LazyInitialization");
         rerunClassInit(a, "sun.nio.ch.AsynchronousSocketChannelImpl$DefaultOptionsHolder", "sun.nio.ch.AsynchronousServerSocketChannelImpl$DefaultOptionsHolder",
                         "sun.nio.ch.DatagramChannelImpl$DefaultOptionsHolder", "sun.nio.ch.ServerSocketChannelImpl$DefaultOptionsHolder", "sun.nio.ch.SocketChannelImpl$DefaultOptionsHolder");
+        rerunClassInit(a, "sun.nio.ch.NioSocketImpl");
         /* Ensure that the interrupt signal handler is initialized at runtime. */
         rerunClassInit(a, "sun.nio.ch.NativeThread");
         rerunClassInit(a, "sun.nio.ch.FileDispatcherImpl", "sun.nio.ch.FileChannelImpl$Unmapper");

--- a/tools/mx.tools/suite.py
+++ b/tools/mx.tools/suite.py
@@ -27,7 +27,7 @@ suite = {
 
     "groupId" : "org.graalvm.tools",
     "version" : "23.1.7",
-    "release" : False,
+    "release" : True,
     "url" : "http://openjdk.java.net/projects/graal",
     "developer" : {
         "name" : "GraalVM Development",

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "6.39.0",
   "name" : "truffle",
   "version" : "23.1.7",
-  "release" : False,
+  "release" : True,
   "groupId" : "org.graalvm.truffle",
   "sourceinprojectwhitelist" : [],
   "url" : "http://openjdk.java.net/projects/graal",

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -2,7 +2,7 @@ suite = {
     "name": "vm",
     "version" : "23.1.7",
     "mxversion": "6.41.0",
-    "release" : False,
+    "release" : True,
     "groupId" : "org.graalvm",
 
     "url" : "http://www.graalvm.org/",


### PR DESCRIPTION
Merge the [jdk-21.0.7](https://github.com/graalvm/graalvm-community-jdk21u/releases/tag/jdk-21.0.7) - or `vm-23.1.7` tag from [graalvm-community-jdk21u](https://github.com/graalvm/graalvm-community-jdk21u) into mandrel/23.1.