### PR TITLE
[CI] Enable assertions

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -59,7 +59,7 @@ on:
       quarkus-additional-build-args-append:
         type: string
         description: 'Additional arguments to append to the quarkus native build command'
-        default: ''
+        default: '-ea,-esa,-J-ea,-J-esa'
     secrets:
       ISSUE_BOT_TOKEN:
         description: 'A token used to report results in GH issues'

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -63,7 +63,7 @@ on:
       quarkus-additional-build-args-append:
         type: string
         description: 'Additional arguments to append to the quarkus native build command'
-        default: ''
+        default: '-ea,-esa,-J-ea,-J-esa'
     secrets:
       ISSUE_BOT_TOKEN:
         description: 'A token used to report results in GH issues'


### PR DESCRIPTION
Opening as draft till upstream graal updates to JDK 26+12, as it currently fails with:

```
 java.lang.NoSuchMethodError: java.lang.StringCoding.implEncodeISOArray([BI[BII)
	at jdk.graal.compiler/jdk.graal.compiler.nodes.graphbuilderconf.InvocationPlugins$Checks.checkResolvable(InvocationPlugins.java:1119)
	at jdk.graal.compiler/jdk.graal.compiler.nodes.graphbuilderconf.InvocationPlugins.register(InvocationPlugins.java:765)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.substitute.SubstitutionInvocationPlugins.register(SubstitutionInvocationPlugins.java:84)
	at jdk.graal.compiler/jdk.graal.compiler.nodes.graphbuilderconf.InvocationPlugins$Registration.register(InvocationPlugins.java:243)
	at jdk.graal.compiler/jdk.graal.compiler.replacements.StandardGraphBuilderPlugins.registerStringCodingPlugins(StandardGraphBuilderPlugins.java:2624)
	at jdk.graal.compiler/jdk.graal.compiler.replacements.StandardGraphBuilderPlugins.registerInvocationPlugins(StandardGraphBuilderPlugins.java:287)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.registerGraphBuilderPlugins(NativeImageGenerator.java:1492)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.initializeBigBang(NativeImageGenerator.java:1314)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.setupNativeImage(NativeImageGenerator.java:1111)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:567)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:534)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:548)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:761)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.start(NativeImageGeneratorRunner.java:163)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:111)
```

due to https://github.com/openjdk/jdk/commit/655dc516c22ac84fccee6b1fdc607c492465be6b#diff-42f5711b7bc39a45a6e647f8e09e69eab24556a282f272017d9b33b42911ee35

Closes https://github.com/graalvm/mandrel/issues/846