### PR TITLE
[CI] Update GHA versions and pin them to SHAs, enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly" # Options: daily, weekly, monthly
+    groups:
+      # Group updates to avoid PR spam
+      actions-updates:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "[CI] Update GitHub Actions"
+      include: "scope"

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -171,7 +171,7 @@ jobs:
       shell: bash
       run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
     - name: Persist Mandrel build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
@@ -180,7 +180,7 @@ jobs:
       shell: bash
       run: find . -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
     - name: Upload failure Archive (if maven failed)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: mandrel-reports-native-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -236,7 +236,7 @@ jobs:
       shell: bash
       run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
     - name: Persist GraalVM CE build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
@@ -245,7 +245,7 @@ jobs:
       shell: bash
       run: find . -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
     - name: Upload failure Archive (if maven failed)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: graal-reports-native-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -286,7 +286,7 @@ jobs:
       shell: bash
       run: tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
     - name: Persist Mandrel or GraalVM
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
@@ -416,7 +416,7 @@ jobs:
             -o -name '*svm_err_*pid*.md' \
             -o -wholename '*/quarkus/integration-tests/*/target/quarkus.log' | tar czvf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: win-test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -427,7 +427,7 @@ jobs:
         run: find . -name '*runner*.json' | tar czvf build-stats.tgz -T -
       - name: Upload build JSON stats
         if: inputs.build-stats-tag != 'null'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-stats-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'build-stats.tgz'
@@ -534,7 +534,7 @@ jobs:
         shell: bash
         run: tar czvf test-reports-mandrel-it.tgz ./testsuite/target/archived-logs/
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: win-test-reports-mandrel-it-${{ needs.get-test-matrix.outputs.artifacts-suffix }}

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -358,7 +358,7 @@ jobs:
           key: base-windows-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: base-windows-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-
       # Use Java 17 for Quarkus as it doesn't work with Java 21 yet
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -483,7 +483,7 @@ jobs:
         shell: bash
         run: tar -xzvf maven-repo.tgz -C ~
       # Use Java 17 for Quarkus as it doesn't work with Java 21 yet
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -112,7 +112,7 @@ jobs:
       - build-vars
     if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.mandrel-repo }}
         fetch-depth: 1
@@ -128,7 +128,7 @@ jobs:
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
         ./mx/mx --version
       shell: bash
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.mandrel-packaging-repo }}
         ref: ${{ inputs.mandrel-packaging-version }}
@@ -194,7 +194,7 @@ jobs:
       - build-vars
     if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.mandrel-repo }}
         fetch-depth: 1
@@ -332,7 +332,7 @@ jobs:
       - name: Support longpaths on Windows
         if: startsWith(matrix.os-name, 'windows')
         run: git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: startsWith(matrix.os-name, 'windows')
         with:
           repository: graalvm/mandrel
@@ -346,7 +346,7 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.quarkus-repo }}
           fetch-depth: 1
@@ -465,12 +465,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
           path: workflow-mandrel
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Karm/mandrel-integration-tests
           fetch-depth: 1

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -119,7 +119,7 @@ jobs:
         ref: ${{ inputs.mandrel-version }}
         path: ${{ env.MANDREL_REPO }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.8'
     - name: Checkout MX
@@ -201,7 +201,7 @@ jobs:
         ref: ${{ inputs.mandrel-version }}
         path: graal
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.8'
     - name: Checkout MX

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -133,7 +133,7 @@ jobs:
         repository: ${{ inputs.mandrel-packaging-repo }}
         ref: ${{ inputs.mandrel-packaging-version }}
         path: ${{ env.MANDREL_PACKAGING_REPO }}
-    - uses: actions/cache@v4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
@@ -210,7 +210,7 @@ jobs:
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} mx
         ./mx/mx --version
       shell: bash
-    - uses: actions/cache@v4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
@@ -352,7 +352,7 @@ jobs:
           fetch-depth: 1
           ref: ${{ needs.get-test-matrix.outputs.quarkus-version }}
           path: ${{ env.QUARKUS_PATH }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: base-windows-${{ needs.get-test-matrix.outputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -339,7 +339,7 @@ jobs:
           fetch-depth: 1
           path: workflow-mandrel
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-maven-repo-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
@@ -363,7 +363,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Mandrel or GraalVM
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
@@ -475,7 +475,7 @@ jobs:
           repository: Karm/mandrel-integration-tests
           fetch-depth: 1
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-maven-repo-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
@@ -488,7 +488,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Mandrel or GraalVM
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: win-jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -160,7 +160,7 @@ jobs:
         ref: ${{ inputs.mandrel-version }}
         path: ${{ env.MANDREL_REPO }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.8'
     - name: Checkout MX
@@ -267,7 +267,7 @@ jobs:
         ref: ${{ inputs.mandrel-version }}
         path: graal
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.8'
     - name: Checkout MX

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -153,7 +153,7 @@ jobs:
       TEMURIN_API_URL: ${{ needs.setup-temurin-api-url.outputs.api-url }}
     if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'mandrel' && inputs.builder-image == 'null'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.mandrel-repo }}
         fetch-depth: 1
@@ -169,7 +169,7 @@ jobs:
         echo "**MX version:** [$VERSION](${GITHUB_SERVER_URL}/graalvm/mx/tree/$VERSION)" >> $GITHUB_STEP_SUMMARY
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_PATH}
         ./mx/mx --version
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.mandrel-packaging-repo }}
         ref: ${{ inputs.mandrel-packaging-version }}
