### PR TITLE
[CI] Move weekly mandrel 23.1 job to Quarkus 3.x

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -110,10 +110,10 @@ jobs:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
-  # Test Q main and Mandrel 23.1 JDK 21
+  # Test Q 3.x and Mandrel 23.1 JDK 21
   ####
-  q-main-mandrel-23_1:
-    name: "Q main M 23.1 JDK 21"
+  q-3_x-mandrel-23_1:
+    name: "Q 3.x M 23.1 JDK 21"
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base.yml
     with:
@@ -122,13 +122,14 @@ jobs:
       issue-number: "739"
       issue-repo: "graalvm/mandrel"
       mandrel-it-issue-number: "198"
+      quarkus-version: "3.999-SNAPSHOT"
       build-stats-tag: "gha-linux-qmain-m23_1-jdk21ea"
       mandrel-packaging-version: "23.1"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-main-mandrel-23_1-win:
-    name: "Q main M 23.1 windows"
+  q-3_x-mandrel-23_1-win:
+    name: "Q 3.x M 23.1 windows"
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/base-windows.yml
     with:
@@ -136,6 +137,7 @@ jobs:
       jdk: "21/ea"
       issue-number: "740"
       issue-repo: "graalvm/mandrel"
+      quarkus-version: "3.999-SNAPSHOT"
       mandrel-it-issue-number: "199"
       build-stats-tag: "gha-win-qmain-m23_1-jdk21ea"
       mandrel-packaging-version: "23.1"


### PR DESCRIPTION
Quarkus main moved to 4.0. Mandrel 23.1 won't be supported in Quarkus 4.x. Move the weekly CI job to the quarkus 3.x branch instead.