### PR TITLE
[CI] Stop weekly testing of the 3.x quarkus branch with Mandrel 23.1

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -128,38 +128,3 @@ jobs:
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  ####
-  # Test Q 3.x and Mandrel 23.1 JDK 21
-  ####
-  q-3_x-mandrel-23_1:
-    name: "Q 3.x M 23.1 JDK 21"
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
-    uses: ./.github/workflows/base.yml
-    with:
-      mandrel-version: "mandrel/23.1"
-      jdk: "21/ea"
-      issue-number: "739"
-      issue-repo: "graalvm/mandrel"
-      mandrel-it-issue-number: "198"
-      quarkus-version: "3.999-SNAPSHOT"
-      build-stats-tag: "gha-linux-qmain-m23_1-jdk21ea"
-      mandrel-packaging-version: "23.1"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}
-  q-3_x-mandrel-23_1-win:
-    name: "Q 3.x M 23.1 windows"
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
-    uses: ./.github/workflows/base-windows.yml
-    with:
-      mandrel-version: "mandrel/23.1"
-      jdk: "21/ea"
-      issue-number: "740"
-      issue-repo: "graalvm/mandrel"
-      quarkus-version: "3.999-SNAPSHOT"
-      mandrel-it-issue-number: "199"
-      build-stats-tag: "gha-win-qmain-m23_1-jdk21ea"
-      mandrel-packaging-version: "23.1"
-    secrets:
-      ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
-      UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}


### PR DESCRIPTION
See: https://github.com/quarkusio/quarkus/pull/55563 which bumps the minimal version for the 3.x branch to Mandrel 25.0

Since quarkus is no longer compatible with 23.1, we should stop testing this combination (tests currently fail anyway).