### PR TITLE
Merge upstream graalvm-community-jdk25u into mandrel/25.0 (2026-04-07 edition)

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_community_bug.yml
+++ b/.github/ISSUE_TEMPLATE/1_community_bug.yml
@@ -38,7 +38,7 @@ body:
       description: "Provide the GraalVM community build you are using."
       placeholder: "Mandrel, Liberica, or other community build"
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: graalvm_version
@@ -47,7 +47,7 @@ body:
       description: "Provide the version of GraalVM used."
       placeholder: "Output of `native-image -version` or `java -version` or commit id if built from source"
     validations:
-      required: true
+      required: false
 
   - type: input
     id: operating_system
@@ -56,7 +56,7 @@ body:
       description: "Provide details of your operating system and version (e.g., output of `uname -a` or Windows version)."
       placeholder: "OS details here"
     validations:
-      required: true
+      required: false
 
   - type: input
     id: architecture
@@ -65,7 +65,7 @@ body:
       description: "Provide details of your system architecture."
       placeholder: "AMD64"
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: additional_context

--- a/.github/actions/build-graalvm/action.yml
+++ b/.github/actions/build-graalvm/action.yml
@@ -55,6 +55,5 @@ runs:
       if: ${{ inputs.java-version }} != ''
       uses: actions/setup-java@v4
       with:
-        distribution: 'oracle'
+        distribution: 'temurin'
         java-version: '${{ inputs.java-version }}'
-  

--- a/.github/workflows/cdt-inspect.yml
+++ b/.github/workflows/cdt-inspect.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, 2023, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # The Universal Permissive License (UPL), Version 1.0
@@ -38,16 +38,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Intergation test of CDT with Inspector backend.
+# Integration test of CDT with Inspector backend.
 name: Weekly CDT Inspector
 
 on:
   schedule:
     - cron: "30 2 * * 2,5" # Tuesday and Friday at 2:30
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/cdt-inspect.yml'
 
 env:
   JAVA_HOME: ${{ github.workspace }}/jdk
-  JDK_VERSION: "latest"
+  JDK_VERSION: "25"
   MX_PATH: ${{ github.workspace }}/mx
   SE_SKIP_DRIVER_IN_PATH: "true"
 
@@ -67,8 +71,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: oracle/graaljs
+        ref: 'release/graal-vm/25.0'
         sparse-checkout: |
           graal-js
+          benchmarks
         path: ${{ github.workspace }}/js
     - name: Checkout graalvm/mx
       uses: actions/checkout@v4
@@ -80,11 +86,20 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.8'
-    - name: Fetch LabsJDK
+    - name: Get OpenJDK with static libs and jmods
       run: |
-        mkdir jdk-dl
-        ${MX_PATH}/mx --java-home= fetch-jdk --jdk-id labsjdk-ce-${JDK_VERSION} --to jdk-dl --alias ${JAVA_HOME}
-    - run: |
+        mkdir -p ${JAVA_HOME}
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/jmods/hotspot/normal/eclipse -o jdk-jmods.tar.gz
+        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
+        tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
+        mkdir -p ${JAVA_HOME}/jmods
+        tar xf jdk-jmods.tar.gz -C ${JAVA_HOME}/jmods --strip-components=1
+        echo "JAVA_HOME is ${JAVA_HOME}"
+        ${JAVA_HOME}/bin/java -version
+    - name: Build and Test
+      run: |
         cd ${{ github.workspace }}/graal/vm
         ${MX_PATH}/mx --dy /tools,graal-js build
         cd tests/gh_workflows/CDTInspectorTest

--- a/.github/workflows/cdt-inspect.yml
+++ b/.github/workflows/cdt-inspect.yml
@@ -56,7 +56,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    if: github.repository == 'oracle/graal'
+    if: github.repository == 'graalvm/graalvm-community-jdk25u'
 
     steps:
     - name: Checkout oracle/graal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ on:
 #    cancelled and a new CI job will be queued for the latest (third) push.
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'oracle/graal' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'graalvm/graalvm-community-jdk25u' }}
 
 env:
   JAVA_HOME: ${{ github.workspace }}/jdk

--- a/.github/workflows/micronaut-native-image-logger.patch
+++ b/.github/workflows/micronaut-native-image-logger.patch
@@ -1,0 +1,18 @@
+--- pom.xml	2026-02-24 18:14:28.606728565 +0100
++++ pom.xml	2026-02-24 18:15:18.102016990 +0100
+@@ -70,6 +70,15 @@
+   <build>
+     <plugins>
+       <plugin>
++        <groupId>org.graalvm.buildtools</groupId>
++        <artifactId>native-maven-plugin</artifactId>
++        <configuration>
++          <buildArgs combine.children="append">
++            <buildArg>--initialize-at-build-time=org.junit.platform.commons.logging.LoggerFactory$DelegatingLogger</buildArg>
++          </buildArgs>
++        </configuration>
++      </plugin>
++      <plugin>
+         <groupId>io.micronaut.maven</groupId>
+         <artifactId>micronaut-maven-plugin</artifactId>
+         <configuration>

