### PR TITLE
[CI] Support augmenting quarkus native additional build arguments

### DIFF
--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -50,6 +50,10 @@ on:
         type: string
         description: 'The tag to use for build stats uploads of native tests (e.g. 22.3.0-dev-jdk17-prepatch-x)'
         default: "null"
+      quarkus-additional-build-args:
+        type: string
+        description: 'Additional arguments to append to the quarkus native build command'
+        default: ''
 
 jobs:
   process-inputs:
@@ -89,5 +93,6 @@ jobs:
       jdk: ${{ github.event.inputs.jdk }}
       # builder-image: ${{ github.event.inputs.builder-image }}
       build-stats-tag: ${{ github.event.inputs.build-stats-tag }}
+      quarkus-additional-build-args-append: ${{ github.event.inputs.quarkus-additional-build-args }}
     secrets:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -56,6 +56,10 @@ on:
         type: string
         description: 'The tag to use for build stats upload of native tests (e.g. 22.3.0-dev-jdk17-mytest-patch-before)'
         default: "null"
+      quarkus-additional-build-args-append:
+        type: string
+        description: 'Additional arguments to append to the quarkus native build command'
+        default: ''
     secrets:
       ISSUE_BOT_TOKEN:
         description: 'A token used to report results in GH issues'
@@ -72,6 +76,7 @@ env:
   DB_NAME: hibernate_orm_test
   COMMON_MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
   NATIVE_TEST_MAVEN_OPTS: "-Dtest-containers -Dstart-containers -DfailIfNoTests=false -Dquarkus.native.native-image-xmx=13g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests -DskipDocs"
+  QUARKUS_NATIVE_ADDITIONAL_BUILD_ARGS_APPEND: ${{ inputs.quarkus-additional-build-args-append }}
   MX_GIT_CACHE: refcache
   JAVA_HOME: ${{ github.workspace }}\openjdk
   GRAALVM_HOME: ${{ github.workspace }}\graalvm-home

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -60,6 +60,10 @@ on:
           - "ubuntu-latest"
           - "ubuntu-24.04"
           - "ubuntu-24.04-arm"
+      quarkus-additional-build-args:
+        type: string
+        description: 'Additional arguments to append to the quarkus native build command'
+        default: ''
 
 jobs:
   process-inputs:
@@ -101,5 +105,6 @@ jobs:
       builder-image: ${{ github.event.inputs.builder-image }}
       build-stats-tag: ${{ github.event.inputs.build-stats-tag }}
       gh-runner: ${{ github.event.inputs.gh-runner }}
+      quarkus-additional-build-args-append: ${{ github.event.inputs.quarkus-additional-build-args }}
     secrets:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -60,6 +60,10 @@ on:
         type: string
         description: 'The github runner we are building on'
         default: 'ubuntu-latest'
+      quarkus-additional-build-args-append:
+        type: string
+        description: 'Additional arguments to append to the quarkus native build command'
+        default: ''
     secrets:
       ISSUE_BOT_TOKEN:
         description: 'A token used to report results in GH issues'
@@ -75,6 +79,7 @@ env:
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test
   NATIVE_TEST_MAVEN_OPTS: "--fail-at-end -Dtest-containers -Dstart-containers -DfailIfNoTests=false -Dquarkus.native.native-image-xmx=13g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs"
+  QUARKUS_NATIVE_ADDITIONAL_BUILD_ARGS_APPEND: ${{ inputs.quarkus-additional-build-args-append }}
   MX_GIT_CACHE: refcache
   JAVA_HOME: ${{ github.workspace }}/openjdk
   GRAALVM_HOME: ${{ github.workspace }}/graalvm-home


### PR DESCRIPTION
Being tested in:

* https://github.com/zakkak/mandrel/actions/runs/18968555417 with `-ea,-esa,-J-ea,-J-esa`
* https://github.com/zakkak/mandrel/actions/runs/18968568560 with no additional args