### PR TITLE
[CI] build-quarkus.yml needs to understand 3.999-SNAPSHOT

### DIFF
--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -83,6 +83,8 @@ jobs:
         QUARKUS_VERSION="${{ inputs.quarkus-version }}"
         if [[ "${QUARKUS_VERSION}" == "999-SNAPSHOT" ]]; then
           QUARKUS_SNAPSHOT_BRANCH="main"
+        elif [[ "${QUARKUS_VERSION}" == "3.999-SNAPSHOT" ]]; then
+          QUARKUS_SNAPSHOT_BRANCH="3.x"
         elif [[ "${QUARKUS_VERSION}" =~ ^([0-9]+\.[0-9]+)\.999-SNAPSHOT$ ]]; then
           QUARKUS_SNAPSHOT_BRANCH="${BASH_REMATCH[1]}"
         else


### PR DESCRIPTION
Same as #992 but for the build-quarkus.yml re-usable workflow. Sorry for missing it earlier.