### PR TITLE
CI: Support arm64 runners

### DIFF
--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -1,7 +1,7 @@
 # Enable base.yml to be executed as a dispatch workflow with:
 #
 # gh workflow run base-windows-wrapper.yml \
-#  -f quarkus-repo=gsmet/quarkus -f quarkus-version=2.2.4-backports-1 \
+#  -f quarkus-version=gsmet/quarkus:2.2.4-backports-1 \
 #  -f builder-image="quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"
 name: Mandrel-Quarkus windows tests wrapper
 
@@ -10,29 +10,17 @@ on:
     inputs:
       quarkus-version:
         type: string
-        description: 'Quarkus version to test (branch, tag, commit, or "latest")'
+        description: 'Quarkus version to test `<repo>:<version>` (branch, tag, commit, or "latest")'
         # "latest" is replaced by the latest release available in maven
-        default: "main"
-      quarkus-repo:
+        default: "quarkusio/quarkus:main"
+      graalvm-version:
         type: string
-        description: 'The Quarkus repository to be used'
-        default: 'quarkusio/quarkus'
-      repo:
-        type: string
-        description: 'The Mandrel/Graal repository to be used'
-        default: 'graalvm/mandrel'
-      version:
-        type: string
-        description: 'Mandrel version to test (branch, tag, or commit)'
-        default: "graal/master"
+        description: 'Mandrel version to test `<repo>:<version>` (branch, tag, or commit)'
+        default: "graalvm/mandrel:graal/master"
       mandrel-packaging-version:
         type: string
-        description: 'Mandrel packaging version to test (branch, tag, or commit)'
-        default: "master"
-      mandrel-packaging-repo:
-        type: string
-        description: 'Mandrel packaging repository to be used'
-        default: "graalvm/mandrel-packaging"
+        description: 'Mandrel packaging version to test `<repo>:<version>` (branch, tag, or commit)'
+        default: "graalvm/mandrel-packaging:master"
       build-type:
         type: choice
         description: 'Build distribution (mandrel/graal) from source or use released binaries'
@@ -64,15 +52,39 @@ on:
         default: "null"
 
 jobs:
+  process-inputs:
+    name: Process inputs
+    runs-on: ubuntu-latest
+    outputs:
+      quarkus-version: ${{ steps.process.outputs.quarkus-version }}
+      quarkus-repo: ${{ steps.process.outputs.quarkus-repo }}
+      mandrel-version: ${{ steps.process.outputs.mandrel-version }}
+      mandrel-repo: ${{ steps.process.outputs.mandrel-repo }}
+      mandrel-packaging-version: ${{ steps.process.outputs.mandrel-packaging-version }}
+      mandrel-packaging-repo: ${{ steps.process.outputs.mandrel-packaging-repo }}
+      build-type: ${{ steps.process.outputs.build-type }}
+      jdk: ${{ steps.process.outputs.jdk }}
+      builder-image: ${{ steps.process.outputs.builder-image }}
+      build-stats-tag: ${{ steps.process.outputs.build-stats-tag }}
+    steps:
+      - id: process
+        run: |
+          echo "quarkus-repo=$(echo ${{ github.event.inputs.quarkus-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
+          echo "quarkus-version=$(echo ${{ github.event.inputs.quarkus-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
+          echo "mandrel-repo=$(echo ${{ github.event.inputs.graalvm-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
+          echo "mandrel-version=$(echo ${{ github.event.inputs.graalvm-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
+          echo "mandrel-packaging-repo=$(echo ${{ github.event.inputs.mandrel-packaging-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
+          echo "mandrel-packaging-version=$(echo ${{ github.event.inputs.mandrel-packaging-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
   delegate:
     uses: ./.github/workflows/base-windows.yml
     with:
