### PR TITLE
[CI] Disable tests depending on old keycloak container image in Quarkus 3.27

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -144,6 +144,8 @@ jobs:
       quarkus-version: "3.27.999-SNAPSHOT"
       build-stats-tag: "gha-linux-q327-m23_1-jdk21ea"
       mandrel-packaging-version: "23.1"
+      # These tests depend on an old keycloak container which runs afoul of an old JDK cgroups bug
+      excluded-native-test-modules: "oidc-client,smallrye-jwt-token-propagation,smallrye-graphql-client-keycloak"
     secrets:
       ISSUE_BOT_TOKEN: ${{ secrets.MANDREL_BOT_TOKEN }}
       UPLOAD_COLLECTOR_TOKEN: ${{ secrets.UPLOAD_COLLECTOR_TOKEN }}


### PR DESCRIPTION
It looks like Looks like a cgroups issue is manifesting on GHA when the keycloak 19.0.3-legacy container image is used .

```
[INFO] DOCKER> [quay.io/keycloak/keycloak:19.0.3-legacy] "quarkus-test-keycloak": Waiting on url http://localhost:8180 with method HEAD for status 200..399.
12:01:06.884 Keycloak:Exception in thread "main" java.lang.NullPointerException
12:01:06.886 Keycloak:	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:81)
12:01:06.886 Keycloak:	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:113)
12:01:06.886 Keycloak:	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:167)
12:01:06.886 Keycloak:	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
12:01:06.886 Keycloak:	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
12:01:06.886 Keycloak:	at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
12:01:06.886 Keycloak:	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
12:01:06.886 Keycloak:	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:281)
12:01:06.888 Keycloak:	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:198)
12:01:06.888 Keycloak:	at java.management/java.lang.management.ManagementFactory.lambda$getPlatformMBeanServer$0(ManagementFactory.java:487)
12:01:06.888 Keycloak:	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:271)
12:01:06.888 Keycloak:	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
12:01:06.888 Keycloak:	at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1693)
12:01:06.888 Keycloak:	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
12:01:06.888 Keycloak:	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
12:01:06.888 Keycloak:	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
12:01:06.888 Keycloak:	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
12:01:06.888 Keycloak:	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
12:01:06.888 Keycloak:	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
12:01:06.888 Keycloak:	at java.management/java.lang.management.ManagementFactory.getPlatformMBeanServer(ManagementFactory.java:488)
12:01:06.888 Keycloak:	at org.jboss.modules.ModuleLoader$RealMBeanReg$1.run(ModuleLoader.java:1258)
12:01:06.888 Keycloak:	at org.jboss.modules.ModuleLoader$RealMBeanReg$1.run(ModuleLoader.java:1256)
12:01:06.888 Keycloak:	at java.base/java.security.AccessController.doPrivileged(Native Method)
12:01:06.888 Keycloak:	at org.jboss.modules.ModuleLoader$RealMBeanReg.<init>(ModuleLoader.java:1256)
12:01:06.888 Keycloak:	at org.jboss.modules.ModuleLoader$TempMBeanReg.installReal(ModuleLoader.java:1240)
12:01:06.888 Keycloak:	at org.jboss.modules.ModuleLoader.installMBeanServer(ModuleLoader.java:273)
12:01:06.888 Keycloak:	at org.jboss.modules.Main.main(Main.java:592)
[ERROR] DOCKER> [quay.io/keycloak/keycloak:19.0.3-legacy] "quarkus-test-keycloak": Container stopped with exit code 1 unexpectedly after 511 ms while waiting on url http://localhost:8180
```

The proper fix would be to update the keycloak image used in the tests, as newer versions don't trigger that. On the other hand it seems to involve quite some work (see
https://github.com/quarkusio/quarkus/pull/49283) so we skip the said tests instead.