--- a/.github/workflows/micronaut.yml
+++ b/.github/workflows/micronaut.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024, 2025, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # The Universal Permissive License (UPL), Version 1.0
@@ -38,7 +38,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-name: Weekly Micronaut Tests
+name: Weekly Micronaut Smoke Tests
 
 on:
   pull_request:
@@ -49,8 +49,7 @@ on:
   workflow_dispatch:
 
 env:
-  MICRONAUT_CORE_PATH: ${{ github.workspace }}/micronaut-core
-  MICRONAUT_JAVA_VERSION: 21
+  MICRONAUT_JAVA_VERSION: 25
   # Enforce experimental option checking in CI (GR-47922)
   NATIVE_IMAGE_EXPERIMENTAL_OPTIONS_ARE_FATAL: 'true'
 
@@ -61,7 +60,7 @@ jobs:
   build-graalvm-and-micronaut:
     name: Native Tests
     runs-on: ubuntu-22.04
-    if: (github.event_name == 'schedule' && github.repository == 'oracle/graal') || (github.event_name != 'schedule')
+    if: (github.event_name == 'schedule' && github.repository == 'graalvm/graalvm-community-jdk25u') || (github.event_name != 'schedule')
     steps:
     - name: Checkout oracle/graal
       uses: actions/checkout@v4
@@ -71,16 +70,8 @@ jobs:
         java-version: ${{ env.MICRONAUT_JAVA_VERSION }}
     - name: Run nativeTest in Micronaut launch project
       run: |
-        curl --fail --silent --location --retry 3 --max-time 10 --output demo.zip --request GET 'https://launch.micronaut.io/create/default/com.example.demo?lang=JAVA&build=GRADLE&test=JUNIT&javaVersion=JDK_${{ env.MICRONAUT_JAVA_VERSION }}'
+        curl --location --request GET 'https://launch.micronaut.io/create/default/com.example.demo?lang=JAVA&build=MAVEN&test=JUNIT&javaVersion=JDK_${{ env.MICRONAUT_JAVA_VERSION }}' --output demo.zip
         unzip demo.zip
         cd demo
-        ./gradlew nativeTest
-    - name: Checkout micronaut-projects/micronaut-core
-      uses: actions/checkout@v4
-      with:
-        repository: micronaut-projects/micronaut-core
-        path: ${{ env.MICRONAUT_CORE_PATH }}
-    - name: Run nativeTest in micronaut-core
-      run: |
-        cd ${{ env.MICRONAUT_CORE_PATH }}
-        ./gradlew nativeTest
+        patch -l < ${{ github.workspace }}/.github/workflows/micronaut-native-image-logger.patch
+        ./mvnw verify -Pnative

--- a/.github/workflows/ni-layers.yml
+++ b/.github/workflows/ni-layers.yml
@@ -110,7 +110,7 @@ jobs:
       - name: "Setup JAVA_HOME"
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/ni-layers.yml
+++ b/.github/workflows/ni-layers.yml
@@ -58,7 +58,7 @@ jobs:
   build-graalvm-and-populate-matrix:
     name: Build GraalVM and populate matrix
     runs-on: ubuntu-latest
-    if: (github.repository=='oracle/graal')
+    if: (github.repository=='graalvm/graalvm-community-jdk25u')
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -161,7 +161,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: '17'
       - name: Build with Maven
         if: startsWith(matrix.os-name, 'ubuntu')

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -65,7 +65,7 @@ jobs:
 
     name: Nightly Quarkus and GraalVM build
     runs-on: ubuntu-22.04
-    if: (github.event_name == 'schedule' && github.repository == 'oracle/graal') || (github.event_name != 'schedule')
+    if: (github.event_name == 'schedule' && github.repository == 'graalvm/graalvm-community-jdk25u') || (github.event_name != 'schedule')
     outputs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:

--- a/.github/workflows/reachability-metadata.yml
+++ b/.github/workflows/reachability-metadata.yml
@@ -116,7 +116,7 @@ jobs:
       - name: "Setup JAVA_HOME"
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: ${{ env.MINIMUM_METADATA_JAVA_VERSION }}
       - name: "Pull allowed docker images"
         run: |

--- a/.github/workflows/reachability-metadata.yml
+++ b/.github/workflows/reachability-metadata.yml
@@ -50,7 +50,7 @@ on:
 
 env:
   REACHABILITY_METADATA_PATH: ${{ github.workspace }}/graalvm-reachability-metadata
-  MINIMUM_METADATA_JAVA_VERSION: 17
+  MINIMUM_METADATA_JAVA_VERSION: 21
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -59,7 +59,7 @@ jobs:
   build-graalvm-and-populate-matrix:
     name: Build GraalVM and populate matrix
     runs-on: ubuntu-22.04
-    if: (github.event_name == 'schedule' && github.repository == 'oracle/graal') || (github.event_name != 'schedule')
+    if: (github.event_name == 'schedule' && github.repository == 'graalvm/graalvm-community-jdk25u') || (github.event_name != 'schedule')
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -124,13 +124,12 @@ jobs:
       - name: "Disable docker"
         run: |
           sudo apt-get install openbsd-inetd