-      quarkus-version: ${{ github.event.inputs.quarkus-version }}
-      quarkus-repo: ${{ github.event.inputs.quarkus-repo }}
-      repo: ${{ github.event.inputs.repo }}
-      version: ${{ github.event.inputs.version }}
-      mandrel-packaging-version: ${{ github.event.inputs.mandrel-packaging-version }}
-      mandrel-packaging-repo: ${{ github.event.inputs.mandrel-packaging-repo }}
+      quarkus-version: ${{ needs.process-inputs.outputs.quarkus-version }}
+      quarkus-repo: ${{ needs.process-inputs.outputs.quarkus-repo }}
+      mandrel-version: ${{ needs.process-inputs.outputs.mandrel-version }}
+      mandrel-repo: ${{ needs.process-inputs.outputs.mandrel-repo }}
+      mandrel-packaging-version: ${{ needs.process-inputs.outputs.mandrel-packaging-version }}
+      mandrel-packaging-repo: ${{ needs.process-inputs.outputs.mandrel-packaging-repo }}
       build-type: ${{ github.event.inputs.build-type }}
       jdk: ${{ github.event.inputs.jdk }}
       # builder-image: ${{ github.event.inputs.builder-image }}

--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -44,7 +44,7 @@ on:
           - "latest/labsjdk"
       builder-image:
         type: string
-        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
+        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21)'
         default: "null"
       build-stats-tag:
         type: string

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -38,7 +38,7 @@ on:
         default: "17/ga"
       # Builder image can't be tested on Windows due to https://github.com/actions/virtual-environments/issues/1143
       # builder-image:
-      #   description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
+      #   description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21)'
       #   default: "null"
       issue-number:
         type: string

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -12,11 +12,11 @@ on:
         type: string
         description: 'The Quarkus repository to be used'
         default: 'quarkusio/quarkus'
-      version:
+      mandrel-version:
         type: string
         description: 'Mandrel version to test (branch, tag, or commit)'
         default: "graal/master"
-      repo:
+      mandrel-repo:
         type: string
         description: 'The Mandrel/Graal repository to be used'
         default: 'graalvm/mandrel'
@@ -175,9 +175,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        repository: ${{ inputs.repo }}
+        repository: ${{ inputs.mandrel-repo }}
         fetch-depth: 1
-        ref: ${{ inputs.version }}
+        ref: ${{ inputs.mandrel-version }}
         path: ${{ env.MANDREL_REPO }}
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -257,9 +257,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        repository: ${{ inputs.repo }}
+        repository: ${{ inputs.mandrel-repo }}
         fetch-depth: 1
-        ref: ${{ inputs.version }}
+        ref: ${{ inputs.mandrel-version }}
         path: graal
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -320,10 +320,10 @@ jobs:
       - build-vars
     if: fromJson(needs.build-vars.outputs.build-from-source) == false
     steps:
-    - name: Get Mandrel ${{ inputs.version }}
+    - name: Get Mandrel ${{ inputs.mandrel-version }}
       if: needs.build-vars.outputs.distribution == 'mandrel'
       run: |
-        $VERSION="${{ inputs.version }}"
+        $VERSION="${{ inputs.mandrel-version }}"
         $VERSION_SHORT=@($VERSION -replace 'mandrel-')
         $wc = New-Object System.Net.WebClient
         $url="$Env:GITHUB_SERVER_URL/graalvm/mandrel/releases/download/${VERSION}/mandrel-java$(("${{ inputs.jdk }}" -split "/")[0])-windows-amd64-${VERSION_SHORT}.zip"
@@ -331,10 +331,10 @@ jobs:
         Expand-Archive "mandrel.zip" -DestinationPath "$Env:temp"
         Move-Item -Path "$Env:temp\mandrel-*" -Destination $Env:JAVA_HOME
         & $Env:JAVA_HOME\bin\native-image --version
-    - name: Get GraalVM CE ${{ inputs.version }}
+    - name: Get GraalVM CE ${{ inputs.mandrel-version }}
       if: needs.build-vars.outputs.distribution == 'graalvm'
       run: |
