### PR TITLE
[CI] No longer build Mandrel with graal/master

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   ####
-  # Test Quarkus main with latest graal sources built as Mandrel and GraalVM
+  # Test Quarkus main with latest graal sources built as GraalVM
   ####
   q-main-graal-25-latest:
     name: "Q main G 25 latest"
@@ -43,32 +43,4 @@ jobs:
       jdk: "latest/ea"
       build-stats-tag: "gha-linux-graal-qmain-glatest-jdk25ea"
     secrets:
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-mandrel-25-latest:
-    name: "Q main M 25 latest"
-    uses: ./.github/workflows/base.yml
-    with:
-      quarkus-version: "main"
-      mandrel-version: "graal/master"
-      jdk: "25/ea"
-      issue-number: "885"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "366"
-      build-stats-tag: "gha-linux-mandrel-qmain-mlatest-jdk25ea"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-mandrel-25-latest-win:
-    name: "Q main M 25 latest windows"
-    uses: ./.github/workflows/base-windows.yml
-    with:
-      quarkus-version: "main"
-      mandrel-version: "graal/master"
-      issue-number: "884"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "367"
-      jdk: "25/ea"
-      build-stats-tag: "gha-win-mandrel-qmain-mlatest-jdk25ea"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -83,24 +83,6 @@ jobs:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
-  # Test Quarkus main with Mandrel latest on AArch64
-  ####
-  q-main-mandrel-25-latest-arm:
-    name: "Q main M 25 latest on AArch64"
-    uses: ./.github/workflows/base.yml
-    with:
-      quarkus-version: "main"
-      mandrel-version: "graal/master"
-      jdk: "25/ea"
-      issue-number: "886"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "368"
-      build-stats-tag: "gha-linux-aarch64-mandrel-qmain-mlatest-jdk25ea"
-      gh-runner: "ubuntu-24.04-arm"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  ####
   # Test Q main and Mandrel 23.1 JDK 21
   ####
   q-main-mandrel-23_1:


### PR DESCRIPTION
Graal master switched to an incompatible (to OpenJDK) version as a base JDK. It now needs Labs OpenJDK 25 with extra patches. There is not point in trying to test the Mandrel config (which uses stock OpenJDK as base JDK) with graal/master as it would fail.

We keep the configuration which uses LabsJDK.