### PR TITLE
Use JDK 24.0.2 (EA) for testing the 24.2 dev tree

### DIFF
--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -35,7 +35,7 @@ jobs:
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
       mandrel-packaging-version: "24.2"
-      jdk: "24/ga"
+      jdk: "24/ea"
   q-main-ea-win:
     name: "Q main M 24.2 windows EA"
     uses: ./.github/workflows/base-windows.yml
@@ -44,4 +44,4 @@ jobs:
       repo: ${{ github.repository }}
       version: ${{ github.ref }}
       mandrel-packaging-version: "24.2"
-      jdk: "24/ga"
+      jdk: "24/ea"


### PR DESCRIPTION
The April release will be 24.2.2 corresponding to the JDK 24.0.2 update and we should test with that JDK to be prepared for breakage caused by the JDK update. We might want to switch to GA again, once 24.0.2 builds are released, though.