-        $VERSION="${{ inputs.version }}"
+        $VERSION="${{ inputs.mandrel-version }}"
         $VERSION_SHORT=@($VERSION -replace 'vm-')
         $wc = New-Object System.Net.WebClient
         $url="$Env:GITHUB_SERVER_URL/graalvm/graalvm-ce-builds/releases/download/${VERSION}/graalvm-ce-java$(("${{ inputs.jdk }}" -split "/")[0])-windows-amd64-${VERSION_SHORT}.zip"

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -1,7 +1,7 @@
 # Enable base.yml to be executed as a dispatch workflow with:
 #
 # gh workflow run base-wrapper.yml \
-#  -f quarkus-repo=gsmet/quarkus -f quarkus-version=2.2.4-backports-1 \
+#  -f quarkus-version=gsmet/quarkus:2.2.4-backports-1 \
 #  -f builder-image="quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"
 name: Mandrel-Quarkus tests wrapper
 
@@ -10,29 +10,17 @@ on:
     inputs:
       quarkus-version:
         type: string
-        description: 'Quarkus version to test (branch, tag, commit, or "latest")'
+        description: 'Quarkus version to test `<repo>:<version>` (branch, tag, commit, or "latest")'
         # "latest" is replaced by the latest release available in maven
-        default: "main"
-      quarkus-repo:
+        default: "quarkusio/quarkus:main"
+      graalvm-version:
         type: string
-        description: 'The Quarkus repository to be used'
-        default: 'quarkusio/quarkus'
-      repo:
-        type: string
-        description: 'The Mandrel/Graal repository to be used'
-        default: 'graalvm/mandrel'
-      version:
-        type: string
-        description: 'Mandrel version to test (branch, tag, or commit)'
-        default: "graal/master"
+        description: 'Mandrel version to test `<repo>:<version>` (branch, tag, or commit)'
+        default: "graalvm/mandrel:graal/master"
       mandrel-packaging-version:
         type: string
-        description: 'Mandrel packaging version to test (branch, tag, or commit)'
-        default: "master"
-      mandrel-packaging-repo:
-        type: string
-        description: 'Mandrel packaging repository to be used'
-        default: "graalvm/mandrel-packaging"
+        description: 'Mandrel packaging version to test `<repo>:<version>` (branch, tag, or commit)'
+        default: "graalvm/mandrel-packaging:master"
       build-type:
         type: choice
         description: 'Build distribution (graal/mandrel) from source or use released binaries, and control of maven should deploy locally'
@@ -64,20 +52,54 @@ on:
         type: string
         description: 'The tag to use for build stats uploads of native tests (e.g. 22.3.0-dev-jdk17-prepatch-x)'
         default: "null"
+      gh-runner:
+        type: choice
+        description: 'The github runner we are building for'
+        default: "ubuntu-latest"
+        options:
+          - "ubuntu-latest"
+          - "ubuntu-24.04"
+          - "ubuntu-24.04-arm"
 
 jobs:
+  process-inputs:
+    name: Process inputs
+    runs-on: ubuntu-latest
+    outputs:
+      quarkus-version: ${{ steps.process.outputs.quarkus-version }}
+      quarkus-repo: ${{ steps.process.outputs.quarkus-repo }}
+      mandrel-version: ${{ steps.process.outputs.mandrel-version }}
+      mandrel-repo: ${{ steps.process.outputs.mandrel-repo }}
+      mandrel-packaging-version: ${{ steps.process.outputs.mandrel-packaging-version }}
+      mandrel-packaging-repo: ${{ steps.process.outputs.mandrel-packaging-repo }}
+      build-type: ${{ steps.process.outputs.build-type }}
+      jdk: ${{ steps.process.outputs.jdk }}
+      builder-image: ${{ steps.process.outputs.builder-image }}
+      build-stats-tag: ${{ steps.process.outputs.build-stats-tag }}
+    steps:
+      - id: process
+        run: |
+          echo "quarkus-repo=$(echo ${{ github.event.inputs.quarkus-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
+          echo "quarkus-version=$(echo ${{ github.event.inputs.quarkus-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
+          echo "mandrel-repo=$(echo ${{ github.event.inputs.graalvm-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
+          echo "mandrel-version=$(echo ${{ github.event.inputs.graalvm-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
+          echo "mandrel-packaging-repo=$(echo ${{ github.event.inputs.mandrel-packaging-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
+          echo "mandrel-packaging-version=$(echo ${{ github.event.inputs.mandrel-packaging-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
   delegate:
