### PR TITLE
[CI] Fix stats uploads for --future-defaults=all weekly job

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -83,7 +83,7 @@ jobs:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
-  # Test Q main and Mandrel 25.0 JDK 25
+  # Test Q main and Mandrel 25.0 JDK 25 with --future-defaults=all
   ####
   q-main-mandrel-25_0-future-defaults:
     name: "Q main M 25.0 --future-defaults=all"
@@ -98,6 +98,9 @@ jobs:
       mandrel-packaging-version: "25.0"
       quarkus-additional-build-args-append: "--future-defaults=all"
       build-stats-tag: "gha-linux-mandrel-qmain-m25_0-jdk25ea-futuredefaults"
+    secrets:
+      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
   # Test Q main and Mandrel 23.1 JDK 21
   ####


### PR DESCRIPTION
Currently build stats uploads fail, because the token is missing:
```
Error: 'TOKEN' must be specified!
./build-stats-AWT, ImageIO and Java2D, Packaging .so files--main-quarkusio-quarkus-mandrel-25.0-graalvm-mandrel-25.0-graalvm-mandrel-packaging-mandrel-source-25-ea-null-ubuntu-latest-future-defaults=all-/:
```

See:
https://github.com/graalvm/mandrel/actions/runs/21553378182/job/62108694480#step:4:17

The [PR which enabled it](https://github.com/graalvm/mandrel/pull/928/) was missing to pass the secrets. This should fix it.