@@ -260,7 +260,7 @@ jobs:
       - build-vars
     if: fromJson(needs.build-vars.outputs.build-from-source) == true && needs.build-vars.outputs.distribution == 'graalvm' && inputs.builder-image == 'null'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.mandrel-repo }}
         fetch-depth: 1
@@ -430,7 +430,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.get-test-matrix.outputs.tests-matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
@@ -460,7 +460,7 @@ jobs:
         run: |
           mkdir -p ${GRAALVM_HOME}
           tar -xzvf jdk.tgz -C ${GRAALVM_HOME} --strip-components=1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.quarkus-repo }}
           fetch-depth: 1
@@ -588,12 +588,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: graalvm/mandrel
           fetch-depth: 1
           path: workflow-mandrel
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Karm/mandrel-integration-tests
           fetch-depth: 1

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -174,7 +174,7 @@ jobs:
         repository: ${{ inputs.mandrel-packaging-repo }}
         ref: ${{ inputs.mandrel-packaging-version }}
         path: ${{ env.MANDREL_PACKAGING_REPO }}
-    - uses: actions/cache@v4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
@@ -276,7 +276,7 @@ jobs:
         echo "**MX version:** [$VERSION](${GITHUB_SERVER_URL}/graalvm/mx/tree/$VERSION)" >> $GITHUB_STEP_SUMMARY
         git clone ${GITHUB_SERVER_URL}/graalvm/mx --depth 1 --branch ${VERSION} ${MX_PATH}
         ./mx/mx --version
-    - uses: actions/cache@v4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -436,7 +436,7 @@ jobs:
           fetch-depth: 1
           path: workflow-mandrel
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: linux-maven-repo-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
@@ -450,7 +450,7 @@ jobs:
           java-version: '17'
       - name: Download Mandrel or GraalVM
         if: inputs.builder-image == 'null'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
@@ -599,7 +599,7 @@ jobs:
           fetch-depth: 1
           path: ${{ env.MANDREL_IT_PATH }}
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: linux-maven-repo-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .
@@ -612,7 +612,7 @@ jobs:
           java-version: '17'
       - name: Download Mandrel or GraalVM
         if: inputs.builder-image == 'null'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: .

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -444,7 +444,7 @@ jobs:
         shell: bash
         run: tar -xzvf maven-repo.tgz -C ~
       # Use Java 17 for Quarkus as it doesn't work with Java 21 yet
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -606,7 +606,7 @@ jobs:
       - name: Extract Maven Repo
         run: tar -xzvf maven-repo.tgz -C ~
       # Use Java 17 for Quarkus as it doesn't work with Java 21 yet
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -225,19 +225,19 @@ jobs:
           mv graalvm-version.tgz ${{ github.workspace }}
         fi
     - name: Persist Mandrel build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
     - name: Persist local maven repository
       if: needs.build-vars.outputs.maven-deploy-local != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: org-graalvm-artefacts-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: graalvm-maven-artefacts.tgz
     - name: Persist GraalVM maven version
       if: needs.build-vars.outputs.maven-deploy-local != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: mandrel-maven-version-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: graalvm-version.tgz
@@ -246,7 +246,7 @@ jobs:
       shell: bash
       run: find . -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
     - name: Upload failure Archive (if maven failed)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: mandrel-reports-native-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -317,19 +317,19 @@ jobs:
     - name: Tar GraalVM
       run: tar czvf jdk.tgz  -C $(dirname ${MANDREL_HOME}) $(basename ${MANDREL_HOME})
     - name: Persist GraalVM build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
     - name: Persist local maven repository
       if: needs.build-vars.outputs.maven-deploy-local != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: org-graalvm-artefacts-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: graalvm-maven-artefacts.tgz
     - name: Persist GraalVM maven version
       if: needs.build-vars.outputs.maven-deploy-local != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: mandrel-maven-version-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: graalvm-version.tgz
@@ -338,7 +338,7 @@ jobs:
       shell: bash
       run: find . -name '*svm_err_*pid*.md' | tar czvf test-reports.tgz -T -
     - name: Upload failure Archive (if maven failed)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:
         name: graal-reports-native-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -386,7 +386,7 @@ jobs:
         ${JAVA_HOME}/bin/native-image --version
         tar czvf jdk.tgz -C $(dirname ${JAVA_HOME}) $(basename ${JAVA_HOME})
     - name: Persist Mandrel or GraalVM
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: jdk-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
         path: jdk.tgz