+    needs: process-inputs
     uses: ./.github/workflows/base.yml
     with:
-      quarkus-version: ${{ github.event.inputs.quarkus-version }}
-      quarkus-repo: ${{ github.event.inputs.quarkus-repo }}
-      repo: ${{ github.event.inputs.repo }}
-      version: ${{ github.event.inputs.version }}
-      mandrel-packaging-version: ${{ github.event.inputs.mandrel-packaging-version }}
-      mandrel-packaging-repo: ${{ github.event.inputs.mandrel-packaging-repo }}
+      quarkus-version: ${{ needs.process-inputs.outputs.quarkus-version }}
+      quarkus-repo: ${{ needs.process-inputs.outputs.quarkus-repo }}
+      mandrel-version: ${{ needs.process-inputs.outputs.mandrel-version }}
+      mandrel-repo: ${{ needs.process-inputs.outputs.mandrel-repo }}
+      mandrel-packaging-version: ${{ needs.process-inputs.outputs.mandrel-packaging-version }}
+      mandrel-packaging-repo: ${{ needs.process-inputs.outputs.mandrel-packaging-repo }}
       build-type: ${{ github.event.inputs.build-type }}
       jdk: ${{ github.event.inputs.jdk }}
       builder-image: ${{ github.event.inputs.builder-image }}
       build-stats-tag: ${{ github.event.inputs.build-stats-tag }}
+      gh-runner: ${{ github.event.inputs.gh-runner }}
     secrets:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -2,7 +2,7 @@
 #
 # gh workflow run base-wrapper.yml \
 #  -f quarkus-version=gsmet/quarkus:2.2.4-backports-1 \
-#  -f builder-image="quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11"
+#  -f builder-image="quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21"
 name: Mandrel-Quarkus tests wrapper
 
 on:
@@ -46,7 +46,7 @@ on:
           - "latest/labsjdk"
       builder-image:
         type: string
-        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
+        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21)'
         default: "null"
       build-stats-tag:
         type: string

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -38,7 +38,7 @@ on:
         default: "17/ga"
       builder-image:
         type: string
-        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
+        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21)'
         default: "null"
       issue-number:
         type: string

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -12,14 +12,14 @@ on:
         type: string
         description: 'The Quarkus repository to be used'
         default: 'quarkusio/quarkus'
-      repo:
-        type: string
-        description: 'The Mandrel/Graal repository to be used'
-        default: 'graalvm/mandrel'
-      version:
+      mandrel-version:
         type: string
         description: 'Mandrel version to test (branch, tag, or commit)'
         default: "graal/master"
+      mandrel-repo:
+        type: string
+        description: 'The Mandrel/Graal repository to be used'
+        default: 'graalvm/mandrel'
       mandrel-packaging-version:
         type: string
         description: 'Mandrel packaging version to test (branch, tag, or commit)'
@@ -56,6 +56,10 @@ on:
         type: string
         description: 'The tag to use for build stats upload of native tests (e.g. 22.3.0-dev-jdk17-mytest-patch-before)'
         default: "null"
+      gh-runner:
+        type: string
+        description: 'The github runner we are building on'
+        default: 'ubuntu-latest'
     secrets:
       ISSUE_BOT_TOKEN:
         description: 'A token used to report results in GH issues'
@@ -86,11 +90,12 @@ env:
 jobs:
   build-vars:
     name: Set distribution, build-from-source, and maven-deploy-local variables based on build-type
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.gh-runner }}
     outputs:
       build-from-source: ${{ steps.source-build.outputs.build-from-source }}
       distribution: ${{ steps.distro.outputs.distribution }}
       maven-deploy-local: ${{ steps.maven-deploy-local.outputs.maven-deploy-local }}
