### PR TITLE
[CI] Add weekly CI job for Q 3.x branch testing and Mandrel 25.0

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -72,6 +72,25 @@ jobs:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
   ####
+  # Test Q 3.x and Mandrel 25.0 JDK 25
+  ####
+  q-3x-mandrel-25_0:
+    name: "Q 3.x M 25.0"
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    uses: ./.github/workflows/base.yml
+    with:
+      mandrel-version: "mandrel/25.0"
+      quarkus-version: "3.999-SNAPSHOT"
+      jdk: "25/ea"
+      issue-number: "997"
+      issue-repo: "graalvm/mandrel"
+      mandrel-it-issue-number: "419"
+      build-stats-tag: "gha-linux-mandrel-q3.x-m25_0-jdk25ea"
+      mandrel-packaging-version: "25.0"
+    secrets:
+      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
+      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
+  ####
   # Test Quarkus main with Mandrel for JDK 25 on AArch64
   ####
   q-main-mandrel-25_0-arm:


### PR DESCRIPTION
We are seeing [recent CI failures](https://github.com/graalvm/mandrel/issues/739#issuecomment-4890965061) on the 3.x branch when testing Mandrel 23.1. Since Mandrel 23.1 isn't officially supported on the most recent 3.x branch it seems good to add weekly testing for it as well so as to cover more configs. Both issues discovered with 23.1 affect Mandrel 25.0 as well.