-          sudo bash -c "cat ./.github/workflows/discard-port.conf >> /etc/inetd.conf"
+          sudo bash -c "cat ./.github/workflows/scripts/discard-port.conf >> /etc/inetd.conf"
           sudo systemctl start inetd
           sudo mkdir /etc/systemd/system/docker.service.d
-          sudo bash -c "cat ./.github/workflows/dockerd.service > /etc/systemd/system/docker.service.d/http-proxy.conf"
+          sudo bash -c "cat ./.github/workflows/scripts/dockerd.service > /etc/systemd/system/docker.service.d/http-proxy.conf"
           sudo systemctl daemon-reload
           sudo systemctl restart docker
       - name: "Run '${{ matrix.coordinates }}' tests"
         run: |
           ./gradlew test -Pcoordinates=${{ matrix.coordinates }}
-    

--- a/.github/workflows/reachability-metadata.yml
+++ b/.github/workflows/reachability-metadata.yml
@@ -84,6 +84,8 @@ jobs:
       with:
         repository: oracle/graalvm-reachability-metadata
         path: ${{ env.REACHABILITY_METADATA_PATH }}
+        # https://github.com/oracle/graalvm-reachability-metadata/issues/1071
+        ref: cb8a9e81f2a6cab3949e8d79ac00bf939c90b015
     - name: "Populate matrix"
       id: set-matrix
       run: |
@@ -106,6 +108,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: oracle/graalvm-reachability-metadata
+          # https://github.com/oracle/graalvm-reachability-metadata/issues/1071
+          ref: cb8a9e81f2a6cab3949e8d79ac00bf939c90b015
       - name: Download GraalVM JDK build
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:

--- a/.github/workflows/spring.yml
+++ b/.github/workflows/spring.yml
@@ -50,7 +50,8 @@ on:
 
 env:
   SPRING_PETCLINIC_PATH: ${{ github.workspace }}/spring-petclinic
-  SPRING_JAVA_VERSION: 21
+  # PetClinic requires Java 17
+  SPRING_JAVA_VERSION: 17
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -59,7 +60,7 @@ jobs:
   build-graalvm-and-spring:
     name: Native Tests
     runs-on: ubuntu-22.04
-    if: (github.event_name == 'schedule' && github.repository == 'oracle/graal') || (github.event_name != 'schedule')
+    if: (github.event_name == 'schedule' && github.repository == 'graalvm/graalvm-community-jdk25u') || (github.event_name != 'schedule')
     steps:
     - name: Checkout oracle/graal
       uses: actions/checkout@v4

--- a/.github/workflows/spring.yml
+++ b/.github/workflows/spring.yml
@@ -73,6 +73,21 @@ jobs:
       with:
         repository: spring-projects/spring-petclinic
         path: ${{ env.SPRING_PETCLINIC_PATH }}
+    - name: resource-config.json to include database test data.
+      run: |
+        cd ${{ env.SPRING_PETCLINIC_PATH }}
+        mkdir -p src/test/resources/META-INF/native-image/petclinic
+        cat << 'EOF' > src/test/resources/META-INF/native-image/petclinic/resource-config.json
+        {
+          "resources": {
+            "includes": [
+              {
+                "pattern": "db/.*/.*\\.sql"
+              }
+            ]
+          }
+        }
+        EOF
     - name: Run nativeTest in spring-petclinic
       run: |
         cd ${{ env.SPRING_PETCLINIC_PATH }}

--- a/vm/tests/gh_workflows/NILayerTests/excluded-popular-maven-libraries.json
+++ b/vm/tests/gh_workflows/NILayerTests/excluded-popular-maven-libraries.json
@@ -322,5 +322,11 @@
     "artifact_id": "quarkus-junit5",
     "version": "3.14.3",
     "reason": "GR-57711"
+  },
+  {
+    "group_id": "org.liquibase",
+    "artifact_id": "liquibase-core",
+    "version": "4.29.2",
+    "reason": "com.oracle.svm.core.util.UserError$UserException: ImageSingletons do not contain key com.oracle.svm.core.jfr.SubstrateJVM"
   }
 ]

--- a/vm/tests/gh_workflows/NILayerTests/popular-maven-libraries.json
+++ b/vm/tests/gh_workflows/NILayerTests/popular-maven-libraries.json
@@ -1740,12 +1740,6 @@
         "rank": 550
     },
     {
-        "group_id": "org.liquibase",
-        "artifact_id": "liquibase-core",
-        "version": "4.29.2",
-        "rank": 552
-    },
-    {
         "group_id": "org.apache.commons",
         "artifact_id": "commons-exec",
         "version": "1.4.0",


### PR DESCRIPTION
Merge latest changes from upstream community backports repository (GHA changes) into `mandrel/25.0` in prep for the April CPU update. The merged github actions shouldn't run since the repository doesn't match (which is intentional). Update: Some PR actioned actions seem to run. Not sure if we want that for every PR.

This merge includes the following upstream PRs:

- https://github.com/graalvm/graalvm-community-jdk25u/pull/11
- https://github.com/graalvm/graalvm-community-jdk25u/pull/18
- https://github.com/graalvm/graalvm-community-jdk25u/pull/20

Thoughts?