+      architecture: ${{ steps.arch.outputs.architecture }}
     steps:
     - name: Log inputs
       run: |
@@ -147,6 +152,16 @@ jobs:
         fi
         echo "maven_deploy_local=$maven_deploy_local"
         echo "maven-deploy-local=$maven_deploy_local" >> $GITHUB_OUTPUT
+    - name: Set architecture output
+      id: arch
+      run: |
+        if [ "${{ runner.arch }}" == "X64" ]
+        then
+          ARCH="amd64"
+        else
+          ARCH="aarch64"
+        fi
+        echo "architecture=$ARCH" >> $GITHUB_OUTPUT
 
   get-test-matrix:
     name: Get test matrix
@@ -195,7 +210,7 @@ jobs:
 
   build-mandrel:
     name: Mandrel build
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.gh-runner }}
     needs:
       - get-test-matrix
       - build-vars
@@ -203,9 +218,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        repository: ${{ inputs.repo }}
+        repository: ${{ inputs.mandrel-repo }}
         fetch-depth: 1
-        ref: ${{ inputs.version }}
+        ref: ${{ inputs.mandrel-version }}
         path: ${{ env.MANDREL_REPO }}
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -229,8 +244,15 @@ jobs:
         restore-keys: ${{ runner.os }}-mx-
     - name: Get OpenJDK with static libs
       run: |
-        curl -sL https://api.adoptium.net/v3/binary/latest/${{ inputs.jdk }}/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
-        curl -sL https://api.adoptium.net/v3/binary/latest/${{ inputs.jdk }}/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        if [ "${{ runner.arch }}" == "X64" ]
+        then
+          ARCH="x64"
+        else
+          ARCH="aarch64"
+        fi
+        echo "architecture=$ARCH" >> $GITHUB_OUTPUT
+        curl -sL https://api.adoptium.net/v3/binary/latest/${{ inputs.jdk }}/linux/${ARCH}/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/${{ inputs.jdk }}/linux/${ARCH}/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
         mkdir -p ${JAVA_HOME}
         tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
         tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
@@ -254,7 +276,7 @@ jobs:
           --archive-suffix tar.gz \
           "${{needs.build-vars.outputs.maven-deploy-local}}"
         ${MANDREL_HOME}/bin/native-image --version
-        mv mandrel-java*-linux-amd64-*.tar.gz ${{ github.workspace }}/jdk.tgz
+        mv mandrel-java*-linux-${{ needs.build-vars.outputs.architecture }}*.tar.gz ${{ github.workspace }}/jdk.tgz
         if [ "$MVN_LOCAL" != "" ]
         then
           rm -rf graalvm-maven-artefacts.tgz && tar -czvf graalvm-maven-artefacts.tgz -C ~ .m2/repository/org/graalvm
@@ -292,7 +314,7 @@ jobs:
 
   build-graal:
     name: GraalVM CE build
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.gh-runner }}
     needs:
       - get-test-matrix
       - build-vars
@@ -300,9 +322,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        repository: ${{ inputs.repo }}
+        repository: ${{ inputs.mandrel-repo }}
         fetch-depth: 1
-        ref: ${{ inputs.version }}
+        ref: ${{ inputs.mandrel-version }}
         path: graal
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -384,27 +406,27 @@ jobs:
 
   get-jdk:
     name: Get JDK ${{ inputs.jdk }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.gh-runner }}
     needs:
       - get-test-matrix
       - build-vars
     if: fromJson(needs.build-vars.outputs.build-from-source) == false && inputs.builder-image == 'null'
     steps:
-    - name: Get Mandrel ${{ inputs.version }}
+    - name: Get Mandrel ${{ inputs.mandrel-version }}
       if: needs.build-vars.outputs.distribution == 'mandrel'
       run: |
-        VERSION=${{ inputs.version }}
+        VERSION=${{ inputs.mandrel-version }}
         echo "**Mandrel version:** [$VERSION](${GITHUB_SERVER_URL}/graalvm/mandrel/releases/tag/$VERSION)" >> $GITHUB_STEP_SUMMARY
         curl \
