### PR TITLE
[CI] Add use-snapshot option to reuse pre-built Quarkus snapshots

### DIFF
--- a/.github/workflows/base-windows-wrapper.yml
+++ b/.github/workflows/base-windows-wrapper.yml
@@ -10,9 +10,9 @@ on:
     inputs:
       quarkus-version:
         type: string
-        description: 'Quarkus version to test `<repo>:<version>` (branch, tag, commit, or "latest")'
+        description: 'Quarkus version to test `<repo>:<version>`. The `<version>` can be a branch, tag, commit, or "latest".'
         # "latest" is replaced by the latest release available in maven
-        default: "quarkusio/quarkus:main"
+        default: "quarkusio/quarkus:999-SNAPSHOT"
       graalvm-version:
         type: string
         description: 'Mandrel version to test `<repo>:<version>` (branch, tag, or commit)'
@@ -73,14 +73,16 @@ jobs:
     steps:
       - id: process
         run: |
-          echo "quarkus-repo=$(echo ${{ github.event.inputs.quarkus-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
-          echo "quarkus-version=$(echo ${{ github.event.inputs.quarkus-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
+          QUARKUS_INPUT="${{ github.event.inputs.quarkus-version }}"
+          echo "quarkus-repo=$(echo $QUARKUS_INPUT | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
+          echo "quarkus-version=$(echo $QUARKUS_INPUT | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
           echo "mandrel-repo=$(echo ${{ github.event.inputs.graalvm-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
           echo "mandrel-version=$(echo ${{ github.event.inputs.graalvm-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
           echo "mandrel-packaging-repo=$(echo ${{ github.event.inputs.mandrel-packaging-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
           echo "mandrel-packaging-version=$(echo ${{ github.event.inputs.mandrel-packaging-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
   delegate:
+    needs: process-inputs
     uses: ./.github/workflows/base-windows.yml
     with:
       quarkus-version: ${{ needs.process-inputs.outputs.quarkus-version }}

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: 'Quarkus version to test (branch, tag, commit, or "latest")'
         # "latest" is replaced by the latest release available in maven
-        default: "main"
+        default: "999-SNAPSHOT"
       quarkus-repo:
         type: string
         description: 'The Quarkus repository to be used'
@@ -308,6 +308,8 @@ jobs:
       target-os: 'windows'
       quarkus-repo: ${{ inputs.quarkus-repo }}
       quarkus-version: ${{ needs.get-test-matrix.outputs.quarkus-version }}
+      quarkus-sha: ${{ needs.get-test-matrix.outputs.quarkus-sha }}
+      use-snapshot: ${{ fromJson(needs.get-test-matrix.outputs.use-snapshot) }}
 
   native-tests:
     name: Q IT ${{ matrix.category }}
@@ -350,13 +352,8 @@ jobs:
         with:
           repository: ${{ inputs.quarkus-repo }}
           fetch-depth: 1
-          ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
+          ref: ${{ needs.get-test-matrix.outputs.quarkus-sha }}
           path: ${{ env.QUARKUS_PATH }}
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.m2/repository
-          key: base-windows-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: base-windows-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-
       # Use Java 17 for Quarkus as it doesn't work with Java 21 yet
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -384,6 +381,15 @@ jobs:
             cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json.new
             mv ~/.docker/config.json.new ~/.docker/config.json
           fi
+      - name: Build Gradle plugins for snapshots
+        if: ${{ fromJson(needs.get-test-matrix.outputs.use-snapshot) == true && contains(matrix.test-modules, 'gradle') }}
+        shell: bash
+        run: |
+          cd ${QUARKUS_PATH}
+          # Build Gradle plugins that are not included in snapshots to avoid Gradle repository lookup
+          echo "Building Gradle plugins to local Maven repository"
+          ./mvnw ${COMMON_MAVEN_ARGS} -Dquickly -pl devtools/gradle,devtools/gradle/gradle-application-plugin,devtools/gradle/gradle-extension-plugin -am install
+          cd -
       - name: Build with Maven
         env:
           TEST_MODULES: ${{matrix.test-modules}}
