### PR TITLE
[CI] Add weekly job with --future-defaults=all

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -83,6 +83,21 @@ jobs:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
+  # Test Q main and Mandrel 25.0 JDK 25
+  ####
+  q-main-mandrel-25_0-future-defaults:
+    name: "Q main M 25.0 --future-defaults=all"
+    uses: ./.github/workflows/base.yml
+    with:
+      quarkus-version: "main"
+      mandrel-version: "mandrel/25.0"
+      jdk: "25/ea"
+      issue-number: "917"
+      issue-repo: "graalvm/mandrel"
+      mandrel-it-issue-number: "379"
+      mandrel-packaging-version: "25.0"
+      quarkus-additional-build-args-append: "--future-defaults=all"
+  ####
   # Test Q main and Mandrel 23.1 JDK 21
   ####
   q-main-mandrel-23_1:


### PR DESCRIPTION
Builds on top of #911.

Useful to see regressions of the patch that landed with: https://github.com/quarkusio/quarkus/pull/50846