-          -sL ${GITHUB_SERVER_URL}/graalvm/mandrel/releases/download/${VERSION}/mandrel-java$(echo ${{ inputs.jdk }} | cut -d / -f 1)-linux-amd64-${VERSION##mandrel-}.tar.gz \
+          -sL ${GITHUB_SERVER_URL}/graalvm/mandrel/releases/download/${VERSION}/mandrel-java$(echo ${{ inputs.jdk }} | cut -d / -f 1)-linux-${{ needs.build-vars.outputs.architecture }}-${VERSION##mandrel-}.tar.gz \
           -o jdk.tgz
-    - name: Get GraalVM CE ${{ inputs.version }}
+    - name: Get GraalVM CE ${{ inputs.mandrel-version }}
       if: needs.build-vars.outputs.distribution == 'graalvm'
       run: |
-        VERSION=${{ inputs.version }}
+        VERSION=${{ inputs.mandrel-version }}
         echo "**GraalVM version:** [$VERSION](${GITHUB_SERVER_URL}/oracle/graal/releases/tag/$VERSION)" >> $GITHUB_STEP_SUMMARY
         curl \
-          -sL ${GITHUB_SERVER_URL}/graalvm/graalvm-ce-builds/releases/download/${VERSION}/graalvm-ce-java$(echo ${{ inputs.jdk }} | cut -d / -f 1)-linux-amd64-${VERSION##vm-}.tar.gz \
+          -sL ${GITHUB_SERVER_URL}/graalvm/graalvm-ce-builds/releases/download/${VERSION}/graalvm-ce-java$(echo ${{ inputs.jdk }} | cut -d / -f 1)-linux-${{ needs.build-vars.outputs.architecture }}-${VERSION##vm-}.tar.gz \
           -o graalvm.tgz
         mkdir -p ${JAVA_HOME}
         tar xzvf graalvm.tgz -C ${JAVA_HOME} --strip-components=1
@@ -444,7 +466,7 @@ jobs:
       - build-quarkus
       - get-test-matrix
     if: always() && needs.build-quarkus.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.gh-runner }}
     env:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g
@@ -547,6 +569,11 @@ jobs:
             # Build main module with constraint memory to ensure we can build apps on smaller machines too
             export NEW_MAX_HEAP_SIZE=-Dquarkus.native.native-image-xmx=5g
           fi
+          # Remove DB2 and Oracle modules on ARM runners as the dev services fail to run
+          if [[ "${{ runner.arch }}" == "ARM64" ]]; then
+            TEST_MODULES=$(echo $TEST_MODULES | tr ',' '\n' | grep -viE 'db2|oracle' | paste -sd, -)
+            echo "Filtered TEST_MODULES for ARM: $TEST_MODULES"
+          fi
           ./mvnw -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml -f integration-tests -pl "$TEST_MODULES" -amd $BUILDER_IMAGE $NATIVE_TEST_MAVEN_OPTS $NEW_MAX_HEAP_SIZE
       - name: Prepare failure archive (if maven failed)
         if: failure()
@@ -592,7 +619,7 @@ jobs:
       - get-jdk
       - build-quarkus
       - get-test-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.gh-runner }}
     env:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g

--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -13,7 +13,7 @@ on:
         default: true
       builder-image:
         type: string
-        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
+        description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21)'
         default: "null"
       maven-deploy-local:
         type: string
@@ -34,7 +34,7 @@ on:
         default: "main"
       # Builder image can't be tested on Windows due to https://github.com/actions/virtual-environments/issues/1143
       # builder-image:
-      #   description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11)'
+      #   description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21)'
       #   default: "null"
 
 env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
-      version: "graal/master"
+      mandrel-version: "graal/master"
       build-type: "graal-source"
       jdk: "latest/ea"
       build-stats-tag: "gha-linux-graal-qmain-glatest-jdk26ea"
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
-      version: "graal/master"
+      mandrel-version: "graal/master"
       jdk: "26/ea"
       issue-number: "855"
       issue-repo: "graalvm/mandrel"
