### PR TITLE
Merge 'graalvm-community-jdk21u' into mandrel/23.1 (2026-06-29 edition)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,25 +119,25 @@ jobs:
       MX_RUNS_STYLE: ${{ contains(matrix.env.GATE_TAGS, 'style') || matrix.env.GATE_TAGS == '' }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.ref }} # Lock ref to current branch to avoid fetching others
         fetch-depth: "${{ env.MX_RUNS_STYLE && '0' || '1' }}" # The style gate needs the full commit history for checking copyright years
     - name: Determine mx version
       run: echo "MX_VERSION=$(jq -r '.mx_version' common.json)" >> ${GITHUB_ENV}
     - name: Checkout graalvm/mx
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: graalvm/mx.git
         ref: ${{ env.MX_VERSION }}
         fetch-depth: 1
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.8'
     - name: Update mx cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,14 +119,14 @@ jobs:
       MX_RUNS_STYLE: ${{ contains(matrix.env.GATE_TAGS, 'style') || matrix.env.GATE_TAGS == '' }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ github.ref }} # Lock ref to current branch to avoid fetching others
         fetch-depth: "${{ env.MX_RUNS_STYLE && '0' || '1' }}" # The style gate needs the full commit history for checking copyright years
     - name: Determine mx version
       run: echo "MX_VERSION=$(jq -r '.mx_version' common.json)" >> ${GITHUB_ENV}
     - name: Checkout graalvm/mx
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         repository: graalvm/mx.git
         ref: ${{ env.MX_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,25 +119,25 @@ jobs:
       MX_RUNS_STYLE: ${{ contains(matrix.env.GATE_TAGS, 'style') || matrix.env.GATE_TAGS == '' }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.ref }} # Lock ref to current branch to avoid fetching others
         fetch-depth: "${{ env.MX_RUNS_STYLE && '0' || '1' }}" # The style gate needs the full commit history for checking copyright years
     - name: Determine mx version
       run: echo "MX_VERSION=$(jq -r '.mx_version' common.json)" >> ${GITHUB_ENV}
     - name: Checkout graalvm/mx
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: graalvm/mx.git
         ref: ${{ env.MX_VERSION }}
         fetch-depth: 1
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.8'
     - name: Update mx cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}

--- a/.github/workflows/mandrel.yml
+++ b/.github/workflows/mandrel.yml
@@ -28,20 +28,20 @@ concurrency:
 
 jobs:
   q-main-ea:
-    name: "Q main M 23.1 EA"
+    name: "Q 3.x M 23.1 EA"
     uses: graalvm/mandrel/.github/workflows/base.yml@default
     with:
-      quarkus-version: "main"
+      quarkus-version: "3.999-SNAPSHOT"
       mandrel-version: ${{ github.ref }}
       mandrel-repo: ${{ github.repository }}
       mandrel-packaging-version: "23.1"
       jdk: "21/ea"
 
   q-main-ea-win:
-    name: "Q main M 23.1 windows EA"
+    name: "Q 3.x M 23.1 windows EA"
     uses: graalvm/mandrel/.github/workflows/base-windows.yml@default
     with:
-      quarkus-version: "main"
+      quarkus-version: "3.999-SNAPSHOT"
       mandrel-version: ${{ github.ref }}
       mandrel-repo: ${{ github.repository }}
       mandrel-packaging-version: "23.1"

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -37,11 +37,11 @@ jobs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 1
     - name: Checkout graalvm/mx
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         repository: graalvm/mx.git
         fetch-depth: 1

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -37,18 +37,18 @@ jobs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 1
     - name: Checkout graalvm/mx
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: graalvm/mx.git
         fetch-depth: 1
         ref: master
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.8'
     - name: Get latest Quarkus release
@@ -58,13 +58,13 @@ jobs:
         curl --output quarkus.tgz -sL https://api.github.com/repos/quarkusio/quarkus/tarball/$QUARKUS_VERSION
         mkdir ${QUARKUS_PATH}
         tar xf quarkus.tgz -C ${QUARKUS_PATH} --strip-components=1
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
@@ -89,12 +89,12 @@ jobs:
       shell: bash
       run: tar -czvf graalvm.tgz -C $(dirname ${GRAALVM_HOME}) $(basename ${GRAALVM_HOME})
     - name: Persist GraalVM build
-      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: graalvm
         path: graalvm.tgz
     - name: Use JDK 17 for Quarkus build
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: temurin
         java-version: 17
@@ -112,7 +112,7 @@ jobs:
       shell: bash
       run: tar -czvf maven-repo.tgz -C ~ .m2/repository
     - name: Persist Maven Repo
-      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: maven-repo
         path: maven-repo.tgz
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: Download GraalVM build
         if: startsWith(matrix.os-name, 'ubuntu')
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: graalvm
           path: .
@@ -151,7 +151,7 @@ jobs:
         run: ${QUARKUS_PATH}/.github/ci-prerequisites.sh
       - name: Download Maven Repo
         if: startsWith(matrix.os-name, 'ubuntu')
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: maven-repo
           path: .
@@ -160,7 +160,7 @@ jobs:
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
       - name: Use JDK 17 for Quarkus build
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17
@@ -178,7 +178,7 @@ jobs:
         shell: bash
         run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: test-reports-native-${{matrix.category}}

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -37,18 +37,18 @@ jobs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         fetch-depth: 1
     - name: Checkout graalvm/mx
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         repository: graalvm/mx.git
         fetch-depth: 1
         ref: master
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: '3.8'
     - name: Get latest Quarkus release
