### PR TITLE
[CI] Add support for 3.999-SNAPSHOT

### DIFF
--- a/.github/workflows/resolve-quarkus-version.yml
+++ b/.github/workflows/resolve-quarkus-version.yml
@@ -72,6 +72,8 @@ jobs:
             QUARKUS_VERSION="${{ inputs.quarkus-version }}"
             if [[ "${QUARKUS_VERSION}" == "999-SNAPSHOT" ]]; then
               QUARKUS_SNAPSHOT_BRANCH="main"
+            elif [[ "${QUARKUS_VERSION}" == "3.999-SNAPSHOT" ]]; then
+              QUARKUS_SNAPSHOT_BRANCH="3.x"
             elif [[ "${QUARKUS_VERSION}" =~ ^([0-9]+\.[0-9]+)\.999-SNAPSHOT$ ]]; then
               QUARKUS_SNAPSHOT_BRANCH="${BASH_REMATCH[1]}"
             else


### PR DESCRIPTION
Amend resolve-quarkus-version.yml so as to properly resolve 3.999-SNAPSHOT quarkus-version to the new 3.x branch. Pre-requisite for #991 