### PR TITLE
Merge upstream branch 'release/graal-vm/25.0' into mandrel/25.0

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -4,8 +4,8 @@ suite = {
   "sourceinprojectwhitelist" : [],
 
   "groupId" : "org.graalvm.compiler",
-  "version" : "25.0.1",
-  "release" : True,
+  "version" : "25.0.2",
+  "release" : False,
   "url" : "http://www.graalvm.org/",
   "developer" : {
     "name" : "GraalVM Development",

--- a/espresso-compiler-stub/mx.espresso-compiler-stub/suite.py
+++ b/espresso-compiler-stub/mx.espresso-compiler-stub/suite.py
@@ -24,8 +24,8 @@
 suite = {
     "mxversion": "7.33.0",
     "name": "espresso-compiler-stub",
-    "version": "24.2.0",
-    "release": True,
+    "version": "25.0.2",
+    "release": False,
     "groupId": "org.graalvm.espresso",
     "url": "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer": {

--- a/espresso-shared/mx.espresso-shared/suite.py
+++ b/espresso-shared/mx.espresso-shared/suite.py
@@ -25,8 +25,8 @@
 suite = {
     "mxversion": "7.38.0",
     "name": "espresso-shared",
-    "version" : "25.0.1",
-    "release" : True,
+    "version" : "25.0.2",
+    "release" : False,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer" : {

--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -24,8 +24,8 @@
 suite = {
     "mxversion": "7.46.0",
     "name": "espresso",
-    "version" : "25.0.1",
-    "release" : True,
+    "version" : "25.0.2",
+    "release" : False,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer" : {

--- a/regex/mx.regex/suite.py
+++ b/regex/mx.regex/suite.py
@@ -43,8 +43,8 @@ suite = {
 
   "name" : "regex",
 
-  "version" : "25.0.1",
-  "release" : True,
+  "version" : "25.0.2",
+  "release" : False,
   "groupId" : "org.graalvm.regex",
   "url" : "http://www.graalvm.org/",
   "developer" : {

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -41,8 +41,8 @@
 suite = {
   "mxversion": "7.54.5",
   "name" : "sdk",
-  "version" : "25.0.1",
-  "release" : True,
+  "version" : "25.0.2",
+  "release" : False,
   "sourceinprojectwhitelist" : [],
   "url" : "https://github.com/oracle/graal",
   "groupId" : "org.graalvm.sdk",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -2,8 +2,8 @@
 suite = {
     "mxversion": "7.38.0",
     "name": "substratevm",
-    "version" : "25.0.1",
-    "release" : True,
+    "version" : "25.0.2",
+    "release" : False,
     "url" : "https://github.com/oracle/graal/tree/master/substratevm",
 
     "groupId" : "org.graalvm.nativeimage",

--- a/sulong/mx.sulong/suite.py
+++ b/sulong/mx.sulong/suite.py
@@ -1,8 +1,8 @@
 suite = {
   "mxversion": "7.48.0",
   "name" : "sulong",
-  "version" : "25.0.1",
-  "release" : True,
+  "version" : "25.0.2",
+  "release" : False,
   "versionConflictResolution" : "latest",
   "groupId": "org.graalvm.llvm",
   "url": "http://www.graalvm.org/",

--- a/tools/mx.tools/suite.py
+++ b/tools/mx.tools/suite.py
@@ -26,8 +26,8 @@ suite = {
     "defaultLicense" : "GPLv2-CPE",
 
     "groupId" : "org.graalvm.tools",
-    "version" : "25.0.1",
-    "release" : True,
+    "version" : "25.0.2",
+    "release" : False,
     "url" : "http://openjdk.java.net/projects/graal",
     "developer" : {
         "name" : "GraalVM Development",

--- a/truffle/external_repos/simplelanguage/pom.xml
+++ b/truffle/external_repos/simplelanguage/pom.xml
@@ -47,7 +47,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <m2e.apt.activation>jdt_apt</m2e.apt.activation>
-    <graalvm.version>25.0.1-dev</graalvm.version>
+    <graalvm.version>25.0.2-dev</graalvm.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <launcherClass>org.graalvm.sl.launcher/com.oracle.truffle.sl.launcher.SLMain</launcherClass>

--- a/truffle/external_repos/simpletool/pom.xml
+++ b/truffle/external_repos/simpletool/pom.xml
@@ -48,7 +48,7 @@
     <version>${graalvm.version}</version>
     <name>simpletool</name>
     <properties>
-        <graalvm.version>25.0.1-dev</graalvm.version>
+        <graalvm.version>25.0.2-dev</graalvm.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -41,8 +41,8 @@
 suite = {
   "mxversion": "7.33.0",
   "name" : "truffle",
-  "version" : "25.0.1",
-  "release" : True,
+  "version" : "25.0.2",
+  "release" : False,
   "groupId" : "org.graalvm.truffle",
   "sourceinprojectwhitelist" : [],
   "url" : "http://openjdk.java.net/projects/graal",

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -1,8 +1,8 @@
 suite = {
     "name": "vm",
-    "version" : "25.0.1",
+    "version" : "25.0.2",
     "mxversion": "7.34.1",
-    "release" : True,
+    "release" : False,
     "groupId" : "org.graalvm",
 
     "url" : "http://www.graalvm.org/",
@@ -33,7 +33,7 @@ suite = {
                 "name": "graal-nodejs",
                 "subdir": True,
                 "dynamic": True,
-                "version": "629f33fe3b0a744890a01962ff3beeab50b638df",
+                "version": "fc10cc7165b61dd9489d867ca9d2c3e670d3a6b6",
                 "urls" : [
                     {"url" : "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -42,14 +42,14 @@ suite = {
                 "name": "graal-js",
                 "subdir": True,
                 "dynamic": True,
-                "version": "629f33fe3b0a744890a01962ff3beeab50b638df",
+                "version": "fc10cc7165b61dd9489d867ca9d2c3e670d3a6b6",
                 "urls": [
                     {"url": "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
             },
             {
                 "name": "truffleruby",
-                "version": "dd6b3ce2fb0e8cc89b050933dc3a58ba66656beb",
+                "version": "ca7377d6a08e9293e3047f7eaa7fce12f78c8c89",
                 "dynamic": True,
                 "urls": [
                     {"url": "https://github.com/oracle/truffleruby.git", "kind": "git"},
@@ -65,7 +65,7 @@ suite = {
             },
             {
                 "name": "graalpython",
-                "version": "0284445be0606bc9c4601b28e8bf03921798905f",
+                "version": "33b7ace8d28d5b076f77c52e1e8535d0920e9e78",
                 "dynamic": True,
                 "urls": [
                     {"url": "https://github.com/graalvm/graalpython.git", "kind": "git"},

--- a/wasm/mx.wasm/suite.py
+++ b/wasm/mx.wasm/suite.py
@@ -42,8 +42,8 @@ suite = {
   "mxversion": "7.33.0",
   "name" : "wasm",
   "groupId" : "org.graalvm.wasm",
-  "version" : "25.0.1",
-  "release" : True,
+  "version" : "25.0.2",
+  "release" : False,
   "versionConflictResolution" : "latest",
   "url" : "http://graalvm.org/webassembly",
   "developer" : {

--- a/web-image/mx.web-image/suite.py
+++ b/web-image/mx.web-image/suite.py
@@ -3,7 +3,7 @@ suite = {
     "name": "web-image",
     "versionConflictResolution": "latest",
     "version": "1.0",
-    "release": True,
+    "release": False,
     "groupId": "org.graalvm.webimage",
     "imports": {
         "suites": [


### PR DESCRIPTION
This is to update the version to 25.0.2.0 dev and bring in latest changes from the upstream `oracle/graal` branch `release/graal-vm/25.0`. I.e. start Mandrel 25.0.2 development.

Thoughts?