### PR TITLE
Merge upstream tag `vm-23.1.10` into `mandrel/23.1`

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -5,7 +5,7 @@ suite = {
 
   "groupId" : "org.graalvm.compiler",
   "version" : "23.1.10",
-  "release" : False,
+  "release" : True,
   "url" : "http://www.graalvm.org/",
   "developer" : {
     "name" : "GraalVM Development",

--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -24,7 +24,7 @@ suite = {
     "mxversion": "6.44.0",
     "name": "espresso",
     "version" : "23.1.10",
-    "release" : False,
+    "release" : True,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer" : {

--- a/regex/mx.regex/suite.py
+++ b/regex/mx.regex/suite.py
@@ -44,7 +44,7 @@ suite = {
   "name" : "regex",
 
   "version" : "23.1.10",
-  "release" : False,
+  "release" : True,
   "groupId" : "org.graalvm.regex",
   "url" : "http://www.graalvm.org/",
   "developer" : {

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "6.39.0",
   "name" : "sdk",
   "version" : "23.1.10",
-  "release" : False,
+  "release" : True,
   "sourceinprojectwhitelist" : [],
   "url" : "https://github.com/oracle/graal",
   "groupId" : "org.graalvm.sdk",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -3,7 +3,7 @@ suite = {
     "mxversion": "6.27.1",
     "name": "substratevm",
     "version" : "23.1.10",
-    "release" : False,
+    "release" : True,
     "url" : "https://github.com/oracle/graal/tree/master/substratevm",
 
     "groupId" : "org.graalvm.nativeimage",

--- a/tools/mx.tools/suite.py
+++ b/tools/mx.tools/suite.py
@@ -27,7 +27,7 @@ suite = {
 
     "groupId" : "org.graalvm.tools",
     "version" : "23.1.10",
-    "release" : False,
+    "release" : True,
     "url" : "http://openjdk.java.net/projects/graal",
     "developer" : {
         "name" : "GraalVM Development",

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "6.39.0",
   "name" : "truffle",
   "version" : "23.1.10",
-  "release" : False,
+  "release" : True,
   "groupId" : "org.graalvm.truffle",
   "sourceinprojectwhitelist" : [],
   "url" : "http://openjdk.java.net/projects/graal",

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -2,7 +2,7 @@ suite = {
     "name": "vm",
     "version" : "23.1.10",
     "mxversion": "6.41.0",
-    "release" : False,
+    "release" : True,
     "groupId" : "org.graalvm",
 
     "url" : "http://www.graalvm.org/",


### PR DESCRIPTION
Preparation for the `23.1.10.0-Final` release.

Includes:

* https://github.com/graalvm/graalvm-community-jdk21u/pull/248