@@ -539,7 +539,7 @@ jobs:
             -o -name '*svm_err_*pid*.md' \
             -o -wholename '*/quarkus/integration-tests/*/target/quarkus.log' | tar czvf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: test-reports-native-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
@@ -550,7 +550,7 @@ jobs:
         run: find . -name '*runner*.json' | tar czvf build-stats.tgz -T -
       - name: Upload build JSON stats
         if: ${{ always() && inputs.build-stats-tag != 'null' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-stats-${{matrix.category}}-${{ needs.get-test-matrix.outputs.artifacts-suffix }}
           path: 'build-stats.tgz'
@@ -663,7 +663,7 @@ jobs:
         if: failure()
         run: tar czvf test-reports-mandrel-it.tgz ${MANDREL_IT_PATH}/testsuite/target/archived-logs/
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: test-reports-mandrel-it-${{ needs.get-test-matrix.outputs.artifacts-suffix }}

--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -119,7 +119,7 @@ jobs:
       run: |
         tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
     - name: Persist Maven Repo
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.target-os }}-maven-repo-${{ inputs.artifacts-suffix }}
         path: maven-repo.tgz

--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -71,7 +71,7 @@ jobs:
         key: ${{ inputs.gh-runner }}-${{ inputs.target-os }}-${{ inputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ inputs.gh-runner }}-${{ inputs.target-os }}-${{ inputs.quarkus-version }}-maven-
     # Use Java 17 to build Quarkus as that's the lowest supported JDK version currently
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'temurin'
         java-version: '17'

--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -65,7 +65,7 @@ jobs:
         fetch-depth: 1
         ref: ${{ inputs.quarkus-version }}
         path: ${{ env.QUARKUS_PATH }}
-    - uses: actions/cache@v4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.m2/repository
         key: ${{ inputs.gh-runner }}-${{ inputs.target-os }}-${{ inputs.quarkus-version }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -54,12 +54,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: graalvm/mandrel
         fetch-depth: 1
         path: workflow-mandrel
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.quarkus-repo }}
         fetch-depth: 1

--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -77,13 +77,13 @@ jobs:
         java-version: '17'
     - name: Download GraalVM Maven Repo
       if: ${{ inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: org-graalvm-artefacts-${{ inputs.artifacts-suffix }}
         path: .
     - name: Download GraalVM Maven Version
       if: ${{ inputs.build-from-source == true && inputs.builder-image == 'null' && inputs.maven-deploy-local != ''}}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: mandrel-maven-version-${{ inputs.artifacts-suffix }}
         path: .

--- a/.github/workflows/github-issue-updater.yml
+++ b/.github/workflows/github-issue-updater.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
             echo "Triggering Workflow Run ID: ${{ github.event.workflow_run.id }}"
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/github-issue-updater.yml
+++ b/.github/workflows/github-issue-updater.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: graalvm/mandrel
           fetch-depth: 1

--- a/.github/workflows/mark-stale-issues-and-prs.yml
+++ b/.github/workflows/mark-stale-issues-and-prs.yml
@@ -12,7 +12,7 @@ jobs:
   mark-stale-issues-and-prs:
     runs-on: ubuntu-slim
     steps:
-    - uses: actions/stale@v6
+    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue appears to be stale because it has been open 30 days with no activity. This issue will be closed in 7 days unless `Stale` label is removed, a new comment is made, or `not-Stale` label is added.'

--- a/.github/workflows/native-tests-stats-upload.yml
+++ b/.github/workflows/native-tests-stats-upload.yml
@@ -26,7 +26,7 @@ jobs:
           repository: graalvm/mandrel
           fetch-depth: 1
           path: workflow-mandrel
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: build-stats-*-${{ inputs.artifacts-suffix }}
           path: .

--- a/.github/workflows/native-tests-stats-upload.yml
+++ b/.github/workflows/native-tests-stats-upload.yml
@@ -21,7 +21,7 @@ jobs:
     name: Upload build stats to collector
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: graalvm/mandrel
           fetch-depth: 1

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
     - name: Checkout graal/master branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: graal/master
         fetch-depth: 0


### PR DESCRIPTION
- **[CI] Bump actions/cache to v5.0.5**
- **[CI] Bump actions/upload-artifact to v7.0.1**
- **[CI] Bump actions/download-artifact to v8.0.1**
- **[CI] Bump actions/checkout to v6.0.2**
- **[CI] Bump actions/stale to v10.2.0**
- **[CI] Bump actions/setup-python to v6.2.0**
- **[CI] Bump actions/setup-java to v5.2.0**
- **[CI] Enable dependabot for github actions**

Dependabot should take care of opening PRs for such updates in the future.