### PR TITLE
[CI] Collect build-stats for future-defaults

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -97,6 +97,7 @@ jobs:
       mandrel-it-issue-number: "379"
       mandrel-packaging-version: "25.0"
       quarkus-additional-build-args-append: "--future-defaults=all"
+      build-stats-tag: "gha-linux-mandrel-qmain-m25_0-jdk25ea-futuredefaults"
   ####
   # Test Q main and Mandrel 23.1 JDK 21
   ####


### PR DESCRIPTION
Future defaults are expected to have an impact on image size, and potentially build times.
We should start collecting these data so that we can then compare them with standard builds.