@@ -58,13 +58,13 @@ jobs:
         curl --output quarkus.tgz -sL https://api.github.com/repos/quarkusio/quarkus/tarball/$QUARKUS_VERSION
         mkdir ${QUARKUS_PATH}
         tar xf quarkus.tgz -C ${QUARKUS_PATH} --strip-components=1
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
@@ -89,12 +89,12 @@ jobs:
       shell: bash
       run: tar -czvf graalvm.tgz -C $(dirname ${GRAALVM_HOME}) $(basename ${GRAALVM_HOME})
     - name: Persist GraalVM build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: graalvm
         path: graalvm.tgz
     - name: Use JDK 17 for Quarkus build
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: temurin
         java-version: 17
@@ -112,7 +112,7 @@ jobs:
       shell: bash
       run: tar -czvf maven-repo.tgz -C ~ .m2/repository
     - name: Persist Maven Repo
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: maven-repo
         path: maven-repo.tgz
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: Download GraalVM build
         if: startsWith(matrix.os-name, 'ubuntu')
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: graalvm
           path: .
@@ -151,7 +151,7 @@ jobs:
         run: ${QUARKUS_PATH}/.github/ci-prerequisites.sh
       - name: Download Maven Repo
         if: startsWith(matrix.os-name, 'ubuntu')
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: maven-repo
           path: .
@@ -160,7 +160,7 @@ jobs:
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
       - name: Use JDK 17 for Quarkus build
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 17
@@ -178,7 +178,7 @@ jobs:
         shell: bash
         run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         if: failure()
         with:
           name: test-reports-native-${{matrix.category}}

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/calc/IntegerLowerThanNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/calc/IntegerLowerThanNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -627,7 +627,7 @@ public abstract class IntegerLowerThanNode extends CompareNode {
              * addition not the comparison.
              */
             if (mirrored) {
-                if (aStamp.contains(0)) {
+                if (aStamp.contains(0) || (aStamp.canBeNegative() && aStamp.canBePositive())) {
                     // a may be zero
                     return aStamp.unrestricted();
                 }

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ValueAPITest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ValueAPITest.java
@@ -72,6 +72,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.Serial;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -125,6 +126,7 @@ import org.junit.Test;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
@@ -2648,4 +2650,122 @@ public class ValueAPITest {
         assertEquals((Character) (char) 1, val.as(Character.class));
     }
 
+    @Test
+    public void testTruffleNumberObject() {
+        try (Context c = Context.create()) {
+            Value val = c.asValue(new TruffleByteObject((byte) 42));
+            Object numberObj = val.as(Object.class);
+            assertTrue(numberObj instanceof Byte);
+            assertEquals(42, (byte) numberObj);
+        }
+    }
+
+    @ExportLibrary(InteropLibrary.class)
+    @SuppressWarnings({"static-method"})
+    static class TruffleByteObject extends Number implements TruffleObject {
+
+        @Serial private static final long serialVersionUID = 1922664232217003500L;
+
+        private final byte byteValue;
+
+        TruffleByteObject(byte byteValue) {
+            this.byteValue = byteValue;
+        }
+
+        @ExportMessage
+        boolean isNumber() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInByte() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInShort() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInInt() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInLong() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInFloat() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInDouble() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInBigInteger() {
+            return true;
+        }
+
+        @ExportMessage
+        byte asByte() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        short asShort() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        int asInt() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        long asLong() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        float asFloat() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        double asDouble() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        @TruffleBoundary
+        BigInteger asBigInteger() {
+            return BigInteger.valueOf(byteValue);
+        }
+
+        @Override
+        public int intValue() {
+            return byteValue;
+        }
+
+        @Override
+        public long longValue() {
+            return byteValue;
+        }
+
+        @Override
+        public float floatValue() {
+            return byteValue;
+        }
+
+        @Override
+        public double doubleValue() {
+            return byteValue;
+        }
+    }
 }

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostUtil.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostUtil.java
@@ -45,6 +45,7 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 
 /**
@@ -115,7 +116,7 @@ final class HostUtil {
                     return delegate;
                 }
             }
-            if (value instanceof Number) {
+            if (value instanceof Number && !(value instanceof TruffleObject)) {
                 return value;
             } else if (interop.fitsInByte(value)) {
                 return interop.asByte(value);

--- a/truffle/src/org.graalvm.shadowed.com.ibm.icu/src/META-INF/native-image/org.graalvm.shadowed.icu4j/reflect-config.json
+++ b/truffle/src/org.graalvm.shadowed.com.ibm.icu/src/META-INF/native-image/org.graalvm.shadowed.icu4j/reflect-config.json
@@ -14,6 +14,13 @@
     "name":"org.graalvm.shadowed.com.ibm.icu.impl.LocaleDisplayNamesImpl",
     "methods":[
       {
+        "name": "getInstance",
+        "parameterTypes": [
+          "org.graalvm.shadowed.com.ibm.icu.util.ULocale",
+          "org.graalvm.shadowed.com.ibm.icu.text.LocaleDisplayNames$DialectHandling"
+        ]
+      },
+      {
         "name":"getInstance",
         "parameterTypes":[
           "org.graalvm.shadowed.com.ibm.icu.util.ULocale",


### PR DESCRIPTION
This includes the following upstream PRs:

- https://github.com/graalvm/graalvm-community-jdk21u/pull/281
- https://github.com/graalvm/graalvm-community-jdk21u/pull/292
- https://github.com/graalvm/graalvm-community-jdk21u/pull/291
- https://github.com/graalvm/graalvm-community-jdk21u/pull/289

This also changes our CI config to build from the quarkus `3.x` branch.