### PR TITLE
[CI] Reduce CI runs triggered by dependabot [skip CI]

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -578,7 +578,7 @@ jobs:
 
   native-tests-stats-upload:
     name: Upload build stats to collector
-    if: always() && inputs.build-stats-tag != 'null' && github.event_name != 'pull_request' && needs.native-tests.result != 'skipped' && needs.native-tests.result != 'cancelled'
+    if: always() && inputs.build-stats-tag != 'null' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && needs.native-tests.result != 'skipped' && needs.native-tests.result != 'cancelled'
     needs:
       - native-tests
       - get-test-matrix

--- a/.github/workflows/biweekly.yml
+++ b/.github/workflows/biweekly.yml
@@ -2,6 +2,8 @@ name: Bi-weekly CI
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - '.github/workflows/biweekly.yml'
       - '.github/workflows/base.yml'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,8 @@ name: Nightly CI
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - '.github/workflows/nightly.yml'
       - '.github/workflows/base.yml'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -2,6 +2,8 @@ name: Weekly CI
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - '.github/workflows/weekly.yml'
       - '.github/workflows/base.yml'


### PR DESCRIPTION
* Skip build stats upload on `pull_request_target` events
* Skip builds on push to `dependabot/*` branches
