### PR TITLE
[CI] Use ubuntu-slim runners where possible

### DIFF
--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -58,7 +58,7 @@ on:
 jobs:
   process-inputs:
     name: Process inputs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       quarkus-version: ${{ steps.process.outputs.quarkus-version }}
       quarkus-repo: ${{ steps.process.outputs.quarkus-repo }}

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -91,7 +91,7 @@ env:
 jobs:
   build-vars:
     name: Set distribution and build-from-source variables based on build-type
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       build-from-source: ${{ steps.source-build.outputs.build-from-source }}
       distribution: ${{ steps.distro.outputs.distribution }}
@@ -136,7 +136,7 @@ jobs:
 
   get-test-matrix:
     name: Get test matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       quarkus-version: ${{ steps.version.outputs.quarkus-version }}
       tests-matrix: ${{ steps.version.outputs.tests-matrix }}

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -68,7 +68,7 @@ on:
 jobs:
   process-inputs:
     name: Process inputs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       quarkus-version: ${{ steps.process.outputs.quarkus-version }}
       quarkus-repo: ${{ steps.process.outputs.quarkus-repo }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -170,7 +170,7 @@ jobs:
 
   get-test-matrix:
     name: Get test matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       quarkus-version: ${{ steps.version.outputs.quarkus-version }}
       tests-matrix: ${{ steps.version.outputs.tests-matrix }}
@@ -431,7 +431,7 @@ jobs:
 
   get-jdk:
     name: Get JDK ${{ inputs.jdk }}
-    runs-on: ${{ inputs.gh-runner }}
+    runs-on: ubuntu-slim
     needs:
       - get-test-matrix
       - build-vars

--- a/.github/workflows/github-issue-updater.yml
+++ b/.github/workflows/github-issue-updater.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/mark-stale-issues-and-prs.yml
+++ b/.github/workflows/mark-stale-issues-and-prs.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   mark-stale-issues-and-prs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/stale@v6
       with:

--- a/.github/workflows/native-tests-stats-upload.yml
+++ b/.github/workflows/native-tests-stats-upload.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   native-tests-stats-upload:
     name: Upload build stats to collector
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   graal-master:
     name: Keep graal/master in sync with upstream master
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - name: Checkout graal/master branch
       uses: actions/checkout@v4


### PR DESCRIPTION
Github's slim runners are now publicly available
https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/

Use them to reduce the CI footpring and speedup CI jobs
