### PR TITLE
[CI] Fix issue number reporting for GraalVM CE graal/master builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,7 @@ jobs:
       jdk: "latest/ea"
       build-stats-tag: "gha-linux-graal-qmain-glatest-jdk25ea"
       issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "898"
+      issue-number: "898"
+      mandrel-it-issue-number: "366"
     secrets:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}


### PR DESCRIPTION
Issue number referenced is an issue number in graalvm/mandrel, not karm/mandrel-integration-tests. Fix that and use an actual existing issue for Mandrel IT test failures.

Issue reporting currently fails with:
```
 Getting logs for job Q main G 25 latest / Set distribution, build-from-source, and maven-deploy-local variables based on build-type
* Found issue https://github.com/karm/mandrel-integration-tests/issues/898
  in logs for job Q main G 25 latest / Set distribution, build-from-source, and maven-deploy-local variables based on build-type
java.io.UncheckedIOException: org.kohsuke.github.GHFileNotFoundException: https://api.github.com/repos/Karm/mandrel-integration-tests/issues/898 {"message":"Not Found","documentation_url":"https://docs.github.com/rest/issues/issues#get-an-issue","status":"404"}
	at Report.processLogs(quarkus-ecosystem-issue.java:247)
	at Report.lambda$run$0(quarkus-ecosystem-issue.java:132)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at Report.run(quarkus-ecosystem-issue.java:129)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2469)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2423)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2425)
	at picocli.CommandLine.execute(CommandLine.java:2174)
	at Report.main(quarkus-ecosystem-issue.java:376)
Caused by: org.kohsuke.github.GHFileNotFoundException: https://api.github.com/repos/Karm/mandrel-integration-tests/issues/898 {"message":"Not Found","documentation_url":"https://docs.github.com/rest/issues/issues#get-an-issue","status":"404"}
	at org.kohsuke.github.GitHubClient.interpretApiError(GitHubClient.java:737)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:480)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:427)
	at org.kohsuke.github.Requester.fetch(Requester.java:85)
	at org.kohsuke.github.GHRepository.getIssue(GHRepository.java:407)
	at Report.processLogs(quarkus-ecosystem-issue.java:244)
	... 12 more
Caused by: java.io.FileNotFoundException: https://api.github.com/repos/Karm/mandrel-integration-tests/issues/898
	at org.kohsuke.github.GitHubConnectorResponseErrorHandler$1.onError(GitHubConnectorResponseErrorHandler.java:84)
	at org.kohsuke.github.GitHubClient.detectKnownErrors(GitHubClient.java:504)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:464)
	... 16 more
Error: Process completed with exit code 1.
```

See: https://github.com/graalvm/mandrel/actions/runs/18394200964/job/52410265111#step:5:180