### PR TITLE
[CI] Base workflow files need to handle 3.999 in Mandrel IT

### DIFF
--- a/.github/workflows/base-windows.yml
+++ b/.github/workflows/base-windows.yml
@@ -530,7 +530,9 @@ jobs:
           # Don't use SNAPSHOT version for release tags
           if ($QUARKUS_VERSION -match "^[0-9]+\.[0-9]+$") {
             $QUARKUS_VERSION="$QUARKUS_VERSION.999-SNAPSHOT"
-          } elseif (! ($QUARKUS_VERSION -match "^.*\.(Final|CR|Alpha|Beta)[0-9]?$")) {
+          } elseif (! ($QUARKUS_VERSION -match "^.*(\.(Final|CR|Alpha|Beta)[0-9]?|-SNAPSHOT)$")) {
+            # QUARKUS_VERSION neither '999-SNAPSHOT', '3.999-SNAPSHOT' or
+            # '3.37' or '3.33.1.Final' etc.
             $QUARKUS_VERSION="999-SNAPSHOT"
           }
           Write-Host "$QUARKUS_VERSION"

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -663,8 +663,10 @@ jobs:
           then
             # release branches use the branch name followed by .999-SNAPSHOT as the version
             export QUARKUS_VERSION="${QUARKUS_VERSION}.999-SNAPSHOT"
-          elif ! $(expr match "$QUARKUS_VERSION" "^.*\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?$" > /dev/null)
+          elif ! $(expr match "$QUARKUS_VERSION" "^.*\(\.\(Final\|CR\|Alpha\|Beta\)[0-9]\?\|-SNAPSHOT\)$" > /dev/null)
           then
+            # QUARKUS_VERSION neither '999-SNAPSHOT', '3.999-SNAPSHOT' or
+            # '3.37' or '3.33.1.Final' etc.
             export QUARKUS_VERSION="999-SNAPSHOT"
           fi
           echo $QUARKUS_VERSION


### PR DESCRIPTION
Previously a passed QUARKUS_VERSION=3.999-SNAPSHOT would translate to 999-SNAPSHOT since none of the quarkus version branches allow the new version used for the 3.x branch. Explicitly allow it and use it untouched.