### PR TITLE
[CI] Improve error handling in GitHub Issue Updater

### DIFF
--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -37,6 +37,7 @@ import picocli.CommandLine.Option;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +71,8 @@ class Report implements Runnable {
 
 	@Option(names = "--dry-run", description = "Whether to actually update the issue or not")
 	private boolean dryRun;
+
+	private final List<String> errors = new ArrayList<>();
 
 	@Override
 	public void run() {
@@ -154,6 +157,21 @@ class Report implements Runnable {
 			for (GHIssue issue: mandrelITIssues.keySet()) {
 				reportJobResults(issue, mandrelITJobs.get(issue));
 			}
+
+			// After processing all issues, report any errors
+			if (!errors.isEmpty()) {
+				System.err.println("\n========================================");
+				System.err.println("ERRORS OCCURRED DURING PROCESSING:");
+				System.err.println("========================================");
+				for (String error : errors) {
+					// GitHub Actions workflow annotation
+					System.out.println("::error::" + error);
+					// Also to stderr for logs
+					System.err.println("  - " + error);
+				}
+				System.err.println("========================================\n");
+				System.exit(1);
+			}
 		}
 		catch (IOException e) {
 			throw new UncheckedIOException(e);
@@ -197,14 +215,16 @@ class Report implements Runnable {
 				if (!dryRun) {
 					try {
 						issue.reopen();
+						System.out.println("The issue has been re-opened");
 					} catch (Exception e) {
-						System.out.println("ERROR: Failed to open issue: " + issue.getHtmlUrl());
-						System.out.println("ERROR: Make sure the issue is owned by @mandrel-bot and that it was not closed by another user");
-						e.printStackTrace();
-						System.exit(1);
+						String errorMsg = String.format("Failed to reopen %s: %s. Make sure the issue is owned by @mandrel-bot and that it was not closed by another user",
+							issue.getHtmlUrl(), e.getMessage());
+						errors.add(errorMsg);
+						System.err.println("ERROR: " + errorMsg);
+						System.err.println("WARN: Attempting to add comment anyway...");
+						// Continue to add comment despite reopen failure
 					}
 				}
-				System.out.println("The issue has been re-opened");
 			}
 			for (GHWorkflowJob job: jobs) {
 		 		processFailedJob(sb, job);
@@ -298,9 +318,18 @@ class Report implements Runnable {
 					} else {
 						sb.append("Unfortunately, the synchronization failed!\n\n");
 						if (!dryRun) {
-							issue.reopen();
+							try {
+								issue.reopen();
+								System.out.println("The issue has been re-opened");
+							} catch (Exception e) {
+								String errorMsg = String.format("Failed to reopen %s: %s. Make sure the issue is owned by @mandrel-bot and that it was not closed by another user",
+									issue.getHtmlUrl(), e.getMessage());
+								errors.add(errorMsg);
+								System.err.println("ERROR: " + errorMsg);
+								System.err.println("WARN: Attempting to add comment anyway...");
+								// Continue to add comment despite reopen failure
+							}
 						}
-						System.out.println("The issue has been re-opened");
 					}
 					sb.append(String.format("Link to failing CI run: %s", job.getHtmlUrl()));
 					String comment = sb.toString();

--- a/.github/quarkus-ecosystem-issue.java
+++ b/.github/quarkus-ecosystem-issue.java
@@ -165,7 +165,7 @@ class Report implements Runnable {
 				System.err.println("========================================");
 				for (String error : errors) {
 					// GitHub Actions workflow annotation
-					System.out.println("::error::" + error);
+					System.out.println("::error::" + escapeWorkflowCommand(error));
 					// Also to stderr for logs
 					System.err.println("  - " + error);
 				}
@@ -407,7 +407,33 @@ class Report implements Runnable {
 	private static boolean isOpen(GHIssue issue) {
 		return (issue.getState() == GHIssueState.OPEN);
 	}
-	
+
+	/**
+	 * Escapes special characters for GitHub Actions workflow commands.
+	 *
+	 * Prevents workflow command injection when outputting untrusted strings.
+	 * The primary risk is newlines: if an error message contains "\n::", the newline
+	 * would create a new physical line where :: at the start becomes a new workflow
+	 * command. By escaping \n to %0A, the entire message stays on one line, so any
+	 * :: within the message has no special meaning.
+	 *
+	 * GitHub Actions decodes these sequences before display, so %0A shows as a
+	 * newline in the web UI.
+	 *
+	 * All three escapes are required per GitHub Actions toolkit implementation:
+	 * https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+	 * https://github.com/orgs/community/discussions/26736
+	 * - %  → %25 (must be first to avoid double-encoding the other escapes)
+	 * - \r → %0D (carriage return can also create new lines on some systems)
+	 * - \n → %0A (newline prevents command injection as explained above)
+	 */
+	private static String escapeWorkflowCommand(String message) {
+		return message
+			.replace("%", "%25")   // Must be first to avoid double-encoding
+			.replace("\r", "%0D")
+			.replace("\n", "%0A");
+	}
+
 	public static void main(String... args) {
 		int exitCode = new CommandLine(new Report()).execute(args);
 		System.exit(exitCode);


### PR DESCRIPTION
- Add error collection field to collect failures during execution
- Modify issue reopen error handling to collect errors instead of exiting
- Continue processing all issues even when reopen fails
- Add end-of-run error reporting with GitHub Actions ::error:: annotations
- Apply consistent error handling to both reportJobResults and processSyncJobs
- Exit with code 1 only after processing all issues if any errors occurred

This ensures that a single issue reopen failure doesn't prevent other
issues from being updated, while still making failures visible in both
CI logs and the GitHub Actions UI.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>
