### PR TITLE
[CI] Explicitly log the inputs passed to the reusable workflows

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -91,6 +91,10 @@ jobs:
       build-from-source: ${{ steps.source-build.outputs.build-from-source }}
       distribution: ${{ steps.distro.outputs.distribution }}
     steps:
+    - name: Log inputs
+      run: |
+        echo "Inputs:"
+        echo '${{ toJson(inputs) }}' | jq . | tr -d '"' | sed 's/,$//g'
     - name: Set build-from-source output
       id: source-build
       run: |

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -92,6 +92,10 @@ jobs:
       distribution: ${{ steps.distro.outputs.distribution }}
       maven-deploy-local: ${{ steps.maven-deploy-local.outputs.maven-deploy-local }}
     steps:
+    - name: Log inputs
+      run: |
+        echo "Inputs:"
+        echo '${{ toJson(inputs) }}' | jq . | tr -d '"' | sed 's/,$//g'
     - name: Set build-from-source output
       id: source-build
       run: |


### PR DESCRIPTION
As of 2025-04-30 github no longer logs the inputs passed to a reusable workflow. In order for `github-issue-updater.yml` to work we need to ensure the issue-repo and issue-number inputs are present in the logs.