@@ -63,7 +63,7 @@ jobs:
     uses: ./.github/workflows/base-windows.yml
     with:
       quarkus-version: "main"
-      version: "graal/master"
+      mandrel-version: "graal/master"
       issue-number: "856"
       issue-repo: "graalvm/mandrel"
       mandrel-it-issue-number: "347"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
-      version: "mandrel/25.0"
+      mandrel-version: "mandrel/25.0"
       jdk: "25/ea"
       issue-number: "853"
       issue-repo: "graalvm/mandrel"
@@ -53,13 +53,49 @@ jobs:
     uses: ./.github/workflows/base-windows.yml
     with:
       quarkus-version: "main"
-      version: "mandrel/25.0"
+      mandrel-version: "mandrel/25.0"
       issue-number: "854"
       issue-repo: "graalvm/mandrel"
       mandrel-it-issue-number: "345"
       jdk: "25/ea"
       build-stats-tag: "gha-win-mandrel-qmain-m25_0-jdk25ea"
       mandrel-packaging-version: "25.0"
+    secrets:
+      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+  ####
+  # Test Quarkus main with Mandrel for JDK 25 on AArch64
+  ####
+  q-main-mandrel-25-latest:
+    name: "Q main M 25 latest on AArch64"
+    uses: ./.github/workflows/base.yml
+    with:
+      quarkus-version: "main"
+      mandrel-version: "graal/master"
+      jdk: "25/ea"
+      issue-number: "830"
+      issue-repo: "graalvm/mandrel"
+      mandrel-it-issue-number: "318"
+      build-stats-tag: "gha-linux-aarch64-mandrel-qmain-mlatest-jdk25ea"
+      gh-runner: "ubuntu-24.04-arm"
+    secrets:
+      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+  ####
+  # Test Quarkus main with Mandrel latest on AArch64
+  ####
+  q-main-mandrel-26-latest:
+    name: "Q main M 26 latest on AArch64"
+    uses: ./.github/workflows/base.yml
+    with:
+      quarkus-version: "main"
+      mandrel-version: "graal/master"
+      jdk: "26/ea"
+      issue-number: "872"
+      issue-repo: "graalvm/mandrel"
+      mandrel-it-issue-number: "359"
+      build-stats-tag: "gha-linux-aarch64-mandrel-qmain-mlatest-jdk26ea"
+      gh-runner: "ubuntu-24.04-arm"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
@@ -71,7 +107,7 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
-      version: "mandrel/24.2"
+      mandrel-version: "mandrel/24.2"
       jdk: "24/ea"
       issue-number: "814"
       issue-repo: "graalvm/mandrel"
@@ -86,7 +122,7 @@ jobs:
     uses: ./.github/workflows/base-windows.yml
     with:
       quarkus-version: "main"
-      version: "mandrel/24.2"
+      mandrel-version: "mandrel/24.2"
       jdk: "24/ea"
       issue-number: "815"
       issue-repo: "graalvm/mandrel"
@@ -104,7 +140,7 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
-      version: "mandrel/23.1"
+      mandrel-version: "mandrel/23.1"
       jdk: "21/ea"
       issue-number: "739"
       issue-repo: "graalvm/mandrel"
@@ -119,7 +155,7 @@ jobs:
     uses: ./.github/workflows/base-windows.yml
     with:
       quarkus-version: "main"
-      version: "mandrel/23.1"
+      mandrel-version: "mandrel/23.1"
       jdk: "21/ea"
       issue-number: "740"
       issue-repo: "graalvm/mandrel"


### PR DESCRIPTION
* Changes the way we pass repositories and versions/tags/branches so
  that we can use a single input for each pair,
  e.g. `graalvm/mandrel:graal/master` which is `<repo>:<version>`
* Adds new `gh-runner` input to allow us to chose `ubuntu-24.04-arm` and macos
  at some point in the future.
* Introduces two new weekly builds on AArch64
* Skips DB2 ITs on AArch64 due to missing docker images required by the
  dev services.