### PR TITLE
[CI] Fix weekly workflow file

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -66,7 +66,7 @@ jobs:
   ####
   # Test Quarkus main with Mandrel for JDK 25 on AArch64
   ####
-  q-main-mandrel-25-latest:
+  q-main-mandrel-25-latest-arm:
     name: "Q main M 25 latest on AArch64"
     uses: ./.github/workflows/base.yml
     with:


### PR DESCRIPTION
We were getting this error message:
```
Invalid workflow file: .github/workflows/weekly.yml#L1
(Line: 69, Col: 3): 'q-main-mandrel-25-latest' is already defined
```
See: https://github.com/graalvm/mandrel/actions/runs/17263809916

This fixes the duplication issue by adding the `-arm` suffix.