@@ -403,7 +409,7 @@ jobs:
           $opts=@()
           -split $Env:NATIVE_TEST_MAVEN_OPTS | foreach { $opts += "`"$_`"" }
           #if ( "${{ inputs.builder-image }}" -eq "null" ) {
-          mvn -f integration-tests -pl "$Env:TEST_MODULES" -amd "-Dquarkus.native.container-build=false" $opts install
+          mvn -f integration-tests -pl "$Env:TEST_MODULES" -am -amd "-Dquarkus.native.container-build=false" $opts install
           #} else {
           #  mvn -pl $do_modules "-Dquarkus.native.container-build=true" "-Dquarkus.native.builder-image=${{ inputs.builder-image }}" $opts package
           #}
@@ -522,8 +528,8 @@ jobs:
           }
           $QUARKUS_VERSION="${{ needs.get-test-matrix.outputs.quarkus-version }}"
           # Don't use SNAPSHOT version for release tags
-          if (${{ inputs.quarkus-version }} -match "^[0-9]+\.[0-9]+$") {
-            $QUARKUS_VERSION="${{ inputs.quarkus-version }}.999-SNAPSHOT"
+          if ($QUARKUS_VERSION -match "^[0-9]+\.[0-9]+$") {
+            $QUARKUS_VERSION="$QUARKUS_VERSION.999-SNAPSHOT"
           } elseif (! ($QUARKUS_VERSION -match "^.*\.(Final|CR|Alpha|Beta)[0-9]?$")) {
             $QUARKUS_VERSION="999-SNAPSHOT"
           }

--- a/.github/workflows/base-wrapper.yml
+++ b/.github/workflows/base-wrapper.yml
@@ -10,9 +10,9 @@ on:
     inputs:
       quarkus-version:
         type: string
-        description: 'Quarkus version to test `<repo>:<version>` (branch, tag, commit, or "latest")'
+        description: 'Quarkus version to test `<repo>:<version>`. The `<version>` can be a branch, tag, commit, or "latest".'
         # "latest" is replaced by the latest release available in maven
-        default: "quarkusio/quarkus:main"
+        default: "quarkusio/quarkus:999-SNAPSHOT"
       graalvm-version:
         type: string
         description: 'Mandrel version to test `<repo>:<version>` (branch, tag, or commit)'
@@ -23,8 +23,8 @@ on:
         default: "graalvm/mandrel-packaging:master"
       build-type:
         type: choice
-        description: 'Build distribution (graal/mandrel) from source or use released binaries, and control of maven should deploy locally'
-        default: "mandrel-source"
+        description: 'Build distribution (graal/mandrel) from source or use released binaries, and control if maven should deploy locally'
+        default: "mandrel-source-nolocalmvn"
         options:
           - "mandrel-source"
           - "graal-source"
@@ -87,8 +87,9 @@ jobs:
     steps:
       - id: process
         run: |
-          echo "quarkus-repo=$(echo ${{ github.event.inputs.quarkus-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
-          echo "quarkus-version=$(echo ${{ github.event.inputs.quarkus-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
+          QUARKUS_INPUT="${{ github.event.inputs.quarkus-version }}"
+          echo "quarkus-repo=$(echo $QUARKUS_INPUT | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
+          echo "quarkus-version=$(echo $QUARKUS_INPUT | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
           echo "mandrel-repo=$(echo ${{ github.event.inputs.graalvm-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT
           echo "mandrel-version=$(echo ${{ github.event.inputs.graalvm-version }} | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
           echo "mandrel-packaging-repo=$(echo ${{ github.event.inputs.mandrel-packaging-version }} | cut -d ':' -f 1)" >> $GITHUB_OUTPUT

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: 'Quarkus version to test (branch, tag, commit, or "latest")'
         # "latest" is replaced by the latest release available in maven
-        default: "main"
+        default: "999-SNAPSHOT"
       quarkus-repo:
         type: string
         description: 'The Quarkus repository to be used'
@@ -31,7 +31,7 @@ on:
       build-type:
         type: string
         description: 'Build distribution (Mandrel/GraalVM) from source or grab a release, and control of maven should deploy locally'
-        default: "mandrel-source"
+        default: "mandrel-source-nolocalmvn"
       jdk:
         type: string
         description: 'OpenJDK to use. One of <feature-version>/ga, <feature-version>/ea, e.g. 17/ga or 17/ea (/ga and /ea suffixes are only relevant when building from source)'
@@ -408,7 +408,9 @@ jobs:
       target-os: 'linux'
       quarkus-repo: ${{ inputs.quarkus-repo }}
       quarkus-version: ${{ needs.get-test-matrix.outputs.quarkus-version }}
+      quarkus-sha: ${{ needs.get-test-matrix.outputs.quarkus-sha }}
       gh-runner: ${{ inputs.gh-runner }}
+      use-snapshot: ${{ fromJson(needs.get-test-matrix.outputs.use-snapshot) }}
 
   native-tests:
     name: Q IT ${{ matrix.category }}
@@ -424,6 +426,7 @@ jobs:
       # leave more space for the actual native compilation and execution
       MAVEN_OPTS: -Xmx1g
       # USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
+      COMMON_MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
     # Ignore the following YAML Schema error
     timeout-minutes: ${{matrix.timeout}}
     strategy:
@@ -464,10 +467,11 @@ jobs:
         with:
           repository: ${{ inputs.quarkus-repo }}
           fetch-depth: 1
-          ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
+          ref: ${{ needs.get-test-matrix.outputs.quarkus-sha }}
           path: ${{ env.QUARKUS_PATH }}
       - name: Reclaim disk space
-        run: ${QUARKUS_PATH}/.github/ci-prerequisites.sh
+        run: |
+          ${QUARKUS_PATH}/.github/ci-prerequisites.sh
       - name: Update Docker Client User Agent
         shell: bash
         run: |
@@ -475,6 +479,15 @@ jobs:
             cat <<< $(jq '.HttpHeaders += {"User-Agent": "Mandrel-CI-Docker-Client"}' ~/.docker/config.json) > ~/.docker/config.json.new
             mv ~/.docker/config.json.new ~/.docker/config.json
           fi
+      - name: Build Gradle plugins for snapshots
+        if: ${{ fromJson(needs.get-test-matrix.outputs.use-snapshot) == true && contains(matrix.test-modules, 'gradle') }}
+        shell: bash
+        run: |
+          cd ${QUARKUS_PATH}
+          # Build Gradle plugins that are not included in snapshots to avoid Gradle repository lookup
+          echo "Building Gradle plugins to local Maven repository"
+          ./mvnw ${COMMON_MAVEN_ARGS} -Dquickly -pl devtools/gradle,devtools/gradle/gradle-application-plugin,devtools/gradle/gradle-extension-plugin -am install
+          cd -
       - name: Build with Maven
         env:
           TEST_MODULES: ${{matrix.test-modules}}
@@ -521,6 +534,11 @@ jobs:
           #   https://github.com/quarkusio/quarkus/issues/51923
           if [[ "${{ runner.arch }}" == "ARM64" ]]; then
             TEST_MODULES=$(echo $TEST_MODULES | tr ',' '\n' | grep -vi -E 'db2|hibernate-orm-spatial' | paste -sd, -)
+            # Quarkus snapshot builds are built on x86_64 which results in some IT failing on ARM.
+            # see https://github.com/quarkusio/quarkus/issues/51562
+            if [[ "${{ needs.get-test-matrix.outputs.use-snapshot }}" == "true" ]]; then
+              TEST_MODULES=$(echo $TEST_MODULES | tr ',' '\n' | grep -vi -E 'jpa-mssql|hibernate-reactive-mssql' | paste -sd, -)
+            fi
             echo "Filtered TEST_MODULES for ARM: $TEST_MODULES"
           fi
           # Filter out user-specified excluded modules
@@ -529,6 +547,9 @@ jobs:
             TEST_MODULES=$(echo $TEST_MODULES | tr ',' '\n' | grep -vi -E "$EXCLUDED_PATTERN" | paste -sd, -)
             echo "Filtered TEST_MODULES after excluding '${{ inputs.excluded-native-test-modules }}': $TEST_MODULES"
           fi
+          # Step 1: Build and install all dependencies/dependents, skipping all tests
+          ./mvnw -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml -f integration-tests -pl "$TEST_MODULES" -DskipTests -am -amd $BUILDER_IMAGE $NATIVE_TEST_MAVEN_OPTS $NEW_MAX_HEAP_SIZE
+          # Step 2: Run the actual tests ONLY on the target modules
           ./mvnw -B --settings ${QUARKUS_PATH}/.github/mvn-settings.xml -f integration-tests -pl "$TEST_MODULES" -amd $BUILDER_IMAGE $NATIVE_TEST_MAVEN_OPTS $NEW_MAX_HEAP_SIZE
       - name: Prepare failure archive (if maven failed)
         if: failure()
@@ -638,10 +659,10 @@ jobs:
           export PATH="${GRAALVM_HOME}/bin:$PATH"
           export QUARKUS_VERSION=${{ needs.get-test-matrix.outputs.quarkus-version }}
           # Don't use SNAPSHOT version for release tags
-          if $(expr match "${{ inputs.quarkus-version }}" "^[0-9]\+\.[0-9]\+$" > /dev/null)
+          if $(expr match "${QUARKUS_VERSION}" "^[0-9]\+\.[0-9]\+$" > /dev/null)
           then
             # release branches use the branch name followed by .999-SNAPSHOT as the version
-            export QUARKUS_VERSION="${{ inputs.quarkus-version }}.999-SNAPSHOT"
+            export QUARKUS_VERSION="${QUARKUS_VERSION}.999-SNAPSHOT"
           elif ! $(expr match "$QUARKUS_VERSION" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
           then
             export QUARKUS_VERSION="999-SNAPSHOT"
@@ -668,3 +689,4 @@ jobs:
         with:
           name: test-reports-mandrel-it-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'test-reports-mandrel-it.tgz'
+

--- a/.github/workflows/biweekly.yml
+++ b/.github/workflows/biweekly.yml
@@ -1,9 +1,9 @@
-name: Monthly CI
+name: Bi-weekly CI
 
 on:
   push:
     paths:
-      - '.github/workflows/monthly.yml'
+      - '.github/workflows/biweekly.yml'
       - '.github/workflows/base.yml'
       - '.github/workflows/base-windows.yml'
       - '.github/workflows/compute-build-config.yml'
@@ -11,15 +11,15 @@ on:
       - '.github/workflows/build-quarkus.yml'
   pull_request:
     paths:
-      - '.github/workflows/monthly.yml'
+      - '.github/workflows/biweekly.yml'
       - '.github/workflows/base.yml'
       - '.github/workflows/base-windows.yml'
       - '.github/workflows/compute-build-config.yml'
       - '.github/workflows/resolve-quarkus-version.yml'
       - '.github/workflows/build-quarkus.yml'
   schedule:
-    # Run at 00:00 on the first day of every month
-    - cron: '0 0 1 * *'
+    # Run every two weeks at 00:00
+    - cron: '0 0 1,15 * *'
   workflow_dispatch:
 
 # The following aims to reduce CI CPU cycles by:
@@ -37,18 +37,43 @@ concurrency:
 
 jobs:
   ####
-  # Test Q main and Mandrel 25.0 JDK 25 with assertions enabled
+  # Test Quarkus main with latest Mandrel sources and maven-deploy-local
+  # This ensures Quarkus can still build with the latest GraalVM/Mandrel SDK
   ####
-  q-main-mandrel-25_0-assertions-enabled:
-    name: "Q main M 25.0 assertions enabled"
+  q-main-mandrel-25_0-with-local-maven-and-assertions:
+    name: "Q main M 25.0 with local maven and assertions"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base.yml
     with:
       quarkus-version: "main"
       mandrel-version: "mandrel/25.0"
+      build-type: "mandrel-source"
       jdk: "25/ea"
       issue-number: "929"
       issue-repo: "graalvm/mandrel"
-      # mandrel-it-issue-number: "399"
       mandrel-packaging-version: "25.0"
       quarkus-additional-build-args-append: "-ea,-esa,-J-ea,-J-esa"
       excluded-native-test-modules: "maven"
+    secrets:
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+  ####
+  # Test Quarkus main with latest GraalVM sources and maven-deploy-local
+  # This ensures Quarkus can still build with the latest GraalVM SDK
+  ####
+  q-main-graal-master-with-local-maven-and-assertions:
+    name: "Q main G master with local maven and assertions"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    uses: ./.github/workflows/base.yml
+    with:
+      quarkus-version: "main"
+      mandrel-version: "graal/master"
+      build-type: "graal-source"
+      jdk: "latest/ea"
+      issue-number: "978"
+      issue-repo: "graalvm/mandrel"
+      quarkus-additional-build-args-append: "-ea,-esa,-J-ea,-J-esa"
+      excluded-native-test-modules: "maven"
+    secrets:
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+
+# Made with Bob

--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -30,13 +30,20 @@ on:
       quarkus-version:
         type: string
         description: 'Quarkus version to test (branch, tag, commit, or "latest")'
-        # "latest" is replaced by the latest release available in maven
+        default: "999-SNAPSHOT"
+      quarkus-sha:
+        type: string
+        description: 'Quarkus commit SHA'
         default: "main"
       gh-runner:
         type: string
         description: 'GHA runner to run the build on'
         # "latest" is replaced by the latest release available in maven
         default: "ubuntu-latest"
+      use-snapshot:
+        type: boolean
+        description: 'Use snapshot version of Quarkus'
+        default: false
       # Builder image can't be tested on Windows due to https://github.com/actions/virtual-environments/issues/1143
       # builder-image:
       #   description: 'The builder image to use instead of a release or building from source (e.g. quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21)'
@@ -59,13 +66,75 @@ jobs:
         repository: graalvm/mandrel
         fetch-depth: 1
         path: workflow-mandrel
+    - name: Try to download pre-built Quarkus SNAPSHOT
+      if: ${{ inputs.use-snapshot == true }}
+      id: download-snapshot
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -e
+
+        if [ -n "${{ inputs.maven-deploy-local }}" ]; then
+          echo "::error::Cannot use maven-deploy-local with SNAPSHOT versions. SNAPSHOT versions are downloaded from pre-built releases."
+          exit 1
+        fi
+
+        # Infer branch from version: 999-SNAPSHOT -> main, X.YY.999-SNAPSHOT -> X.YY
+        QUARKUS_VERSION="${{ inputs.quarkus-version }}"
+        if [[ "${QUARKUS_VERSION}" == "999-SNAPSHOT" ]]; then
+          QUARKUS_SNAPSHOT_BRANCH="main"
+        elif [[ "${QUARKUS_VERSION}" =~ ^([0-9]+\.[0-9]+)\.999-SNAPSHOT$ ]]; then
+          QUARKUS_SNAPSHOT_BRANCH="${BASH_REMATCH[1]}"
+        else
+          echo "::error::Invalid SNAPSHOT version format: ${QUARKUS_VERSION}. Expected '999-SNAPSHOT' or 'X.YY.999-SNAPSHOT'"
+          exit 1
+        fi
+
+        QUARKUS_SNAPSHOT_REPO="quarkusio/quarkus-ecosystem-ci"
+        PREFIX="maven-repo-${QUARKUS_SNAPSHOT_BRANCH}-"
+
+        echo "Looking for latest Quarkus snapshot release for branch: ${QUARKUS_SNAPSHOT_BRANCH}"
+
+        # Get the tag of the latest release matching the prefix
+        TAG=$(gh release list --limit 20 \
+          --repo "${QUARKUS_SNAPSHOT_REPO}" \
+          --json tagName,name \
+          --jq ".[] | select(.tagName | startswith(\"${PREFIX}\")) | .tagName" \
+          | head -n 1) || true
+
+        if [ -z "${TAG}" ]; then
+          echo "::warning::No snapshot release found for branch '${QUARKUS_SNAPSHOT_BRANCH}'. Falling back to build from source."
+          echo "snapshot-available=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "Found release: ${TAG}"
+
+        echo "Downloading Quarkus snapshot: ${TAG}"
+        if ! gh release download "${TAG}" \
+          --repo "${QUARKUS_SNAPSHOT_REPO}" \
+          --pattern "maven-repo.tar.gz" \
+          --dir /tmp; then
+          echo "::warning::Failed to download snapshot release '${TAG}'. Falling back to build from source."
+          echo "snapshot-available=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        mkdir -p ~/.m2/repository
+        tar -xzf /tmp/maven-repo.tar.gz -C ~/.m2/repository
+        rm -f /tmp/maven-repo.tar.gz
+
+        echo "snapshot-available=true" >> "$GITHUB_OUTPUT"
+        echo "Quarkus ${QUARKUS_VERSION} for branch '${QUARKUS_SNAPSHOT_BRANCH}' installed successfully."
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      if: ${{ inputs.use-snapshot != true || steps.download-snapshot.outputs.snapshot-available != 'true' }}
       with:
         repository: ${{ inputs.quarkus-repo }}
         fetch-depth: 1
-        ref: ${{ inputs.quarkus-version }}
+        ref: ${{ inputs.quarkus-sha }}
         path: ${{ env.QUARKUS_PATH }}
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      if: ${{ inputs.use-snapshot != true ||  steps.download-snapshot.outputs.snapshot-available != 'true' }}
       with:
         path: ~/.m2/repository
         key: ${{ inputs.gh-runner }}-${{ inputs.target-os }}-${{ inputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -76,24 +145,24 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
     - name: Download GraalVM Maven Repo
-      if: ${{ inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
+      if: ${{ inputs.use-snapshot != true && inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: org-graalvm-artefacts-${{ inputs.artifacts-suffix }}
         path: .
     - name: Download GraalVM Maven Version
-      if: ${{ inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
+      if: ${{ inputs.use-snapshot != true && inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: mandrel-maven-version-${{ inputs.artifacts-suffix }}
         path: .
     - name: Extract GraalVM Maven Repo and GraalVM Maven Version
-      if: ${{ inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
+      if: ${{ inputs.use-snapshot != true && inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
       run: |
         tar -xzvf graalvm-maven-artefacts.tgz -C ~
         tar -xzvf graalvm-version.tgz -C $(dirname ${MANDREL_HOME})
     - name: Build quarkus with local graalvm version
-      if: ${{ inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
+      if: ${{ inputs.use-snapshot != true && inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
       run: |
         rm -f maven_graalvm_before_build.txt maven_graalvm_after_build.txt
         find ~/.m2/repository/org/graalvm | sort > maven_graalvm_before_build.txt
@@ -105,7 +174,7 @@ jobs:
         find ~/.m2/repository/org/graalvm | sort > maven_graalvm_after_build.txt
         diff -u maven_graalvm_before_build.txt maven_graalvm_after_build.txt
     - name: Build quarkus with default graalvm version
-      if: ${{ inputs.build-from-source == false || inputs.builder-image != 'null' ||  inputs.maven-deploy-local == ''}}
+      if: ${{ (inputs.use-snapshot != true || steps.download-snapshot.outputs.snapshot-available != 'true') && (inputs.build-from-source == false || inputs.builder-image != 'null' ||  inputs.maven-deploy-local == '')}}
       run: |
         cd ${QUARKUS_PATH}
         ./mvnw ${COMMON_MAVEN_ARGS} -Dquickly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,11 +41,11 @@ jobs:
   ####
   q-main-graal-25-latest:
     name: "Q main G 25 latest"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base.yml
     with:
-      quarkus-version: "main"
       mandrel-version: "graal/master"
-      build-type: "graal-source"
+      build-type: "graal-source-nolocalmvn"
       jdk: "latest/ea"
       build-stats-tag: "gha-linux-graal-qmain-glatest-jdk25ea"
       issue-repo: "graalvm/mandrel"

--- a/.github/workflows/resolve-quarkus-version.yml
+++ b/.github/workflows/resolve-quarkus-version.yml
@@ -20,8 +20,11 @@ on:
         description: 'JSON string of all workflow inputs for artifact suffix generation'
         required: true
     outputs:
+      quarkus-sha:
+        description: 'Quarkus commit SHA'
+        value: ${{ jobs.resolve.outputs.sha }}
       quarkus-version:
-        description: 'Resolved Quarkus version (commit SHA or release version)'
+        description: 'Quarkus artifacts version'
         value: ${{ jobs.resolve.outputs.version }}
       tests-matrix:
         description: 'Test matrix JSON'
@@ -29,15 +32,20 @@ on:
       artifacts-suffix:
         description: 'Artifact naming suffix'
         value: ${{ jobs.resolve.outputs.artifacts-suffix }}
+      use-snapshot:
+        description: 'Whether the Quarkus version is a SNAPSHOT'
+        value: ${{ jobs.resolve.outputs.use-snapshot }}
 
 jobs:
   resolve:
     name: Resolve Version and Generate Matrix
     runs-on: ubuntu-slim
     outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
       version: ${{ steps.resolve.outputs.version }}
       test-matrix: ${{ steps.matrix.outputs.test-matrix }}
       artifacts-suffix: ${{ steps.suffix.outputs.suffix }}
+      use-snapshot: ${{ steps.resolve.outputs.use-snapshot }}
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -56,33 +64,87 @@ jobs:
       - name: Get Quarkus version
         id: resolve
         run: |
-          if [ ${{ inputs.quarkus-version }} == "latest" ]
-          then
-            export QUARKUS_VERSION=$(curl -s https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/Final/ {print $3}' | sort -V | tail -n 1)
-          elif $(expr match "${{ inputs.quarkus-version }}" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
-          then
-            export QUARKUS_VERSION=${{ inputs.quarkus-version }}
-          elif ! [[ "${{ inputs.quarkus-version }}" =~ ^[0-9a-f]{40}$ ]];
-          then
-            sha=$(gh api repos/${{ inputs.quarkus-repo }}/commits/${{ inputs.quarkus-version }} --jq .sha || echo "")
-            if [ "$sha" != "" ]; then
-              export QUARKUS_VERSION=$sha
+          # Detect if this is a SNAPSHOT version
+          if echo "${{ inputs.quarkus-version }}" | grep -q "\-SNAPSHOT$"; then
+            set -e
+
+            # Infer branch from version: 999-SNAPSHOT -> main, X.YY.999-SNAPSHOT -> X.YY
+            QUARKUS_VERSION="${{ inputs.quarkus-version }}"
+            if [[ "${QUARKUS_VERSION}" == "999-SNAPSHOT" ]]; then
+              QUARKUS_SNAPSHOT_BRANCH="main"
+            elif [[ "${QUARKUS_VERSION}" =~ ^([0-9]+\.[0-9]+)\.999-SNAPSHOT$ ]]; then
+              QUARKUS_SNAPSHOT_BRANCH="${BASH_REMATCH[1]}"
             else
-              export QUARKUS_VERSION=$(git ls-remote ${GITHUB_SERVER_URL}/${{ inputs.quarkus-repo }} | grep "refs/heads/${{ inputs.quarkus-version }}$\|refs/tags/${{ inputs.quarkus-version }}$" | cut -f 1)
+              echo "::error::Invalid SNAPSHOT version format: ${QUARKUS_VERSION}. Expected '999-SNAPSHOT' or 'X.YY.999-SNAPSHOT'"
+              exit 1
+            fi
+
+            QUARKUS_SNAPSHOT_REPO="quarkusio/quarkus-ecosystem-ci"
+            PREFIX="maven-repo-${QUARKUS_SNAPSHOT_BRANCH}-"
+
+            echo "Looking for latest Quarkus snapshot release for branch: ${QUARKUS_SNAPSHOT_BRANCH}"
+
+            # Get the tag of the latest release matching the prefix
+            TAG=$(gh release list --limit 20 \
+              --repo "${QUARKUS_SNAPSHOT_REPO}" \
+              --json tagName,name \
+              --jq ".[] | select(.tagName | startswith(\"${PREFIX}\")) | .tagName" \
+              | head -n 1) || true
+
+            if [ -z "${TAG}" ]; then
+              echo "::warning::No snapshot release found for branch ${QUARKUS_SNAPSHOT_BRANCH}.  Falling back to building from source."
+              QUARKUS_VERSION=${QUARKUS_SNAPSHOT_BRANCH}
+            else
+              echo "Found release: ${TAG}"
+
+              # Get release body to extract Quarkus SHA
+              RELEASE_BODY=$(gh release view "${TAG}" --repo "${QUARKUS_SNAPSHOT_REPO}" --json body --jq .body)
+              QUARKUS_SHA=$(echo "${RELEASE_BODY}" | grep -oP 'Built from https://github.com/quarkusio/quarkus/tree/\K[0-9a-f]{40}' | head -1)
+
+              if [ -z "${QUARKUS_SHA}" ]; then
+                echo "::warning::Could not extract Quarkus SHA from release '${TAG}'. Falling back to building branch ${QUARKUS_SNAPSHOT_BRANCH} from source"
+                QUARKUS_VERSION=${QUARKUS_SNAPSHOT_BRANCH}
+              else
+                echo "use-snapshot=true" >> $GITHUB_OUTPUT
+                echo "Detected SNAPSHOT version: ${{ inputs.quarkus-version }}"
+              fi
             fi
           fi
-          if [ "$QUARKUS_VERSION" == "" ]
-          then
-            export QUARKUS_VERSION=${{ inputs.quarkus-version }}
+
+          if [ -z "${QUARKUS_SHA}" ]; then
+            echo "use-snapshot=false" >> $GITHUB_OUTPUT
+            echo "Not a SNAPSHOT version: ${{ inputs.quarkus-version }}"
+
+            if [ ${{ inputs.quarkus-version }} == "latest" ]
+            then
+              QUARKUS_VERSION=$(curl -s https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/version/ {print $3}'  | grep -v -E 'Alpha|Beta|CR' | sort -V | tail -n 1)
+            elif [ -z "${QUARKUS_VERSION}" ]; then
+              QUARKUS_VERSION=${{ inputs.quarkus-version }}
+            fi
+
+            sha=$(gh api repos/${{ inputs.quarkus-repo }}/commits/${QUARKUS_VERSION} --jq .sha 2>/dev/null || echo "")
+            if [ -n "$sha" ]; then
+              QUARKUS_SHA=$sha
+            else
+              sha=$(git ls-remote ${GITHUB_SERVER_URL}/${{ inputs.quarkus-repo }} | grep "refs/heads/${QUARKUS_VERSION}$\|refs/tags/${QUARKUS_VERSION}$" | cut -f 1)
+              if [ -n "$sha" ]; then
+                QUARKUS_SHA=$sha
+              else
+                echo "::error::Could not resolve SHA for version: ${QUARKUS_VERSION}"
+                exit 1
+              fi
+            fi
           fi
+          echo "Quarkus SHA: ${QUARKUS_SHA}"
+          echo "sha=${QUARKUS_SHA}" >> "$GITHUB_OUTPUT"
           echo ${QUARKUS_VERSION}
           echo "version=${QUARKUS_VERSION}" >> $GITHUB_OUTPUT
-          echo "**Quarkus version:** [${QUARKUS_VERSION}](${GITHUB_SERVER_URL}/${{ inputs.quarkus-repo }}/commits/${QUARKUS_VERSION})" >> $GITHUB_STEP_SUMMARY
-      
+          echo "**Quarkus version:** [${QUARKUS_VERSION}](${GITHUB_SERVER_URL}/${{ inputs.quarkus-repo }}/commits/${QUARKUS_SHA})" >> $GITHUB_STEP_SUMMARY
+
       - name: Get test matrix
         id: matrix
         run: |
-          curl --output native-tests.json https://raw.githubusercontent.com/${{ inputs.quarkus-repo }}/${{ steps.resolve.outputs.version }}/.github/native-tests.json
+          curl --output native-tests.json https://raw.githubusercontent.com/${{ inputs.quarkus-repo }}/${{ steps.resolve.outputs.sha }}/.github/native-tests.json
           tests_json=$(jq -c --arg os "${{ inputs.os-filter }}" '.include |= map(select(.["os-name"] | startswith($os)))' native-tests.json)
           echo ${tests_json}
           echo "test-matrix=${tests_json}" >> $GITHUB_OUTPUT

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -41,9 +41,9 @@ jobs:
   ####
   q-main-mandrel-25_0:
     name: "Q main M 25.0"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base.yml
     with:
-      quarkus-version: "main"
       mandrel-version: "mandrel/25.0"
       jdk: "25/ea"
       issue-number: "853"
@@ -56,9 +56,9 @@ jobs:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   q-main-mandrel-25_0-win:
     name: "Q main M 25.0 windows"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base-windows.yml
     with:
-      quarkus-version: "main"
       mandrel-version: "mandrel/25.0"
       issue-number: "854"
       issue-repo: "graalvm/mandrel"
@@ -74,9 +74,9 @@ jobs:
   ####
   q-main-mandrel-25_0-arm:
     name: "Q main M 25.0 on AArch64"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base.yml
     with:
-      quarkus-version: "main"
       mandrel-version: "mandrel/25.0"
       mandrel-packaging-version: "25.0"
       jdk: "25/ea"
@@ -93,9 +93,9 @@ jobs:
   ####
   q-main-mandrel-25_0-future-defaults:
     name: "Q main M 25.0 --future-defaults=all"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base.yml
     with:
-      quarkus-version: "main"
       mandrel-version: "mandrel/25.0"
       jdk: "25/ea"
       issue-number: "946"
@@ -112,9 +112,9 @@ jobs:
   ####
   q-main-mandrel-23_1:
     name: "Q main M 23.1 JDK 21"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base.yml
     with:
-      quarkus-version: "main"
       mandrel-version: "mandrel/23.1"
       jdk: "21/ea"
       issue-number: "739"
@@ -127,9 +127,9 @@ jobs:
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   q-main-mandrel-23_1-win:
     name: "Q main M 23.1 windows"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base-windows.yml
     with:
-      quarkus-version: "main"
       mandrel-version: "mandrel/23.1"
       jdk: "21/ea"
       issue-number: "740"


### PR DESCRIPTION
Adaptation of https://github.com/quarkusio/install-quarkus-snapshots-action/ to reduce CI overhead.

> We've updated the Quarkus Ecosystem CI to use pre-built Quarkus SNAPSHOT artifacts instead of building Quarkus from source on every run. This significantly reduces CI execution time and resource usage, since the ~20 minute Quarkus build step is replaced by downloading a pre-built Maven repository archive.
The pre-built snapshots are published as GitHub releases and are validated to be less than 36 hours old to ensure freshness. If a pre-built snapshot is unavailable for any reason, the CI automatically falls back to building Quarkus from source.
For workflows outside the Ecosystem CI: If your GitHub Actions workflow needs Quarkus SNAPSHOT artifacts during the build (e.g., for testing against the latest Quarkus), you can use the [install-quarkus-snapshots-action](https://github.com/quarkusio/install-quarkus-snapshots-action/) to install them into your local Maven repository with a single step.
  
Assisted-by: Bob

Being tested in https://github.com/zakkak/mandrel/actions/runs/26498254169