### PR TITLE
Mandrel 25.0 upstream merge (2026-02-24 edition)

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -630,14 +630,12 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
                     osArch.equals("aarch64") && zgcSupport);
     public final int NMethodPatchingType_stw_instruction_and_data_patch = getConstant("NMethodPatchingType::stw_instruction_and_data_patch", Integer.class, -1, osArch.equals("aarch64"));
     public final int NMethodPatchingType_conc_instruction_and_data_patch = getConstant("NMethodPatchingType::conc_instruction_and_data_patch", Integer.class, -1, osArch.equals("aarch64"));
-    public final int NMethodPatchingType_conc_data_patch = getConstant("NMethodPatchingType::conc_data_patch", Integer.class, -1, osArch.equals("aarch64"));
     // @formatter:on
 
     {
         if (osArch.equals("aarch64")) {
             if (BarrierSetAssembler_nmethod_patching_type != NMethodPatchingType_stw_instruction_and_data_patch &&
-                            BarrierSetAssembler_nmethod_patching_type != NMethodPatchingType_conc_instruction_and_data_patch &&
-                            BarrierSetAssembler_nmethod_patching_type != NMethodPatchingType_conc_data_patch) {
+                            BarrierSetAssembler_nmethod_patching_type != NMethodPatchingType_conc_instruction_and_data_patch) {
                 throw new IllegalArgumentException("unsupported barrier sequence " + BarrierSetAssembler_nmethod_patching_type);
             }
         }

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
@@ -338,10 +338,6 @@ public class AArch64HotSpotBackend extends HotSpotHostBackend implements LIRGene
 
                 } else {
 
-                    if (config.BarrierSetAssembler_nmethod_patching_type == config.NMethodPatchingType_conc_data_patch) {
-                        masm.dmb(AArch64Assembler.BarrierKind.LOAD_ANY);
-                    }
-
                     AArch64Address threadDisarmedAddr = masm.makeAddress(32, thread, config.threadDisarmedOffset, scratch2);
                     masm.ldr(32, scratch2, threadDisarmedAddr);
                     masm.cmp(32, scratch1, scratch2);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
@@ -33,6 +33,7 @@ import static com.oracle.svm.hosted.xml.XMLParsersRegistration.SAXParserClasses;
 import static com.oracle.svm.hosted.xml.XMLParsersRegistration.SchemaDVFactoryClasses;
 import static com.oracle.svm.hosted.xml.XMLParsersRegistration.StAXParserClasses;
 import static com.oracle.svm.hosted.xml.XMLParsersRegistration.TransformerClassesAndResources;
+import static com.oracle.svm.hosted.xml.XMLParsersRegistration.XMLCryptoTransformServiceClassesAndResources;
 
 import org.graalvm.nativeimage.hosted.FieldValueTransformer;
 
@@ -57,6 +58,10 @@ public class JavaxXmlClassAndResourcesLoaderFeature extends JNIRegistrationUtil 
 
         access.registerReachabilityHandler(new TransformerClassesAndResources()::registerConfigs,
                         method(access, "javax.xml.transform.FactoryFinder", "find", Class.class, String.class));
+
+        // TransformService of java.xml.crypto module
+        optionalMethod(access, "com.sun.org.apache.xml.internal.security.utils.I18n", "init", String.class, String.class)
+                        .ifPresent(method -> access.registerReachabilityHandler(new XMLCryptoTransformServiceClassesAndResources()::registerConfigs, method));
 
         access.registerReachabilityHandler(new DOMImplementationRegistryClasses()::registerConfigs,
                         method(access, "org.w3c.dom.bootstrap.DOMImplementationRegistry", "newInstance"));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/XMLParsersRegistration.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/XMLParsersRegistration.java
@@ -154,4 +154,23 @@ public abstract class XMLParsersRegistration extends JNIRegistrationUtil {
             return Collections.singletonList("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl");
         }
     }
+
+    static class XMLCryptoTransformServiceClassesAndResources extends XMLParsersRegistration {
+
+        @Override
+        void registerResources() {
+            /*
+             * To allow register new resource bundle classes during analysis phase
+             */
+            ClassInitializationSupport classInitializationSupport = (ClassInitializationSupport) ImageSingletons.lookup(RuntimeClassInitializationSupport.class);
+            classInitializationSupport.withUnsealedConfiguration(() -> {
+                ResourcesRegistry.singleton().addResourceBundles(ConfigurationCondition.alwaysTrue(), "com.sun.org.apache.xml.internal.security/resource/xmlsecurity");
+            });
+        }
+
+        @Override
+        List<String> xmlParserClasses() {
+            return Collections.emptyList();
+        }
+    }
 }


### PR DESCRIPTION
Includes the following upstream PRs which includes one XML crypto fix and the AArch64 build fix for `JDK 25.0.3+1` EA:

- https://github.com/graalvm/graalvm-community-jdk25u/pull/5
- https://github.com/graalvm/graalvm-community-jdk25u/pull/12

Thoughts?